### PR TITLE
Fix system release version planning

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -41,16 +41,7 @@ jobs:
             latest_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 || true)"
           fi
 
-          source_version="$(node - <<'NODE'
-          const manifest = require('./assets/press-system.json');
-          const version = String(manifest.version || '').trim();
-          const tag = String(manifest.tag || '').trim();
-          if (!/^\d+\.\d+\.\d+$/.test(version) || tag !== `v${version}`) {
-            throw new Error('assets/press-system.json must declare matching version and tag');
-          }
-          process.stdout.write(version);
-          NODE
-          )"
+          source_version="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) { throw new Error('assets/press-system.json must declare matching version and tag'); } process.stdout.write(version);")"
           next_tag="v${source_version}"
 
           if [[ -n "${latest_tag}" ]]; then
@@ -70,20 +61,7 @@ jobs:
           if [[ -n "${latest_tag}" ]]; then
             export LATEST_TAG="${latest_tag}"
             export NEXT_TAG="${next_tag}"
-            node <<'NODE'
-            function parse(tag) {
-              const match = String(tag || '').match(/^v(\d+)\.(\d+)\.(\d+)$/);
-              if (!match) throw new Error(`invalid release tag: ${tag}`);
-              return match.slice(1).map(Number);
-            }
-            const latest = parse(process.env.LATEST_TAG);
-            const next = parse(process.env.NEXT_TAG);
-            for (let i = 0; i < 3; i += 1) {
-              if (next[i] > latest[i]) process.exit(0);
-              if (next[i] < latest[i]) break;
-            }
-            throw new Error(`assets/press-system.json version ${process.env.NEXT_TAG} must be greater than latest release ${process.env.LATEST_TAG}`);
-            NODE
+            node -e "function parse(tag) { const match = String(tag || '').match(/^v(\\d+)\\.(\\d+)\\.(\\d+)$/); if (!match) throw new Error(\`invalid release tag: \${tag}\`); return match.slice(1).map(Number); } const latest = parse(process.env.LATEST_TAG); const next = parse(process.env.NEXT_TAG); for (let i = 0; i < 3; i += 1) { if (next[i] > latest[i]) process.exit(0); if (next[i] < latest[i]) break; } throw new Error(\`assets/press-system.json version \${process.env.NEXT_TAG} must be greater than latest release \${process.env.LATEST_TAG}\`);"
           fi
 
           {

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -73,6 +73,11 @@ if grep -F '$((patch + 1))' "${workflow}" >/dev/null || grep -F 'next_tag="v0.0.
   exit 1
 fi
 
+if grep -Eq '^[[:space:]]+NODE$' "${workflow}"; then
+  echo "system release workflow must not use indented heredoc terminators inside shell blocks" >&2
+  exit 1
+fi
+
 if grep -F 'assets/themes/catalog.json' "${workflow}" >/dev/null; then
   echo "system release planning must not include the external official theme catalog" >&2
   exit 1


### PR DESCRIPTION
## Summary
- replace nested node heredocs in system-release planning with node -e calls
- add a workflow test guard against indented heredoc terminators in shell blocks

## Tests
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-system-release-package.sh