### PR TITLE
Dispatch system releases with Ekily Release App

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -339,49 +339,16 @@ jobs:
           git worktree remove artifacts-worktree --force
           echo "url=${artifact_url}" >> "${GITHUB_OUTPUT}"
 
-      - name: Notify YAP template
+      - name: Dispatch release targets
         if: steps.plan.outputs.should_release == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
-          STARTER_SYNC_TOKEN: ${{ secrets.STARTER_SYNC_TOKEN }}
-          STARTER_REPOSITORY: ${{ vars.STARTER_REPOSITORY || 'EkilyHQ/YAP' }}
+          EKILY_RELEASE_APP_ID: ${{ vars.EKILY_RELEASE_APP_ID }}
+          EKILY_RELEASE_PRIVATE_KEY: ${{ secrets.EKILY_RELEASE_PRIVATE_KEY }}
+          RELEASE_DISPATCH_TARGETS: ${{ vars.RELEASE_DISPATCH_TARGETS }}
           NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
           ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
           ASSET_SIZE: ${{ steps.package.outputs.archive_size }}
           ASSET_SHA256: ${{ steps.package.outputs.archive_sha256 }}
-          RELEASE_ID: ${{ steps.create.outputs.release_id }}
         run: |
           set -euo pipefail
-          if [[ -z "${STARTER_SYNC_TOKEN}" ]]; then
-            echo "STARTER_SYNC_TOKEN is not configured; skipping YAP sync dispatch."
-            exit 0
-          fi
-
-          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > dist/starter-release.json; then
-            echo "::warning title=YAP sync skipped::Unable to read the published release for YAP dispatch."
-            exit 0
-          fi
-          node <<'NODE' > dist/starter-dispatch.json
-          const fs = require('fs');
-          const release = JSON.parse(fs.readFileSync('dist/starter-release.json', 'utf8'));
-          const payload = {
-            event_type: 'press-system-release',
-            client_payload: {
-              press_repository: process.env.GITHUB_REPOSITORY,
-              tag: process.env.NEXT_TAG,
-              asset_name: process.env.ASSET_NAME,
-              asset_size: Number(process.env.ASSET_SIZE || 0),
-              asset_sha256: process.env.ASSET_SHA256,
-              release_url: release.html_url || ''
-            }
-          };
-          process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-          NODE
-
-          if ! GH_TOKEN="${STARTER_SYNC_TOKEN}" gh api \
-            --method POST \
-            "repos/${STARTER_REPOSITORY}/dispatches" \
-            --input dist/starter-dispatch.json; then
-            echo "::warning title=YAP sync dispatch failed::Release ${NEXT_TAG} was published, but the optional dispatch to ${STARTER_REPOSITORY} failed."
-            exit 0
-          fi
+          node scripts/dispatch-system-release.js

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Merges to `main` that change Press runtime files automatically publish a patch r
 
 Official documentation, site content, installed theme registry state, and external theme directories stay out of system update packages. Changes that only touch `wwwroot/` do not create a system release, and update packages must never include `wwwroot/`, `site.yaml`, `CNAME`, `robots.txt`, `sitemap.xml`, repository policy files, workflow files, scripts, site-specific media such as `assets/avatar.png` and `assets/hero.jpeg`, `assets/themes/packs.json`, or arbitrary `assets/themes/<slug>` directories outside `native`.
 
-After a system release is published, the release workflow can dispatch `EkilyHQ/YAP` to rebuild the template from that release package. Configure `STARTER_SYNC_TOKEN` in this repository with permission to call repository dispatch on the YAP repository. `STARTER_REPOSITORY` can be set as a repository variable when the target repository name differs from `EkilyHQ/YAP`.
+After a system release is published, the release workflow runs `scripts/dispatch-system-release.js` to notify downstream repositories. Configure the `Ekily Release` GitHub App for the `EkilyHQ` organization, install it on `YAP`, `Press-Theme-Starter`, and the official theme repositories, then set `EKILY_RELEASE_APP_ID` as a repository variable and `EKILY_RELEASE_PRIVATE_KEY` as a repository secret in `Press`. The workflow exchanges those credentials for an installation token and sends `press-system-release` repository dispatch events to rebuild YAP, refresh the theme starter version marker, and update official theme demo sites.
 
 ## Branching
 

--- a/scripts/dispatch-system-release.js
+++ b/scripts/dispatch-system-release.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+
+const API_ROOT = process.env.GITHUB_API_URL || 'https://api.github.com';
+const API_VERSION = '2022-11-28';
+const DEFAULT_TARGETS = [
+  { repository: 'EkilyHQ/YAP', eventType: 'press-system-release', label: 'YAP starter runtime' },
+  { repository: 'EkilyHQ/Press-Theme-Starter', eventType: 'press-system-release', label: 'theme starter version' },
+  { repository: 'EkilyHQ/Press-Theme-Arcus', eventType: 'press-system-release', label: 'Arcus demo site' },
+  { repository: 'EkilyHQ/Press-Theme-Cartograph', eventType: 'press-system-release', label: 'Cartograph demo site' },
+  { repository: 'EkilyHQ/Press-Theme-Glasswing', eventType: 'press-system-release', label: 'Glasswing demo site' },
+  { repository: 'EkilyHQ/Press-Theme-Solstice', eventType: 'press-system-release', label: 'Solstice demo site' }
+];
+
+function env(name, fallback = '') {
+  return process.env[name] || fallback;
+}
+
+function base64url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function makeJwt(appId, privateKey) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({
+    iat: now - 60,
+    exp: now + 540,
+    iss: appId
+  }));
+  const body = `${header}.${payload}`;
+  const signature = crypto
+    .createSign('RSA-SHA256')
+    .update(body)
+    .sign(privateKey);
+  return `${body}.${base64url(signature)}`;
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_ROOT}${path}`, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': API_VERSION,
+      ...(options.headers || {})
+    }
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`${options.method || 'GET'} ${path} failed with ${response.status}: ${text.slice(0, 500)}`);
+  }
+  if (response.status === 204) return null;
+  return await response.json();
+}
+
+function normalizeTargets(input) {
+  const raw = String(input || '').trim();
+  const targets = raw ? JSON.parse(raw) : DEFAULT_TARGETS;
+  if (!Array.isArray(targets) || !targets.length) {
+    throw new Error('release dispatch targets must be a non-empty JSON array');
+  }
+  return targets.map((target) => {
+    const repository = String(target.repository || '').trim();
+    const eventType = String(target.eventType || target.event_type || 'press-system-release').trim();
+    const label = String(target.label || repository).trim();
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+      throw new Error(`invalid dispatch repository: ${repository}`);
+    }
+    if (!eventType || eventType.length > 100) {
+      throw new Error(`invalid dispatch event type for ${repository}`);
+    }
+    return { repository, eventType, label };
+  });
+}
+
+function readRelease() {
+  const releasePath = env('PRESS_RELEASE_JSON', 'dist/release-published.json');
+  if (!fs.existsSync(releasePath)) return {};
+  return JSON.parse(fs.readFileSync(releasePath, 'utf8'));
+}
+
+function buildPayload(release) {
+  const tag = env('NEXT_TAG');
+  const assetName = env('ASSET_NAME');
+  const assetSize = Number(env('ASSET_SIZE', '0'));
+  const assetSha256 = env('ASSET_SHA256');
+  if (!tag || !assetName || !assetSha256) {
+    throw new Error('NEXT_TAG, ASSET_NAME, and ASSET_SHA256 are required for release dispatch');
+  }
+  return {
+    press_repository: env('GITHUB_REPOSITORY', 'EkilyHQ/Press'),
+    tag,
+    asset_name: assetName,
+    asset_size: Number.isFinite(assetSize) ? assetSize : 0,
+    asset_sha256: assetSha256,
+    release_url: release.html_url || env('RELEASE_URL')
+  };
+}
+
+async function installationTokenForTargets(jwt, targets) {
+  const owners = new Set(targets.map((target) => target.repository.split('/')[0]));
+  if (owners.size !== 1) {
+    throw new Error('release dispatch targets must belong to one GitHub App installation owner');
+  }
+  const owner = Array.from(owners)[0];
+  const installations = await request('/app/installations', {
+    headers: { Authorization: `Bearer ${jwt}` }
+  });
+  const installation = installations.find((item) => {
+    const login = item && item.account && item.account.login;
+    return String(login || '').toLowerCase() === owner.toLowerCase();
+  });
+  if (!installation || !installation.id) {
+    throw new Error(`GitHub App is not installed for ${owner}`);
+  }
+  const repositories = targets.map((target) => target.repository.split('/')[1]);
+  const token = await request(`/app/installations/${installation.id}/access_tokens`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${jwt}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      repositories,
+      permissions: {
+        contents: 'write',
+        metadata: 'read'
+      }
+    })
+  });
+  if (!token || !token.token) {
+    throw new Error('GitHub App installation token response did not include a token');
+  }
+  return token.token;
+}
+
+async function dispatch(token, target, clientPayload) {
+  await request(`/repos/${target.repository}/dispatches`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      event_type: target.eventType,
+      client_payload: clientPayload
+    })
+  });
+}
+
+async function main() {
+  const appId = env('EKILY_RELEASE_APP_ID');
+  const privateKey = env('EKILY_RELEASE_PRIVATE_KEY');
+  const targets = normalizeTargets(env('RELEASE_DISPATCH_TARGETS'));
+  if (!appId || !privateKey) {
+    console.log('::warning title=Release dispatch skipped::EKILY_RELEASE_APP_ID or EKILY_RELEASE_PRIVATE_KEY is not configured.');
+    return;
+  }
+
+  const release = readRelease();
+  const clientPayload = buildPayload(release);
+  const jwt = makeJwt(appId, privateKey);
+  const token = await installationTokenForTargets(jwt, targets);
+  const failures = [];
+
+  for (const target of targets) {
+    try {
+      await dispatch(token, target, clientPayload);
+      console.log(`Dispatched ${target.eventType} for ${clientPayload.tag} to ${target.repository} (${target.label}).`);
+    } catch (error) {
+      failures.push(`${target.repository}: ${error.message}`);
+      console.log(`::warning title=Release dispatch failed::${target.repository}: ${error.message}`);
+    }
+  }
+
+  if (failures.length) {
+    console.log(`::warning title=Release dispatch incomplete::${failures.length} target(s) failed after ${clientPayload.tag} was published.`);
+  }
+}
+
+main().catch((error) => {
+  console.log(`::warning title=Release dispatch skipped::${error.message}`);
+});

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -185,39 +185,68 @@ fi
 
 publish_line="$(grep -nF -- '- name: Publish release' "${workflow}" | head -n 1 | cut -d: -f1)"
 artifact_line="$(grep -nF -- '- name: Publish fetchable artifact' "${workflow}" | head -n 1 | cut -d: -f1)"
-notify_line="$(grep -nF -- '- name: Notify YAP template' "${workflow}" | head -n 1 | cut -d: -f1)"
-if [[ -z "${publish_line}" || -z "${artifact_line}" || -z "${notify_line}" || "${publish_line}" -ge "${artifact_line}" || "${artifact_line}" -ge "${notify_line}" ]]; then
-  echo "system release workflow must publish the release-artifacts manifest after release publication and before YAP notification" >&2
+dispatch_line="$(grep -nF -- '- name: Dispatch release targets' "${workflow}" | head -n 1 | cut -d: -f1)"
+if [[ -z "${publish_line}" || -z "${artifact_line}" || -z "${dispatch_line}" || "${publish_line}" -ge "${artifact_line}" || "${artifact_line}" -ge "${dispatch_line}" ]]; then
+  echo "system release workflow must publish the release-artifacts manifest after release publication and before release dispatches" >&2
   exit 1
 fi
 
-if ! grep -F 'Notify YAP template' "${workflow}" >/dev/null; then
-  echo "system release workflow must notify the YAP template after publishing" >&2
+if ! grep -F 'Dispatch release targets' "${workflow}" >/dev/null; then
+  echo "system release workflow must dispatch release targets after publishing" >&2
   exit 1
 fi
 
-if ! grep -F 'STARTER_SYNC_TOKEN' "${workflow}" >/dev/null; then
-  echo "system release workflow must use STARTER_SYNC_TOKEN for cross-repository YAP dispatch" >&2
+if grep -F 'STARTER_SYNC_TOKEN' "${workflow}" >/dev/null; then
+  echo "system release workflow must not use the legacy STARTER_SYNC_TOKEN for cross-repository dispatch" >&2
   exit 1
 fi
 
-if ! grep -F "STARTER_REPOSITORY: \${{ vars.STARTER_REPOSITORY || 'EkilyHQ/YAP' }}" "${workflow}" >/dev/null; then
-  echo "system release workflow must default dispatches to EkilyHQ/YAP" >&2
+if grep -F 'STARTER_REPOSITORY' "${workflow}" >/dev/null; then
+  echo "system release workflow must not use the legacy single STARTER_REPOSITORY target" >&2
   exit 1
 fi
 
-if ! grep -F "event_type: 'press-system-release'" "${workflow}" >/dev/null; then
+if ! grep -F 'EKILY_RELEASE_APP_ID' "${workflow}" >/dev/null; then
+  echo "system release workflow must read the Ekily Release GitHub App ID" >&2
+  exit 1
+fi
+
+if ! grep -F 'EKILY_RELEASE_PRIVATE_KEY' "${workflow}" >/dev/null; then
+  echo "system release workflow must read the Ekily Release GitHub App private key" >&2
+  exit 1
+fi
+
+if ! grep -F 'scripts/dispatch-system-release.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must run the release dispatch orchestrator" >&2
+  exit 1
+fi
+
+if ! grep -F "eventType: 'press-system-release'" scripts/dispatch-system-release.js >/dev/null; then
   echo "system release workflow must dispatch the press-system-release event" >&2
   exit 1
 fi
 
-if ! grep -F '"repos/${STARTER_REPOSITORY}/dispatches"' "${workflow}" >/dev/null; then
-  echo "system release workflow must call the YAP repository dispatch endpoint" >&2
+for target in \
+  'EkilyHQ/YAP' \
+  'EkilyHQ/Press-Theme-Starter' \
+  'EkilyHQ/Press-Theme-Arcus' \
+  'EkilyHQ/Press-Theme-Cartograph' \
+  'EkilyHQ/Press-Theme-Glasswing' \
+  'EkilyHQ/Press-Theme-Solstice'
+do
+  if ! grep -F "${target}" scripts/dispatch-system-release.js >/dev/null; then
+    echo "release dispatch orchestrator must include ${target}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -F '/repos/${target.repository}/dispatches' scripts/dispatch-system-release.js >/dev/null; then
+  echo "release dispatch orchestrator must call repository dispatch endpoints" >&2
   exit 1
 fi
 
-if ! grep -F 'asset_sha256: process.env.ASSET_SHA256' "${workflow}" >/dev/null; then
-  echo "system release workflow must pass the system package digest to YAP" >&2
+if ! grep -F 'asset_sha256: assetSha256' scripts/dispatch-system-release.js >/dev/null; then
+  echo "release dispatch orchestrator must pass the system package digest to targets" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- replace the legacy single-target STARTER_SYNC_TOKEN dispatch with a Press-owned release orchestrator
- mint a GitHub App installation token from EKILY_RELEASE_APP_ID and EKILY_RELEASE_PRIVATE_KEY
- dispatch press-system-release to YAP, Press-Theme-Starter, and the four official theme demo repos

## Configuration
- create/install the Ekily Release GitHub App with Contents: read/write on the downstream repos
- set Press repo variable EKILY_RELEASE_APP_ID
- set Press repo secret EKILY_RELEASE_PRIVATE_KEY

## Tests
- git diff --check
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- node --experimental-default-type=module scripts/test-system-updates.js
- ruby YAML parse for .github/workflows/*.yml