### PR TITLE
Add Press version compatibility checks

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -41,10 +41,22 @@ jobs:
             latest_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 || true)"
           fi
 
+          source_version="$(node - <<'NODE'
+          const manifest = require('./assets/press-system.json');
+          const version = String(manifest.version || '').trim();
+          const tag = String(manifest.tag || '').trim();
+          if (!/^\d+\.\d+\.\d+$/.test(version) || tag !== `v${version}`) {
+            throw new Error('assets/press-system.json must declare matching version and tag');
+          }
+          process.stdout.write(version);
+          NODE
+          )"
+          next_tag="v${source_version}"
+
           if [[ -n "${latest_tag}" ]]; then
-            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
           else
-            changed_files="$(git ls-files -- index.html index_editor.html index_editor_preview.html assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+            changed_files="$(git ls-files -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
           fi
 
           if [[ -z "${changed_files}" ]]; then
@@ -55,13 +67,23 @@ jobs:
             exit 0
           fi
 
-          if [[ "${latest_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            major="${BASH_REMATCH[1]}"
-            minor="${BASH_REMATCH[2]}"
-            patch="${BASH_REMATCH[3]}"
-            next_tag="v${major}.${minor}.$((patch + 1))"
-          else
-            next_tag="v0.0.1"
+          if [[ -n "${latest_tag}" ]]; then
+            export LATEST_TAG="${latest_tag}"
+            export NEXT_TAG="${next_tag}"
+            node <<'NODE'
+            function parse(tag) {
+              const match = String(tag || '').match(/^v(\d+)\.(\d+)\.(\d+)$/);
+              if (!match) throw new Error(`invalid release tag: ${tag}`);
+              return match.slice(1).map(Number);
+            }
+            const latest = parse(process.env.LATEST_TAG);
+            const next = parse(process.env.NEXT_TAG);
+            for (let i = 0; i < 3; i += 1) {
+              if (next[i] > latest[i]) process.exit(0);
+              if (next[i] < latest[i]) break;
+            }
+            throw new Error(`assets/press-system.json version ${process.env.NEXT_TAG} must be greater than latest release ${process.env.LATEST_TAG}`);
+            NODE
           fi
 
           {
@@ -284,10 +306,16 @@ jobs:
 
           with open("dist/release-published.json", "r", encoding="utf-8") as fh:
               release = json.load(fh)
+          with open("assets/press-system.json", "r", encoding="utf-8") as fh:
+              system = json.load(fh)
 
           expected_name = os.environ["EXPECTED_ASSET"]
           expected_size = int(os.environ["EXPECTED_SIZE"])
           expected_sha = os.environ["EXPECTED_SHA256"].lower()
+          version = str(system.get("version") or "").strip()
+          tag = str(system.get("tag") or "").strip()
+          if not version or tag != f"v{version}" or tag != str(release.get("tag_name") or ""):
+              sys.exit("assets/press-system.json version must match the published release tag")
           assets = [asset for asset in release.get("assets", []) if asset.get("name") == expected_name]
           if len(assets) != 1:
               sys.exit(f"expected exactly one release asset named {expected_name}, found {len(assets)}")
@@ -298,8 +326,10 @@ jobs:
               "schemaVersion": 1,
               "name": release.get("name") or release.get("tag_name") or "",
               "tag": release.get("tag_name") or "",
+              "version": version,
               "publishedAt": release.get("published_at") or release.get("created_at") or "",
               "notes": release.get("body") or "",
+              "upgradeFrom": system.get("upgradeFrom") or {},
               "htmlUrl": release.get("html_url") or "",
               "asset": {
                   "name": asset.get("name") or expected_name,

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ node scripts/test-content-model.js
 
 ## System Releases
 
-Merges to `main` that change Press runtime files automatically publish a patch release with a dedicated `press-system-vX.Y.Z.zip` update package. The package is intentionally limited to the application shell and runtime assets: `index.html`, `index_editor.html`, `assets/main.js`, `assets/js/`, `assets/i18n/`, `assets/schema/`, and `assets/themes/native/**`. The encrypted-article envelope helper in `assets/js/encrypted-content.js` is part of that runtime boundary.
+Merges to `main` that change Press runtime files publish the explicit SemVer recorded in `assets/press-system.json` with a dedicated `press-system-vX.Y.Z.zip` update package. Runtime changes must bump that source version before release. The package is intentionally limited to the application shell and runtime assets: `index.html`, `index_editor.html`, `assets/press-system.json`, `assets/main.js`, `assets/js/`, `assets/i18n/`, `assets/schema/`, and `assets/themes/native/**`. The encrypted-article envelope helper in `assets/js/encrypted-content.js` is part of that runtime boundary.
+
+System release manifests include `upgradeFrom` compatibility metadata. The editor blocks update staging when the current installed Press version does not satisfy that source range, so future releases can require intermediate updates before older compatibility code is removed.
 
 Official documentation, site content, installed theme registry state, and external theme directories stay out of system update packages. Changes that only touch `wwwroot/` do not create a system release, and update packages must never include `wwwroot/`, `site.yaml`, `CNAME`, `robots.txt`, `sitemap.xml`, repository policy files, workflow files, scripts, site-specific media such as `assets/avatar.png` and `assets/hero.jpeg`, `assets/themes/packs.json`, or arbitrary `assets/themes/<slug>` directories outside `native`.
 
@@ -102,7 +104,7 @@ Want to list your site here? Open a PR with the site URL and a one-line descript
 
 ## Theme Repositories
 
-Official themes use separate repositories such as `EkilyHQ/Press-Theme-Arcus`. New theme repositories should start from [EkilyHQ/Press-Theme-Starter](https://github.com/EkilyHQ/Press-Theme-Starter). Each theme repository owns its theme source, contract checks, release workflow, `press-theme-<slug>-vX.Y.Z.zip` artifact, SHA-256 digest, and root `theme-release.json` manifest. `EkilyHQ/Press-Theme-Catalog` owns the official theme list. Press owns only the runtime infrastructure and `native`; each site owns its installed `packs.json`.
+Official themes use separate repositories such as `EkilyHQ/Press-Theme-Arcus`. New theme repositories should start from [EkilyHQ/Press-Theme-Starter](https://github.com/EkilyHQ/Press-Theme-Starter). Each theme repository owns its theme source, Press engine range in `theme/theme.json`, contract checks, release workflow, `press-theme-<slug>-vX.Y.Z.zip` artifact, SHA-256 digest, and root `theme-release.json` manifest. `EkilyHQ/Press-Theme-Catalog` owns the official theme list. Press owns only the runtime infrastructure and `native`; each site owns its installed `packs.json`.
 
 ## Roadmap
 

--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -236,6 +236,9 @@ const translations = {
         filesHeading: '待更新的系统文件',
         releaseNotes: '发布说明',
         noNotes: '此次发布未提供额外说明。',
+        currentVersionLabel: ({ version }) => `当前 Press：${version}`,
+        targetVersionLabel: ({ version }) => `目标 Press：${version}`,
+        unknownVersion: '未知',
         latestLabel: ({ name, tag }) => `最新发布：${name}${tag ? `（${tag}）` : ''}`,
         publishedLabel: ({ date }) => `发布时间：${date}`,
         assetLabel: ({ name, size }) => `附件：${name}（${size}）`,
@@ -256,6 +259,7 @@ const translations = {
           emptyFile: '选择的文件为空。',
           invalidArchive: '选中的 ZIP 无法作为 Press 发布读取。',
           downloadFailed: '无法下载最新系统更新包。请改为选择已下载的 ZIP。',
+          upgradeBlocked: ({ current, target, ranges }) => `不能从 ${current} 直接更新到 ${target}。请先应用中间版本的 Press 发布。支持的来源范围：${ranges}。`,
           sizeMismatch: ({ expected, actual }) => `选中的压缩包大小（${actual}）与发布附件（${expected}）不一致。`,
           digestMismatch: '选中的压缩包 SHA-256 与发布附件不一致。',
           generic: '系统更新失败，请重试。'

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -236,6 +236,9 @@ const translations = {
         filesHeading: '待更新的系統檔案',
         releaseNotes: '釋出說明',
         noNotes: '此次釋出未提供額外說明。',
+        currentVersionLabel: ({ version }) => `目前 Press：${version}`,
+        targetVersionLabel: ({ version }) => `目標 Press：${version}`,
+        unknownVersion: '未知',
         latestLabel: ({ name, tag }) => `最新發布：${name}${tag ? `（${tag}）` : ''}`,
         publishedLabel: ({ date }) => `釋出時間：${date}`,
         assetLabel: ({ name, size }) => `附件：${name}（${size}）`,
@@ -256,6 +259,7 @@ const translations = {
           emptyFile: '選擇的檔案為空。',
           invalidArchive: '選中的 ZIP 無法作為 Press 釋出讀取。',
           downloadFailed: '無法下載最新系統更新包。請改為選擇已下載的 ZIP。',
+          upgradeBlocked: ({ current, target, ranges }) => `不能從 ${current} 直接更新到 ${target}。請先套用中間版本的 Press 釋出。支援的來源範圍：${ranges}。`,
           sizeMismatch: ({ expected, actual }) => `選中的壓縮包大小（${actual}）與釋出附件（${expected}）不一致。`,
           digestMismatch: '選中的壓縮包 SHA-256 與釋出附件不一致。',
           generic: '系統更新失敗，請重試。'

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -238,6 +238,9 @@ const translations = {
         filesHeading: 'Pending system files',
         releaseNotes: 'Release notes',
         noNotes: 'This release does not include additional notes.',
+        currentVersionLabel: ({ version }) => `Current Press: ${version}`,
+        targetVersionLabel: ({ version }) => `Target Press: ${version}`,
+        unknownVersion: 'unknown',
         latestLabel: ({ name, tag }) => `Latest release: ${name}${tag ? ` (${tag})` : ''}`,
         publishedLabel: ({ date }) => `Published on ${date}`,
         assetLabel: ({ name, size }) => `Asset: ${name} (${size})`,
@@ -258,6 +261,7 @@ const translations = {
           emptyFile: 'The selected file is empty.',
           invalidArchive: 'The selected ZIP could not be read as a Press release.',
           downloadFailed: 'Unable to download the latest system update package. Select a downloaded ZIP instead.',
+          upgradeBlocked: ({ current, target, ranges }) => `Cannot update from ${current} to ${target}. Apply an intermediate Press release first. Supported source range: ${ranges}.`,
           sizeMismatch: ({ expected, actual }) => `The selected archive size (${actual}) does not match the release asset (${expected}).`,
           digestMismatch: 'The selected archive SHA-256 does not match the release asset.',
           generic: 'System update failed. Please try again.'

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -236,6 +236,9 @@ const translations = {
         filesHeading: '更新待ちのシステムファイル',
         releaseNotes: 'リリースノート',
         noNotes: 'このリリースには追加の説明がありません。',
+        currentVersionLabel: ({ version }) => `現在の Press：${version}`,
+        targetVersionLabel: ({ version }) => `更新先 Press：${version}`,
+        unknownVersion: '不明',
         latestLabel: ({ name, tag }) => `最新リリース：${name}${tag ? `（${tag}）` : ''}`,
         publishedLabel: ({ date }) => `公開日：${date}`,
         assetLabel: ({ name, size }) => `アセット：${name}（${size}）`,
@@ -256,6 +259,7 @@ const translations = {
           emptyFile: '選択したファイルは空です。',
           invalidArchive: '選択した ZIP を Press リリースとして読み込めませんでした。',
           downloadFailed: '最新のシステム更新パッケージをダウンロードできませんでした。ダウンロード済み ZIP を選択してください。',
+          upgradeBlocked: ({ current, target, ranges }) => `${current} から ${target} へ直接更新できません。先に中間の Press リリースを適用してください。対応する元バージョン範囲：${ranges}。`,
           sizeMismatch: ({ expected, actual }) => `選択したアーカイブのサイズ（${actual}）がリリースアセット（${expected}）と一致しません。`,
           digestMismatch: '選択したアーカイブの SHA-256 がリリースアセットと一致しません。',
           generic: 'システム更新に失敗しました。再試行してください。'

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -10,8 +10,8 @@ import {
 } from './yaml.js';
 import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=annotate-i18n-20260510';
 import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=annotate-i18n-20260510';
-import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=katex-math-20260510';
-import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=theme-switch-fix-20260508';
+import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=version-compat-20260512';
+import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=version-compat-20260512';
 import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=theme-manager-20260507';
 import {
   decryptMarkdownDocument,

--- a/assets/js/press-version.js
+++ b/assets/js/press-version.js
@@ -1,0 +1,110 @@
+export const PRESS_SYSTEM_MANIFEST_PATH = 'assets/press-system.json';
+
+let pressSystemCache = null;
+
+export function normalizeSemver(value) {
+  const raw = String(value || '').trim();
+  const match = raw.match(/^v?(\d+)\.(\d+)\.(\d+)$/i);
+  if (!match) return '';
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+}
+
+export function semverToTag(value) {
+  const version = normalizeSemver(value);
+  return version ? `v${version}` : '';
+}
+
+export function compareSemver(a, b) {
+  const left = normalizeSemver(a);
+  const right = normalizeSemver(b);
+  if (!left || !right) return left === right ? 0 : null;
+  const leftParts = left.split('.').map((part) => Number(part));
+  const rightParts = right.split('.').map((part) => Number(part));
+  for (let i = 0; i < 3; i += 1) {
+    if (leftParts[i] !== rightParts[i]) return leftParts[i] > rightParts[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+function testComparator(version, token) {
+  const raw = String(token || '').trim();
+  if (!raw || raw === '*') return true;
+  const match = raw.match(/^(>=|<=|>|<|=)?\s*(v?\d+\.\d+\.\d+)$/i);
+  if (!match) return false;
+  const op = match[1] || '=';
+  const comparison = compareSemver(version, match[2]);
+  if (comparison === null) return false;
+  if (op === '>') return comparison > 0;
+  if (op === '>=') return comparison >= 0;
+  if (op === '<') return comparison < 0;
+  if (op === '<=') return comparison <= 0;
+  return comparison === 0;
+}
+
+export function satisfiesSemverRange(version, range) {
+  const normalizedVersion = normalizeSemver(version);
+  if (!normalizedVersion) return false;
+  const clauses = String(range || '').split('||').map((part) => part.trim()).filter(Boolean);
+  if (!clauses.length) return false;
+  return clauses.some((clause) => {
+    const tokens = clause.split(/\s+/).filter(Boolean);
+    return tokens.length > 0 && tokens.every((token) => testComparator(normalizedVersion, token));
+  });
+}
+
+export function satisfiesAnySemverRange(version, ranges) {
+  const list = Array.isArray(ranges) ? ranges : [ranges];
+  return list.some((range) => satisfiesSemverRange(version, range));
+}
+
+export function normalizeUpgradeFrom(input) {
+  const source = input && typeof input === 'object' ? input : {};
+  const ranges = Array.isArray(source.ranges)
+    ? source.ranges.map((range) => String(range || '').trim()).filter(Boolean)
+    : [];
+  return {
+    ranges,
+    allowUnknownSource: source.allowUnknownSource === true,
+    message: String(source.message || '')
+  };
+}
+
+export function normalizePressSystemManifest(input) {
+  if (!input || typeof input !== 'object') throw new Error('Press system manifest is missing.');
+  if (Number(input.schemaVersion) !== 1 || input.type !== 'press-system') {
+    throw new Error('Press system manifest must be schemaVersion 1 and type "press-system".');
+  }
+  const version = normalizeSemver(input.version);
+  const tag = semverToTag(input.tag || version);
+  if (!version || tag !== semverToTag(version)) {
+    throw new Error('Press system manifest version and tag must be matching SemVer values.');
+  }
+  return {
+    schemaVersion: 1,
+    type: 'press-system',
+    version,
+    tag,
+    upgradeFrom: normalizeUpgradeFrom(input.upgradeFrom)
+  };
+}
+
+export async function loadPressSystemManifest(options = {}) {
+  if (pressSystemCache && options.force !== true) return pressSystemCache;
+  const path = options.path || PRESS_SYSTEM_MANIFEST_PATH;
+  const response = await fetch(path, { cache: 'no-store' });
+  if (!response || !response.ok) throw new Error('Unable to load Press system version.');
+  pressSystemCache = normalizePressSystemManifest(await response.json());
+  return pressSystemCache;
+}
+
+export function setPressSystemManifestForTests(manifest) {
+  pressSystemCache = manifest ? normalizePressSystemManifest(manifest) : null;
+}
+
+export function isUpgradeAllowed(currentVersion, upgradeFrom) {
+  const sourceVersion = normalizeSemver(currentVersion);
+  const rule = normalizeUpgradeFrom(upgradeFrom);
+  if (!sourceVersion) return rule.allowUnknownSource === true;
+  if (!rule.ranges.length) return true;
+  return satisfiesAnySemverRange(sourceVersion, rule.ranges);
+}

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -2,6 +2,15 @@ import { mdParse } from './markdown.js?v=katex-math-20260510';
 import { renderPressMath } from './math-render.js?v=katex-math-20260510';
 import { setSafeHtml } from './safe-html.js?v=katex-math-20260510';
 import { t } from './i18n.js?v=annotate-i18n-20260510';
+import {
+  compareSemver,
+  isUpgradeAllowed,
+  loadPressSystemManifest,
+  normalizePressSystemManifest,
+  normalizeSemver,
+  normalizeUpgradeFrom,
+  semverToTag
+} from './press-version.js?v=version-compat-20260512';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([
@@ -14,7 +23,7 @@ export const SYSTEM_UPDATE_ASSET_NAME_PATTERN = /^press-system-v\d+\.\d+\.\d+\.z
 
 const RELEASE_API_URL = 'https://api.github.com/repos/EkilyHQ/Press/releases/latest';
 const RELEASE_MANIFEST_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json';
-const SYSTEM_UPDATE_ALLOWED_PATH_PATTERN = /^(?:index\.html|index_editor\.html|index_editor_preview\.html|assets\/(?:main\.js|js\/.+|i18n\/.+|schema\/.+|themes\/native\/.+))$/;
+const SYSTEM_UPDATE_ALLOWED_PATH_PATTERN = /^(?:index\.html|index_editor\.html|index_editor_preview\.html|assets\/(?:press-system\.json|main\.js|js\/.+|i18n\/.+|schema\/.+|themes\/native\/.+))$/;
 const SYSTEM_UPDATE_BLOCKED_PATH_PATTERN = /^(?:\.git\/|\.github\/|wwwroot\/|site\.ya?ml$|site\.local\.ya?ml$|CNAME$|robots\.txt$|sitemap\.xml$|README(?:\.md)?$|BRANCHING\.md$|scripts\/|assets\/(?:avatar\.png|avatar\.jpe?g|hero\.jpeg)$)/i;
 
 let initialized = false;
@@ -25,6 +34,7 @@ let currentFiles = [];
 let assetSha256 = '';
 let assetSize = 0;
 let assetName = '';
+let currentPressSystem = null;
 
 const listeners = new Set();
 
@@ -39,6 +49,8 @@ const elements = {
   fileList: null,
   notes: null,
   notesWrap: null,
+  currentVersion: null,
+  targetVersion: null,
   metaTitle: null,
   metaPublished: null,
   assetMeta: null
@@ -276,20 +288,8 @@ export function selectSystemUpdateAsset(releaseData) {
   };
 }
 
-function parseReleaseTag(tag) {
-  const match = String(tag || '').trim().match(/^v(\d+)\.(\d+)\.(\d+)$/i);
-  if (!match) return null;
-  return match.slice(1).map((part) => Number(part));
-}
-
 function compareReleaseTags(a, b) {
-  const left = parseReleaseTag(a);
-  const right = parseReleaseTag(b);
-  if (!left || !right) return String(a || '') === String(b || '') ? 0 : null;
-  for (let i = 0; i < left.length; i += 1) {
-    if (left[i] !== right[i]) return left[i] > right[i] ? 1 : -1;
-  }
-  return 0;
+  return compareSemver(a, b);
 }
 
 function isFetchableSystemUpdateAssetUrl(url) {
@@ -311,11 +311,14 @@ function requireManifestString(manifest, key) {
 
 function normalizeReleaseCache(data) {
   const asset = selectSystemUpdateAsset(data);
+  const version = normalizeSemver(data.version || data.tag_name || '');
   return {
     name: data.name || data.tag_name || 'latest',
     tag: data.tag_name || '',
+    version,
     publishedAt: data.published_at || data.created_at || '',
     notes: data.body || '',
+    upgradeFrom: normalizeUpgradeFrom(data.upgradeFrom),
     htmlUrl: data.html_url || '',
     asset: asset ? { ...asset, fetchable: false } : asset
   };
@@ -327,6 +330,10 @@ export function normalizeSystemReleaseManifest(manifest) {
   }
   const name = requireManifestString(manifest, 'name');
   const tag = requireManifestString(manifest, 'tag');
+  const version = normalizeSemver(manifest.version || tag);
+  if (!version || semverToTag(version) !== semverToTag(tag)) {
+    throw new Error('Invalid system release manifest: invalid version');
+  }
   const publishedAt = requireManifestString(manifest, 'publishedAt');
   const notes = requireManifestString(manifest, 'notes');
   const htmlUrl = requireManifestString(manifest, 'htmlUrl');
@@ -348,8 +355,10 @@ export function normalizeSystemReleaseManifest(manifest) {
   return {
     name,
     tag,
+    version,
     publishedAt,
     notes,
+    upgradeFrom: normalizeUpgradeFrom(manifest.upgradeFrom),
     htmlUrl,
     asset: {
       ...asset,
@@ -410,6 +419,57 @@ function createReleaseFetchError(response) {
 export function getDisplayReleaseNotes(release) {
   if (!release || !release.asset) return '';
   return typeof release.notes === 'string' ? release.notes : '';
+}
+
+function versionLabel(version) {
+  const normalized = normalizeSemver(version);
+  return normalized ? `v${normalized}` : t('editor.systemUpdates.unknownVersion');
+}
+
+function renderCurrentPressVersion() {
+  if (!elements.currentVersion) return;
+  elements.currentVersion.textContent = t('editor.systemUpdates.currentVersionLabel', {
+    version: versionLabel(currentPressSystem && currentPressSystem.version)
+  });
+}
+
+async function refreshCurrentPressSystem(options = {}) {
+  try {
+    currentPressSystem = await loadPressSystemManifest(options);
+  } catch (_) {
+    currentPressSystem = null;
+  }
+  renderCurrentPressVersion();
+  return currentPressSystem;
+}
+
+function readArchivePressSystemManifest(entries) {
+  const entry = entries.find((item) => item && item.path === 'assets/press-system.json');
+  if (!entry) return null;
+  try {
+    return normalizePressSystemManifest(JSON.parse(strFromU8(entry.data)));
+  } catch (err) {
+    const error = new Error('System update press-system.json is invalid.');
+    error.cause = err;
+    throw error;
+  }
+}
+
+function assertSystemUpdateCompatibility(release, archiveSystem) {
+  const targetVersion = normalizeSemver(
+    (archiveSystem && archiveSystem.version) || (release && (release.version || release.tag)) || ''
+  );
+  const upgradeFrom = normalizeUpgradeFrom(
+    (archiveSystem && archiveSystem.upgradeFrom) || (release && release.upgradeFrom)
+  );
+  const currentVersion = currentPressSystem && currentPressSystem.version ? currentPressSystem.version : '';
+  if (isUpgradeAllowed(currentVersion, upgradeFrom)) return;
+  const message = upgradeFrom.message || t('editor.systemUpdates.errors.upgradeBlocked', {
+    current: versionLabel(currentVersion),
+    target: versionLabel(targetVersion),
+    ranges: upgradeFrom.ranges.join(', ') || t('editor.systemUpdates.unknownVersion')
+  });
+  throw new Error(message);
 }
 
 function renderRelease() {
@@ -511,6 +571,12 @@ async function fetchSystemUpdateAsset(url) {
 
 function renderReleaseMeta() {
   if (!releaseCache) return;
+  renderCurrentPressVersion();
+  if (elements.targetVersion) {
+    elements.targetVersion.textContent = t('editor.systemUpdates.targetVersionLabel', {
+      version: versionLabel(releaseCache.version || releaseCache.tag)
+    });
+  }
   if (elements.metaTitle) {
     const { name, tag } = releaseCache;
     elements.metaTitle.textContent = tag ? t('editor.systemUpdates.latestLabel', { name, tag }) : name;
@@ -608,8 +674,7 @@ async function compareArchive(entries) {
   return files;
 }
 
-async function processArchive(buffer) {
-  const entries = collectSystemUpdateArchiveEntries(buffer);
+async function processArchiveEntries(entries) {
   return compareArchive(entries);
 }
 
@@ -649,11 +714,18 @@ export async function analyzeArchive(buffer, filename) {
 
   setStatus(t('editor.systemUpdates.status.verifying'));
 
+  let entries = [];
+  let archiveSystem = null;
   let files = [];
   try {
-    files = await processArchive(buffer);
+    entries = collectSystemUpdateArchiveEntries(buffer);
+    archiveSystem = readArchivePressSystemManifest(entries);
+    await refreshCurrentPressSystem();
+    assertSystemUpdateCompatibility(release, archiveSystem);
+    files = await processArchiveEntries(entries);
   } catch (err) {
     console.error('Failed to unpack system update archive', err);
+    if (err && err.message && /upgrade|version|Press/i.test(err.message)) throw err;
     throw new Error(t('editor.systemUpdates.errors.invalidArchive'));
   }
 
@@ -742,6 +814,8 @@ export function initSystemUpdates(options = {}) {
   elements.fileSection = document.getElementById('systemUpdateFileSection');
   elements.fileList = document.getElementById('systemUpdateFileList');
   elements.notes = document.getElementById('systemUpdateReleaseNotes');
+  elements.currentVersion = document.getElementById('systemUpdateCurrentVersion');
+  elements.targetVersion = document.getElementById('systemUpdateTargetVersion');
   elements.metaTitle = document.getElementById('systemUpdateReleaseMeta');
   elements.metaPublished = document.getElementById('systemUpdateReleasePublished');
   elements.assetMeta = document.getElementById('systemUpdateAssetMeta');
@@ -762,6 +836,7 @@ export function initSystemUpdates(options = {}) {
 
   updateDownloadLink();
   setStatus(t('editor.systemUpdates.status.idle'));
+  refreshCurrentPressSystem().catch(() => {});
   fetchLatestRelease().catch((err) => {
     console.error('Failed to load system update metadata', err);
     setStatus(err && err.message ? err.message : t('editor.systemUpdates.errors.releaseFetch'), { tone: 'error' });

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,4 +1,5 @@
 import { t } from './i18n.js?v=annotate-i18n-20260510';
+import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=version-compat-20260512';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';
@@ -111,6 +112,21 @@ function normalizeDigest(value, options = {}) {
     throw new Error('Theme release manifest asset digest must be a SHA-256 hash.');
   }
   return `sha256:${hex}`;
+}
+
+function normalizeThemeEngines(input, options = {}) {
+  const engines = input && typeof input === 'object' ? input : {};
+  const press = safeString(engines.press || '').trim();
+  if (!press && options.required) throw new Error('Theme manifest engines.press is required.');
+  return press ? { press } : {};
+}
+
+async function assertThemePressCompatibility(label, engines) {
+  const normalized = normalizeThemeEngines(engines, { required: true });
+  const current = await loadPressSystemManifest();
+  if (!satisfiesSemverRange(current.version, normalized.press)) {
+    throw new Error(`${label || 'Theme'} supports Press ${normalized.press}, but this site is running ${current.tag}.`);
+  }
 }
 
 export function sanitizeThemeSlug(value) {
@@ -240,6 +256,7 @@ function validateThemeManifestContract(themeManifest, availablePaths) {
   requireThemeObject(themeManifest, 'theme.json');
   requireThemeString(themeManifest.name, 'name');
   requireThemeString(themeManifest.version, 'version');
+  normalizeThemeEngines(themeManifest.engines, { required: true });
   const contractVersion = Number(themeManifest.contractVersion);
   if (contractVersion !== REQUIRED_CONTRACT_VERSION) {
     throw new Error(`Theme contractVersion ${contractVersion || '(missing)'} is not supported.`);
@@ -317,6 +334,7 @@ export function normalizeThemeRegistry(input) {
       label: safeString(entry.label || entry.name || value) || value,
       version: safeString(entry.version || ''),
       contractVersion: Number.isFinite(Number(entry.contractVersion)) ? Number(entry.contractVersion) : REQUIRED_CONTRACT_VERSION,
+      engines: normalizeThemeEngines(entry.engines),
       builtIn,
       removable: builtIn ? false : entry.removable !== false,
       source: normalizeRegistrySource(entry.source, builtIn ? 'builtin' : 'manual'),
@@ -335,6 +353,7 @@ export function normalizeThemeRegistry(input) {
       label: 'Native',
       version: '',
       contractVersion: REQUIRED_CONTRACT_VERSION,
+      engines: {},
       builtIn: true,
       removable: false,
       source: { type: 'builtin' },
@@ -379,6 +398,7 @@ export function normalizeThemeReleaseManifest(input) {
   if (contractVersion !== REQUIRED_CONTRACT_VERSION) {
     throw new Error(`Theme contractVersion ${contractVersion || '(missing)'} is not supported.`);
   }
+  const engines = normalizeThemeEngines(input.engines, { required: true });
   const asset = input.asset && typeof input.asset === 'object' ? input.asset : null;
   if (!asset) throw new Error('Theme release manifest asset is required.');
   const assetName = safeString(asset.name || '').trim();
@@ -401,6 +421,7 @@ export function normalizeThemeReleaseManifest(input) {
     label: safeString(input.label || input.name || value) || value,
     version,
     contractVersion,
+    engines,
     release: {
       tag: safeString(release.tag || input.tag || '').trim(),
       name: safeString(release.name || input.name || '').trim(),
@@ -479,6 +500,7 @@ export function collectThemeArchiveEntries(buffer, options = {}) {
     label: safeString(themeManifest.name || themeManifest.label || slug) || slug,
     version: safeString(themeManifest.version || ''),
     contractVersion,
+    engines: normalizeThemeEngines(themeManifest.engines, { required: true }),
     manifest: themeManifest,
     files: normalizedEntries
   };
@@ -723,6 +745,7 @@ function makeRegistryEntry({ archive, previous, releaseManifest, source, assetMe
     label: releaseManifest ? releaseManifest.label : archive.label,
     version: releaseManifest ? releaseManifest.version : archive.version,
     contractVersion: archive.contractVersion,
+    engines: archive.engines,
     builtIn: !!(previous && previous.builtIn),
     removable: previous && previous.builtIn ? false : true,
     source: previous && previous.builtIn ? { type: 'builtin' } : source,
@@ -834,6 +857,10 @@ async function stageThemeArchive(buffer, fileName, options = {}) {
   if (releaseManifest && archive.version && archive.version !== releaseManifest.version) {
     throw new Error('Theme ZIP theme.json version does not match the release manifest.');
   }
+  if (releaseManifest && archive.engines.press !== releaseManifest.engines.press) {
+    throw new Error('Theme ZIP engines.press does not match the release manifest.');
+  }
+  await assertThemePressCompatibility(releaseManifest ? releaseManifest.label : archive.label, archive.engines);
   const registry = await loadRegistry({ force: true, allowFallback: false });
   const previous = registry.find((entry) => entry.value === archive.slug) || null;
   if (previous && previous.builtIn && !options.allowBuiltInUpdate) {
@@ -887,7 +914,7 @@ async function fetchArrayBuffer(url) {
   return response.arrayBuffer();
 }
 
-async function stageCatalogTheme(catalogEntry, options = {}) {
+export async function stageCatalogTheme(catalogEntry, options = {}) {
   const releaseManifest = normalizeThemeReleaseManifest(await fetchJson(catalogEntry.manifestUrl));
   if (releaseManifest.value !== catalogEntry.value) {
     throw new Error('Official catalog entry does not match release manifest slug.');

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "type": "press-system",
+  "version": "3.4.0",
+  "tag": "v3.4.0",
+  "upgradeFrom": {
+    "ranges": [
+      ">=3.3.0 <3.4.0"
+    ],
+    "allowUnknownSource": true,
+    "message": ""
+  }
+}

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -7,6 +7,7 @@
   "type": "object",
   "required": [
     "contractVersion",
+    "engines",
     "content",
     "modules"
   ],
@@ -24,6 +25,20 @@
       "type": "integer",
       "const": 1,
       "description": "Press theme contract version this manifest targets."
+    },
+    "engines": {
+      "type": "object",
+      "description": "Runtime engine compatibility ranges for this theme.",
+      "required": [
+        "press"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "press": {
+          "type": "string",
+          "description": "Supported Press system SemVer range."
+        }
+      }
     },
     "styles": {
       "type": "array",

--- a/assets/themes/native/theme.json
+++ b/assets/themes/native/theme.json
@@ -3,6 +3,9 @@
   "name": "Native",
   "version": "3.4.0",
   "contractVersion": 1,
+  "engines": {
+    "press": ">=3.4.0 <4.0.0"
+  },
   "styles": [
     "theme.css"
   ],

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -4,6 +4,9 @@
     "label": "Native",
     "version": "3.4.0",
     "contractVersion": 1,
+    "engines": {
+      "press": ">=3.4.0 <4.0.0"
+    },
     "builtIn": true,
     "removable": false,
     "source": {

--- a/index_editor.html
+++ b/index_editor.html
@@ -2506,6 +2506,8 @@
         <div class="updates-header">
           <div class="updates-header-text">
             <div class="updates-meta">
+              <span id="systemUpdateCurrentVersion"></span>
+              <span id="systemUpdateTargetVersion"></span>
               <span id="systemUpdateReleaseMeta"></span>
               <span id="systemUpdateReleasePublished"></span>
               <span id="systemUpdateAssetMeta" class="updates-asset"></span>
@@ -2575,7 +2577,7 @@
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=annotate-i18n-20260510"></script>
   <script type="module" src="assets/js/editor-main.js?v=blocks-default-view-20260510"></script>
-  <script type="module" src="assets/js/composer.js?v=protection-native-switch-20260510"></script>
+  <script type="module" src="assets/js/composer.js?v=version-compat-20260512"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/dispatch-system-release.js
+++ b/scripts/dispatch-system-release.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 
 const API_ROOT = process.env.GITHUB_API_URL || 'https://api.github.com';
 const API_VERSION = '2022-11-28';
+const PRESS_SYSTEM_MANIFEST = 'assets/press-system.json';
 const DEFAULT_TARGETS = [
   { repository: 'EkilyHQ/YAP', eventType: 'press-system-release', label: 'YAP starter runtime' },
   { repository: 'EkilyHQ/Press-Theme-Starter', eventType: 'press-system-release', label: 'theme starter version' },
@@ -92,9 +93,14 @@ function buildPayload(release) {
   if (!tag || !assetName || !assetSha256) {
     throw new Error('NEXT_TAG, ASSET_NAME, and ASSET_SHA256 are required for release dispatch');
   }
+  const system = fs.existsSync(PRESS_SYSTEM_MANIFEST)
+    ? JSON.parse(fs.readFileSync(PRESS_SYSTEM_MANIFEST, 'utf8'))
+    : {};
   return {
     press_repository: env('GITHUB_REPOSITORY', 'EkilyHQ/Press'),
     tag,
+    version: String(system.version || '').trim(),
+    upgrade_from: system.upgradeFrom || {},
     asset_name: assetName,
     asset_size: Number.isFinite(assetSize) ? assetSize : 0,
     asset_sha256: assetSha256,

--- a/scripts/package-system-release.sh
+++ b/scripts/package-system-release.sh
@@ -17,6 +17,7 @@ system_paths=(
   "index.html"
   "index_editor.html"
   "index_editor_preview.html"
+  "assets/press-system.json"
   "assets/main.js"
   "assets/js"
   "assets/i18n"

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -107,14 +107,14 @@ assert.match(
 
 assert.match(
   editorSource,
-  /assets\/js\/editor-main\.js\?v=highlightjs-common-20260510/,
-  'editor HTML should cache-bust editor-main.js when Highlight.js editor handling changes'
+  /assets\/js\/editor-main\.js\?v=blocks-default-view-20260510/,
+  'editor HTML should cache-bust editor-main.js when block editor defaults change'
 );
 
 assert.match(
   editorSource,
-  /assets\/js\/composer\.js\?v=annotate-combobox-20260510/,
-  'editor HTML should cache-bust composer.js when site settings UI changes'
+  /assets\/js\/composer\.js\?v=version-compat-20260512/,
+  'editor HTML should cache-bust composer.js when version compatibility changes'
 );
 
 assert.match(
@@ -125,20 +125,20 @@ assert.match(
 
 assert.match(
   editorSource,
-  /button#btnProtectMarkdown\.btn-secondary\[data-protected="true"\][\s\S]*\.composer-protection-modal[\s\S]*\.composer-protection-card/,
-  'editor stylesheet should include protected article password dialog and protected button state'
+  /\.composer-protection-modal[\s\S]*\.composer-protection-card[\s\S]*id="btnProtectMarkdown"[^>]+role="switch"/,
+  'editor stylesheet should include protected article password dialog and native protected switch state'
 );
 
 assert.match(
   editorSource,
-  /assets\/js\/editor-main\.js\?v=highlightjs-common-20260510/,
-  'editor HTML should cache-bust editor-main.js when Highlight.js editor handling changes'
+  /assets\/js\/editor-main\.js\?v=blocks-default-view-20260510/,
+  'editor HTML should cache-bust editor-main.js when block editor defaults change'
 );
 
 assert.match(
   editorMainSource,
-  /from '\.\/markdown\.js\?v=katex-math-20260510'/,
-  'editor preview should cache-bust the Markdown parser when math syntax changes'
+  /from '\.\/editor-blocks\.js\?v=katex-blocks-20260510'/,
+  'editor preview should cache-bust the Markdown blocks editor when math block handling changes'
 );
 
 assert.match(
@@ -148,15 +148,15 @@ assert.match(
 );
 
 assert.match(
-  editorMainSource,
+  editorBlocksSource,
   /from '\.\/math-render\.js\?v=katex-math-20260510'/,
-  'editor preview should cache-bust the math renderer when KaTeX support changes'
+  'editor blocks should cache-bust the math renderer when KaTeX support changes'
 );
 
 assert.match(
   source,
-  /from '\.\/system-updates\.js\?v=katex-math-20260510'/,
-  'composer should cache-bust system update notes when math rendering changes'
+  /from '\.\/system-updates\.js\?v=version-compat-20260512'/,
+  'composer should cache-bust system updates when version compatibility changes'
 );
 
 assert.match(
@@ -388,20 +388,20 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /class="vt-btn active" data-view="edit"[\s\S]*class="vt-btn" data-view="blocks"[\s\S]*class="vt-btn" data-view="preview"[\s\S]*id="blocks-wrap" hidden aria-hidden="true"/,
-  'markdown editor should expose Edit, Blocks, and Preview views with a dedicated blocks surface'
+  /class="vt-btn active" data-view="blocks"[\s\S]*class="vt-btn" data-view="edit"[\s\S]*id="blocks-wrap" hidden aria-hidden="true"/,
+  'markdown editor should expose Blocks and Editor views with a dedicated blocks surface'
 );
 
 assert.match(
   editorMainSource,
-  /function switchView\(mode\) \{[\s\S]*const blocksWrap = \$\('#blocks-wrap'\);[\s\S]*mode === 'blocks'[\s\S]*blocksWrap\.hidden = false;[\s\S]*editorToolbar\.hidden = true;[\s\S]*viewToggle && \(viewToggle\.dataset\.view = 'blocks'\);/,
-  'markdown view switcher should show blocks mode while hiding source toolbar and preview'
+  /function switchView\(mode\) \{[\s\S]*const blocksWrap = \$\('#blocks-wrap'\);[\s\S]*mode === 'blocks'[\s\S]*editorWrap\.style\.display = 'none';[\s\S]*blocksWrap\.hidden = false;[\s\S]*editorToolbar\.hidden = true;[\s\S]*viewToggle && \(viewToggle\.dataset\.view = 'blocks'\);/,
+  'markdown view switcher should show blocks mode while hiding source toolbar'
 );
 
 assert.match(
   editorMainSource,
-  /const LS_VIEW_KEY = 'press_editor_markdown_view';[\s\S]*function readPersistedMarkdownEditorView\(\) \{[\s\S]*localStorage\.getItem\(LS_VIEW_KEY\)[\s\S]*function persistMarkdownEditorView\(mode\) \{[\s\S]*localStorage\.setItem\(LS_VIEW_KEY, normalizeMarkdownEditorView\(mode\)\);/,
-  'markdown editor should persist the selected source/blocks/preview view'
+  /const LS_VIEW_KEY = 'press_editor_markdown_view_v2';[\s\S]*function readPersistedMarkdownEditorView\(\) \{[\s\S]*localStorage\.getItem\(LS_VIEW_KEY\)[\s\S]*function persistMarkdownEditorView\(mode\) \{[\s\S]*localStorage\.setItem\(LS_VIEW_KEY, normalizeMarkdownEditorView\(mode\)\);/,
+  'markdown editor should persist the selected source/blocks view'
 );
 
 assert.match(
@@ -1021,8 +1021,8 @@ assert.match(
 
 assert.match(
   editorMainSource,
-  /const refreshPreviewAssetOverrides = \(\) => \{[\s\S]*\['preview-main', 'blocks-wrap'\]\.forEach\(\(id\) => \{[\s\S]*document\.getElementById\(id\)[\s\S]*applyPreviewAssetOverrides\(target, previewAssetCurrentPath\);[\s\S]*\}\);[\s\S]*\};/,
-  'asset preview refresh should update both rendered preview and WYSIWYG block images'
+  /const refreshPreviewAssetOverrides = \(\) => \{[\s\S]*\['blocks-wrap'\]\.forEach\(\(id\) => \{[\s\S]*document\.getElementById\(id\)[\s\S]*applyPreviewAssetOverrides\(target, previewAssetCurrentPath\);[\s\S]*\}\);[\s\S]*\};/,
+  'asset preview refresh should update WYSIWYG block images'
 );
 
 assert.doesNotMatch(
@@ -1604,9 +1604,9 @@ assert.match(
 );
 
 assert.match(
-  editorMainSource,
-  /setSafeHtml\(target, post \|\| '', baseDir,[\s\S]*try \{ initSyntaxHighlighting\(target\); \} catch \(_\) \{\}/,
-  'editor preview syntax highlighting should stay scoped to the preview container'
+  editorBlocksSource,
+  /highlight\.replaceChildren\(createSafeHighlightFragment\(raw, meta\.highlight \? meta\.language : 'plain'\)\);/,
+  'editor block syntax highlighting should render through the safe highlight fragment helper'
 );
 
 assert.match(

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -46,6 +46,11 @@ if ! grep -qx "press-system-${version}/index_editor_preview.html" "${entries_fil
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/press-system.json" "${entries_file}"; then
+  echo "expected package to include the Press system version manifest" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/system-updates.js" "${entries_file}"; then
   echo "expected package to include system updater code" >&2
   exit 1
@@ -144,7 +149,7 @@ if grep -Eq "${blocked}" "${entries_file}"; then
   exit 1
 fi
 
-allowed="^press-system-${version}/(index\\.html|index_editor\\.html|index_editor_preview\\.html|assets/(main\\.js|js/.*|i18n/.*|schema/.*|themes/native/.*))$"
+allowed="^press-system-${version}/(index\\.html|index_editor\\.html|index_editor_preview\\.html|assets/(press-system\\.json|main\\.js|js/.*|i18n/.*|schema/.*|themes/native/.*))$"
 while IFS= read -r entry; do
   if [[ ! "${entry}" =~ ${allowed} ]]; then
     echo "unexpected file in system release package: ${entry}" >&2

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -58,6 +58,21 @@ if ! grep -F 'assets/themes/native)' "${workflow}" >/dev/null && ! grep -F 'asse
   exit 1
 fi
 
+if ! grep -F 'assets/press-system.json' "${workflow}" >/dev/null; then
+  echo "system release planning must include the Press system version manifest" >&2
+  exit 1
+fi
+
+if ! grep -F "require('./assets/press-system.json')" "${workflow}" >/dev/null; then
+  echo "system release workflow must read the next release version from assets/press-system.json" >&2
+  exit 1
+fi
+
+if grep -F '$((patch + 1))' "${workflow}" >/dev/null || grep -F 'next_tag="v0.0.1"' "${workflow}" >/dev/null; then
+  echo "system release workflow must not auto-increment release versions" >&2
+  exit 1
+fi
+
 if grep -F 'assets/themes/catalog.json' "${workflow}" >/dev/null; then
   echo "system release planning must not include the external official theme catalog" >&2
   exit 1
@@ -168,6 +183,16 @@ if ! grep -F '"url": os.environ["FETCHABLE_ASSET_URL"]' "${workflow}" >/dev/null
   exit 1
 fi
 
+if ! grep -F '"version": version' "${workflow}" >/dev/null; then
+  echo "system release manifest must publish the explicit Press version" >&2
+  exit 1
+fi
+
+if ! grep -F '"upgradeFrom": system.get("upgradeFrom") or {}' "${workflow}" >/dev/null; then
+  echo "system release manifest must publish upgradeFrom compatibility metadata" >&2
+  exit 1
+fi
+
 if ! grep -F 'Path("dist/system-release.json").write_text' "${workflow}" >/dev/null; then
   echo "system release workflow must write the static release manifest into dist" >&2
   exit 1
@@ -247,6 +272,11 @@ fi
 
 if ! grep -F 'asset_sha256: assetSha256' scripts/dispatch-system-release.js >/dev/null; then
   echo "release dispatch orchestrator must pass the system package digest to targets" >&2
+  exit 1
+fi
+
+if ! grep -F 'upgrade_from: system.upgradeFrom || {}' scripts/dispatch-system-release.js >/dev/null; then
+  echo "release dispatch orchestrator must pass upgrade compatibility metadata to targets" >&2
   exit 1
 fi
 

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { webcrypto } from 'node:crypto';
 import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
+import {
+  satisfiesSemverRange,
+  setPressSystemManifestForTests
+} from '../assets/js/press-version.js?v=version-compat-20260512';
 
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 if (!globalThis.btoa) {
@@ -84,7 +88,22 @@ function arrayBufferResponse(buffer, options = {}) {
   };
 }
 
+function setDefaultCurrentPressSystemForTests() {
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.3.64',
+    tag: 'v3.3.64',
+    upgradeFrom: {
+      ranges: ['>=3.3.0 <3.4.0'],
+      allowUnknownSource: true,
+      message: ''
+    }
+  });
+}
+
 async function run(name, fn) {
+  setDefaultCurrentPressSystemForTests();
   try {
     await fn();
     console.log(`ok - ${name}`);
@@ -107,6 +126,12 @@ await run('selects the dedicated Press system release asset', async () => {
   assert.equal(selectSystemUpdateAsset({
     assets: [{ name: 'Press-v3.3.5-source.zip', browser_download_url: 'https://example.test/source.zip' }]
   }), null);
+});
+
+await run('matches Press SemVer ranges', async () => {
+  assert.equal(satisfiesSemverRange('3.4.0', '>=3.4.0 <4.0.0'), true);
+  assert.equal(satisfiesSemverRange('v3.5.1', '3.4.0 || >=3.5.0 <4.0.0'), true);
+  assert.equal(satisfiesSemverRange('3.3.64', '>=3.4.0 <4.0.0'), false);
 });
 
 await run('verifies release asset size and digest before archive comparison', async () => {
@@ -134,8 +159,14 @@ await run('normalizes static system release manifests', async () => {
     schemaVersion: 1,
     name: 'v3.3.5',
     tag: 'v3.3.5',
+    version: '3.3.5',
     publishedAt: '2026-04-29T08:18:39Z',
     notes: 'Release notes',
+    upgradeFrom: {
+      ranges: ['>=3.3.0 <3.3.5'],
+      allowUnknownSource: true,
+      message: ''
+    },
     htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
     asset: {
       name: 'press-system-v3.3.5.zip',
@@ -146,6 +177,8 @@ await run('normalizes static system release manifests', async () => {
   });
 
   assert.equal(release.tag, 'v3.3.5');
+  assert.equal(release.version, '3.3.5');
+  assert.deepEqual(release.upgradeFrom.ranges, ['>=3.3.0 <3.3.5']);
   assert.equal(release.asset.name, 'press-system-v3.3.5.zip');
   assert.throws(
     () => normalizeSystemReleaseManifest({
@@ -541,6 +574,7 @@ await run('keeps manual fallback available when automatic download fails', async
 await run('normalizes a rooted system update archive to safe site-relative paths', async () => {
   const buffer = makeZip({
     'press-system-v3.3.5/index.html': '<!doctype html>',
+    'press-system-v3.3.5/assets/press-system.json': '{"schemaVersion":1,"type":"press-system","version":"3.3.5","tag":"v3.3.5","upgradeFrom":{"ranges":[">=3.3.0 <3.3.5"],"allowUnknownSource":true,"message":""}}',
     'press-system-v3.3.5/assets/js/system-updates.js': 'export {};',
     'press-system-v3.3.5/assets/themes/native/theme.json': '{"name":"Native","contractVersion":1}'
   });
@@ -549,9 +583,81 @@ await run('normalizes a rooted system update archive to safe site-relative paths
 
   assert.deepEqual(entries.map((entry) => entry.path).sort(), [
     'assets/js/system-updates.js',
+    'assets/press-system.json',
     'assets/themes/native/theme.json',
     'index.html'
   ]);
+});
+
+await run('allows bootstrap system updates when current version is unknown', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests(null);
+  const buffer = makeZip({
+    'press-system-v3.4.0/index.html': '<!doctype html><p>bootstrap</p>',
+    'press-system-v3.4.0/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.0',
+      tag: 'v3.4.0',
+      upgradeFrom: {
+        ranges: ['>=3.3.0 <3.4.0'],
+        allowUnknownSource: true,
+        message: ''
+      }
+    })
+  });
+
+  globalThis.fetch = async () => ({
+    ok: false,
+    json: async () => ({}),
+    arrayBuffer: async () => new ArrayBuffer(0)
+  });
+
+  await analyzeArchive(buffer, 'press-system-v3.4.0.zip');
+  assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path).sort(), [
+    'assets/press-system.json',
+    'index.html'
+  ]);
+  delete globalThis.fetch;
+});
+
+await run('blocks system updates outside the declared source range', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.0',
+    tag: 'v3.4.0',
+    upgradeFrom: { ranges: ['>=3.3.0 <3.4.0'], allowUnknownSource: true, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v4.0.0/index.html': '<!doctype html><p>major</p>',
+    'press-system-v4.0.0/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '4.0.0',
+      tag: 'v4.0.0',
+      upgradeFrom: {
+        ranges: ['>=3.5.0 <4.0.0'],
+        allowUnknownSource: false,
+        message: ''
+      }
+    })
+  });
+
+  globalThis.fetch = async () => ({
+    ok: false,
+    json: async () => ({}),
+    arrayBuffer: async () => new ArrayBuffer(0)
+  });
+
+  await assert.rejects(
+    () => analyzeArchive(buffer, 'press-system-v4.0.0.zip'),
+    /intermediate|source range|不能|直接更新|中間|Press/i
+  );
+  assert.deepEqual(getSystemUpdateCommitFiles(), []);
+  delete globalThis.fetch;
+  setPressSystemManifestForTests(null);
 });
 
 await run('rejects system packages that would overwrite external theme directories', async () => {

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -214,7 +214,7 @@ CORE_RUNTIME_FILES.forEach((file) => {
   });
 });
 
-['contractVersion', 'regions', 'views', 'components', 'scrollContainer', 'configSchema', 'content', 'shapes', 'handler'].forEach((needle) => {
+['contractVersion', 'engines', 'press', 'regions', 'views', 'components', 'scrollContainer', 'configSchema', 'content', 'shapes', 'handler'].forEach((needle) => {
   if (!themeContractSource.includes(needle)) {
     fail(`wwwroot/post/theme-contract/theme-contract_en.md must document manifest field ${needle}`);
   }
@@ -253,6 +253,9 @@ themeNames.forEach((themeName) => {
   if (!manifest.name) fail(`${relManifest} must declare name`);
   if (!manifest.version) fail(`${relManifest} must declare version`);
   if (manifest.contractVersion !== 1) fail(`${relManifest} contractVersion must be 1`);
+  if (!manifest.engines || typeof manifest.engines.press !== 'string' || !manifest.engines.press.trim()) {
+    fail(`${relManifest} must declare engines.press`);
+  }
 
   const styles = requireList(manifest, 'styles', 'styles', relManifest);
   let styleSource = '';

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -39,6 +39,7 @@ const {
   normalizeThemeReleaseManifest,
   OFFICIAL_THEME_CATALOG_URL,
   sanitizeThemeSlug,
+  stageCatalogTheme,
   stageThemeUninstall,
   verifyThemeAsset
 } = await import('../assets/js/theme-manager.js?theme-manager-test');
@@ -60,6 +61,7 @@ function makeThemeManifest({
   name = 'Test',
   version = '1.0.0',
   contractVersion = 1,
+  engines = { press: '>=3.4.0 <4.0.0' },
   styles = ['theme.css'],
   modules = ['modules/layout.js'],
   overrides = {}
@@ -68,6 +70,7 @@ function makeThemeManifest({
     name,
     version,
     contractVersion,
+    engines,
     styles,
     modules,
     views: {
@@ -106,12 +109,25 @@ function makeThemeZip({ slug = 'test', name = 'Test', version = '1.0.0', contrac
 
 function mockFetchRegistry(registry, options = {}) {
   const textFiles = options.textFiles || {};
+  const binaryFiles = options.binaryFiles || {};
   const catalog = options.catalog || { schemaVersion: 1, themes: [] };
   const jsonFiles = options.jsonFiles || {};
   globalThis.fetch = async (input) => {
     const url = String(input || '').split('?')[0];
     if (url === 'assets/themes/packs.json') {
       return { ok: true, json: async () => registry };
+    }
+    if (url === 'assets/press-system.json') {
+      return {
+        ok: true,
+        json: async () => ({
+          schemaVersion: 1,
+          type: 'press-system',
+          version: '3.4.0',
+          tag: 'v3.4.0',
+          upgradeFrom: { ranges: ['>=3.3.0 <3.4.0'], allowUnknownSource: true, message: '' }
+        })
+      };
     }
     if (url === OFFICIAL_THEME_CATALOG_URL) {
       if (options.catalogFailure) {
@@ -128,6 +144,12 @@ function mockFetchRegistry(registry, options = {}) {
         ok: true,
         text: async () => value,
         arrayBuffer: async () => Buffer.from(value).buffer
+      };
+    }
+    if (Object.prototype.hasOwnProperty.call(binaryFiles, url)) {
+      return {
+        ok: true,
+        arrayBuffer: async () => binaryFiles[url]
       };
     }
     return {
@@ -245,6 +267,7 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
     label: 'Arcus',
     version: '1.2.3',
     contractVersion: 1,
+    engines: { press: '>=3.4.0 <4.0.0' },
     release: { tag: 'v1.2.3' },
     asset: {
       name: 'press-theme-arcus-v1.2.3.zip',
@@ -255,7 +278,9 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
     files: ['theme.json', 'theme.css']
   });
   assert.equal(manifest.value, 'arcus');
+  assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }), /contractVersion/i);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, engines: {} }), /engines\.press/i);
 });
 
 await run('rejects unsafe and multi-theme ZIP archives', async () => {
@@ -313,7 +338,7 @@ await run('rejects invalid theme manifests before staging', async () => {
       }, null, 2),
       'press-theme-bad/theme.css': ':root{}'
     }), 'press-theme-bad-v1.0.0.zip'),
-    /modules|content|views|regions/i
+    /engines|modules|content|views|regions/i
   );
   assert.equal(getThemeManagerCommitFiles().length, 0);
 
@@ -337,6 +362,80 @@ await run('rejects invalid theme manifests before staging', async () => {
     })),
     /styles.*missing/i
   );
+});
+
+await run('blocks manual theme imports without compatible Press engines', async () => {
+  mockFetchRegistry([{ value: 'native', label: 'Native', builtIn: true, removable: false, files: [] }]);
+  await assert.rejects(
+    () => analyzeThemeArchive(makeZip({
+      'press-theme-missing/theme.json': JSON.stringify(makeThemeManifest({
+        name: 'Missing',
+        overrides: { engines: undefined }
+      }), null, 2),
+      'press-theme-missing/theme.css': ':root{}',
+      'press-theme-missing/modules/layout.js': 'export default {};'
+    }), 'press-theme-missing-v1.0.0.zip'),
+    /engines\.press/i
+  );
+  assert.equal(getThemeManagerCommitFiles().length, 0);
+
+  await assert.rejects(
+    () => analyzeThemeArchive(makeZip({
+      'press-theme-future/theme.json': JSON.stringify(makeThemeManifest({
+        name: 'Future',
+        engines: { press: '>=4.0.0 <5.0.0' }
+      }), null, 2),
+      'press-theme-future/theme.css': ':root{}',
+      'press-theme-future/modules/layout.js': 'export default {};'
+    }), 'press-theme-future-v1.0.0.zip'),
+    /supports Press|running v3\.4\.0/i
+  );
+  assert.equal(getThemeManagerCommitFiles().length, 0);
+});
+
+await run('blocks official theme releases outside the current Press engine range', async () => {
+  const buffer = makeThemeZip({ slug: 'cataloged', name: 'Cataloged', version: '1.0.0', files: {
+    'theme.json': JSON.stringify(makeThemeManifest({
+      name: 'Cataloged',
+      engines: { press: '>=4.0.0 <5.0.0' }
+    }), null, 2)
+  } });
+  const digest = await sha256(buffer);
+  const assetUrl = 'https://example.test/press-theme-cataloged-v1.0.0.zip';
+  mockFetchRegistry([{ value: 'native', label: 'Native', builtIn: true, removable: false, files: [] }], {
+    jsonFiles: {
+      'https://example.test/cataloged-theme-release.json': {
+        schemaVersion: 1,
+        type: 'press-theme',
+        value: 'cataloged',
+        label: 'Cataloged',
+        version: '1.0.0',
+        contractVersion: 1,
+        engines: { press: '>=4.0.0 <5.0.0' },
+        asset: {
+          name: 'press-theme-cataloged-v1.0.0.zip',
+          url: assetUrl,
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        },
+        files: ['theme.json', 'theme.css', 'modules/layout.js']
+      }
+    },
+    binaryFiles: {
+      [assetUrl]: buffer
+    }
+  });
+
+  await assert.rejects(
+    () => stageCatalogTheme({
+      value: 'cataloged',
+      label: 'Cataloged',
+      repo: 'EkilyHQ/Press-Theme-Cataloged',
+      manifestUrl: 'https://example.test/cataloged-theme-release.json'
+    }),
+    /supports Press|running v3\.4\.0/i
+  );
+  assert.equal(getThemeManagerCommitFiles().length, 0);
 });
 
 await run('accepts theme manifests without optional view states', async () => {
@@ -624,6 +723,7 @@ await run('filters catalog-inferred inventory to existing files during uninstall
         label: 'Cataloged',
         version: '1.0.0',
         contractVersion: 1,
+        engines: { press: '>=3.4.0 <4.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
           url: 'https://example.test/press-theme-cataloged-v1.0.0.zip',

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -116,9 +116,9 @@ assert.match(main, /from '\.\/js\/post-nav\.js\?v=annotate-i18n-20260510';/, 'ma
 assert.match(main, /from '\.\/js\/annotate\.js\?v=katex-math-20260510';/, 'main should cache-bust annotate runtime helpers when comments are mounted');
 assert.match(composer, /from '\.\/i18n\.js\?v=annotate-i18n-20260510';/, 'composer should share the repository deletion docs i18n cache key');
 assert.match(composer, /from '\.\/seo\.js\?v=annotate-i18n-20260510';/, 'composer should cache-bust SEO helpers after editor i18n dependency changes');
-assert.match(composer, /from '\.\/system-updates\.js\?v=katex-math-20260510';/, 'composer should cache-bust system updates after math renderer changes');
+assert.match(composer, /from '\.\/system-updates\.js\?v=version-compat-20260512';/, 'composer should cache-bust system updates after version compatibility changes');
 assert.match(read('assets/js/system-updates.js'), /from '\.\/safe-html\.js\?v=katex-math-20260510';/, 'system updates should cache-bust sanitizer when release notes can contain math');
-assert.match(composer, /from '\.\/theme-manager\.js\?v=theme-switch-fix-20260508';/, 'composer should cache-bust theme manager after editor i18n dependency changes');
+assert.match(composer, /from '\.\/theme-manager\.js\?v=version-compat-20260512';/, 'composer should cache-bust theme manager after Press engine compatibility changes');
 assert.match(composer, /from '\.\/encrypted-content\.js\?v=encrypted-demo-20260508';/, 'composer should use the encrypted markdown envelope helpers for protected editor flows');
 assert.match(themeLayout, /from '\.\/i18n\.js\?v=annotate-i18n-20260510';/, 'theme layout should share the repository deletion docs i18n cache key');
 assert.match(languageManifest, /en\.js\?v=annotate-i18n-20260510/, 'language manifest should cache-bust bundles when editor asset deletion strings change');
@@ -186,7 +186,7 @@ assert.match(editorPreviewRuntime, /callThemeEffect\('renderPostView'[\s\S]*mark
 assert.match(editorPreviewRuntime, /restorePreviewThemeStyles\(activePack, layout && layout\.manifest\)/, 'editor preview runtime should restore non-persistent theme styles after theme tools render');
 assert.doesNotMatch(editorMain, /if \(nextView === 'blocks'\) renderPreview/, 'block mode should not trigger themed preview rendering');
 assert.match(indexEditorHtml, /src="assets\/js\/editor-main\.js\?v=blocks-default-view-20260510"/, 'editor should cache-bust editor-main after default blocks view changes');
-assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=protection-native-switch-20260510"/, 'editor should cache-bust composer after native protection switch UI changes');
+assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=version-compat-20260512"/, 'editor should cache-bust composer after version compatibility changes');
 assert.match(composer, /if \('checked' in btn\) btn\.checked = protectedState;[\s\S]*btn\.setAttribute\('aria-checked', protectedState \? 'true' : 'false'\);[\s\S]*switchEl\.dataset\.state = protectedState \? 'on' : 'off';/, 'markdown protection switch should synchronize native checked state and visual switch state');
 assert.match(search, /addEventListener\('press:search'[\s\S]*navigateSearch/, 'search routing should listen for press:search');
 assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -36,6 +36,7 @@ remote repository at runtime; a selected theme must exist locally under
   "name": "Native",
   "version": "3.4.0",
   "contractVersion": 1,
+  "engines": { "press": ">=3.4.0 <4.0.0" },
   "styles": ["theme.css"],
   "modules": ["modules/layout.js", "modules/interactions.js", "modules/views.js"],
   "views": {
@@ -66,6 +67,9 @@ remote repository at runtime; a selected theme must exist locally under
 - `name` and `version`: Human-facing theme identity.
 - `contractVersion`: Press runtime contract version. The current value is
   `1`.
+- `engines.press`: Press system SemVer range the theme supports. Theme Manager
+  rejects official and manually imported themes outside the current Press
+  version.
 - `styles`: Ordered CSS files relative to the theme pack root.
 - `modules`: Ordered JavaScript modules relative to the theme pack root.
 - `views`: Public view states the theme supports. Required views are `post`,
@@ -93,6 +97,7 @@ changes to it through Publish, and Press system updates do not overwrite it.
   "label": "Arcus",
   "version": "3.4.0",
   "contractVersion": 1,
+  "engines": { "press": ">=3.4.0 <4.0.0" },
   "builtIn": false,
   "removable": true,
   "source": {
@@ -132,6 +137,7 @@ Official theme repositories publish a root `theme-release.json`:
   "label": "Arcus",
   "version": "3.4.0",
   "contractVersion": 1,
+  "engines": { "press": ">=3.4.0 <4.0.0" },
   "release": {
     "tag": "v3.4.0",
     "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.0",
@@ -153,7 +159,9 @@ same ZIP to a `release-artifacts` branch and keep the GitHub Release URL in
 `release.htmlUrl`.
 
 Theme Manager verifies `schemaVersion`, `type`, slug, version,
-`contractVersion`, ZIP size, and SHA-256 digest before staging changes.
+`contractVersion`, `engines.press`, ZIP size, and SHA-256 digest before staging
+changes. The release manifest and the packaged `theme.json` must agree on the
+Press engine range.
 
 ## Theme ZIP Format
 
@@ -161,7 +169,7 @@ A theme ZIP is a single-theme package. After removing one common archive root,
 it must contain `theme.json` at the theme root. Theme Manager rejects absolute
 paths, drive paths, URL paths, `.` and `..` segments, nested `*/theme.json`
 entries, unsupported file extensions, missing `theme.json`, and
-`contractVersion` mismatches.
+`contractVersion` or `engines.press` mismatches.
 
 Install and update operations map files to `assets/themes/<slug>/...`. Updates
 compare the new ZIP file list with the installed registry `files` list; removed


### PR DESCRIPTION
## Summary
- add tracked Press system identity in assets/press-system.json for v3.4.0
- read system release versions from the source manifest and publish upgradeFrom metadata
- enforce Press upgradeFrom checks in System Updates and engines.press checks in Theme Manager
- extend theme schema/docs/native theme metadata and YAP/downstream release dispatch metadata

## Tests
- bash scripts/test-system-release-package.sh
- node --experimental-default-type=module scripts/test-system-updates.js
- node --experimental-default-type=module scripts/test-theme-manager.js
- node scripts/test-theme-contracts.js
- bash scripts/test-system-release-workflow.sh
- node scripts/test-ui-components.js
- node scripts/test-composer-identity-grid.js
- bash scripts/test-main-guard.sh
- bash scripts/test-frontmatter-roundtrip.sh
- node scripts/test-content-model.js

## Notes
Chrome extension currently blocks local localhost preview with ERR_BLOCKED_BY_CLIENT; browser smoke will be run against the published URL after release.