### PR TITLE
Preserve upgrade block messages

### DIFF
--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -469,7 +469,9 @@ function assertSystemUpdateCompatibility(release, archiveSystem) {
     target: versionLabel(targetVersion),
     ranges: upgradeFrom.ranges.join(', ') || t('editor.systemUpdates.unknownVersion')
   });
-  throw new Error(message);
+  const error = new Error(message);
+  error.pressUpgradeBlocked = true;
+  throw error;
 }
 
 function renderRelease() {
@@ -725,6 +727,7 @@ export async function analyzeArchive(buffer, filename) {
     files = await processArchiveEntries(entries);
   } catch (err) {
     console.error('Failed to unpack system update archive', err);
+    if (err && err.pressUpgradeBlocked) throw err;
     if (err && err.message && /upgrade|version|Press/i.test(err.message)) throw err;
     throw new Error(t('editor.systemUpdates.errors.invalidArchive'));
   }

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.0",
-  "tag": "v3.4.0",
+  "version": "3.4.1",
+  "tag": "v3.4.1",
   "upgradeFrom": {
     "ranges": [
-      ">=3.3.0 <3.4.0"
+      ">=3.4.0 <3.4.1"
     ],
-    "allowUnknownSource": true,
-    "message": ""
+    "allowUnknownSource": false,
+    "message": "Update to v3.4.0 first."
   }
 }

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -660,6 +660,45 @@ await run('blocks system updates outside the declared source range', async () =>
   setPressSystemManifestForTests(null);
 });
 
+await run('preserves custom upgradeFrom block messages', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.0',
+    tag: 'v3.4.0',
+    upgradeFrom: { ranges: ['>=3.3.0 <3.4.0'], allowUnknownSource: true, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v4.0.0/index.html': '<!doctype html><p>major</p>',
+    'press-system-v4.0.0/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '4.0.0',
+      tag: 'v4.0.0',
+      upgradeFrom: {
+        ranges: ['>=3.5.0 <4.0.0'],
+        allowUnknownSource: false,
+        message: 'Update to v3.5.x first.'
+      }
+    })
+  });
+
+  globalThis.fetch = async () => ({
+    ok: false,
+    json: async () => ({}),
+    arrayBuffer: async () => new ArrayBuffer(0)
+  });
+
+  await assert.rejects(
+    () => analyzeArchive(buffer, 'press-system-v4.0.0.zip'),
+    /Update to v3\.5\.x first\./
+  );
+  assert.deepEqual(getSystemUpdateCommitFiles(), []);
+  delete globalThis.fetch;
+  setPressSystemManifestForTests(null);
+});
+
 await run('rejects system packages that would overwrite external theme directories', async () => {
   assert.throws(
     () => collectSystemUpdateArchiveEntries(makeZip({


### PR DESCRIPTION
Fixes system update compatibility blocking so a release-defined upgradeFrom.message is shown instead of being wrapped as a generic invalid ZIP error. Bumps the Press source identity to 3.4.1 with fail-closed upgradeFrom from 3.4.0.\n\nTests run:\n- node --experimental-default-type=module scripts/test-system-updates.js\n- bash scripts/test-system-release-package.sh\n- bash scripts/test-system-release-workflow.sh\n- git diff --check