### PR TITLE
Sanitize Markdown fence languages

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -5508,7 +5508,7 @@ function buildDefaultIndexHtml(metaBlock, lang) {
   html += '  <link rel="stylesheet" id="theme-pack">\n';
   html += '</head>\n\n';
   html += '<body>\n';
-  html += '  <script type="module" src="assets/main.js?v=theme-layout-generation-20260510"></script>\n';
+  html += '  <script type="module" src="assets/main.js?v=markdown-security-20260512"></script>\n';
   html += '</body>\n\n';
   html += '</html>\n';
   return html;

--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -1,5 +1,5 @@
 import './components.js';
-import { mdParse } from './markdown.js?v=katex-math-20260510';
+import { mdParse } from './markdown.js?v=markdown-security-20260512';
 import { createContentModel } from './content-model.js';
 import { parseFrontMatter } from './content.js';
 import { getContentRoot, setSafeHtml } from './safe-html.js?v=katex-math-20260510';

--- a/assets/js/markdown.js
+++ b/assets/js/markdown.js
@@ -40,6 +40,11 @@ function parseNestedMarkdown(markdown, baseDir, options) {
   return mdParse(markdown, baseDir, { ...options, depth: options.depth + 1 });
 }
 
+function normalizeCodeFenceLanguage(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  return /^[a-z0-9][a-z0-9_.+-]{0,39}$/u.test(raw) ? raw : '';
+}
+
 function isPipeTableSeparator(line) {
   // Matches a classic Markdown table separator like:
   // | ----- | :----: | ------- |
@@ -279,7 +284,7 @@ export function mdParse(markdown, baseDir, options = {}) {
       closePara();
       activeCodeFence = fence;
       codeBlockIndent = lineIndent; // Remember the indent level
-      codeLang = (fence.info.trim().split(/\s+/)[0] || '').toLowerCase();
+      codeLang = normalizeCodeFenceLanguage(fence.info.trim().split(/\s+/)[0] || '');
       // Calculate indent level (tab = 4 spaces, each level = 2rem roughly)
       const indentLevel = Math.floor(lineIndent.replace(/\t/g, '    ').length / 4);
       const indentClass = indentLevel > 0 ? ` code-indent-${indentLevel}` : '';

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,4 +1,4 @@
-import { mdParse } from './markdown.js?v=katex-math-20260510';
+import { mdParse } from './markdown.js?v=markdown-security-20260512';
 import { renderPressMath } from './math-render.js?v=katex-math-20260510';
 import { setSafeHtml } from './safe-html.js?v=katex-math-20260510';
 import { t } from './i18n.js?v=annotate-i18n-20260510';

--- a/assets/main.js
+++ b/assets/main.js
@@ -6,7 +6,7 @@ import {
   parseEncryptedMarkdownEnvelope,
   stripEncryptedBodyForPublicUse
 } from './js/encrypted-content.js?v=encrypted-demo-20260508';
-import { mdParse } from './js/markdown.js?v=katex-math-20260510';
+import { mdParse } from './js/markdown.js?v=markdown-security-20260512';
 import { setupAnchors, setupTOC } from './js/toc.js?v=annotate-i18n-20260510';
 import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=local-theme-overlays-20260510';
 import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=theme-layout-generation-20260510';

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.1",
-  "tag": "v3.4.1",
+  "version": "3.4.2",
+  "tag": "v3.4.2",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.0 <3.4.1"
+      ">=3.4.1 <3.4.2"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.0 first."
+    "message": "Update to v3.4.1 first."
   }
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@
   <link rel="stylesheet" id="theme-pack">
 </head>
 <body>
-  <script type="module" src="assets/main.js?v=theme-layout-generation-20260510"></script>
+  <script type="module" src="assets/main.js?v=markdown-security-20260512"></script>
 </body>
 </html>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -191,7 +191,7 @@ assert.match(
 
 assert.match(
   readFileSync(resolve(here, '../assets/js/system-updates.js'), 'utf8'),
-  /from '\.\/markdown\.js\?v=katex-math-20260510'[\s\S]*from '\.\/math-render\.js\?v=katex-math-20260510'[\s\S]*from '\.\/safe-html\.js\?v=katex-math-20260510'/,
+  /from '\.\/markdown\.js\?v=markdown-security-20260512'[\s\S]*from '\.\/math-render\.js\?v=katex-math-20260510'[\s\S]*from '\.\/safe-html\.js\?v=katex-math-20260510'/,
   'system update notes should cache-bust Markdown, math renderer, and sanitizer when math rendering changes'
 );
 

--- a/scripts/test-markdown-security.js
+++ b/scripts/test-markdown-security.js
@@ -756,6 +756,19 @@ const maliciousTocHtml = '<ul><li><a href="#heading">Heading</a><ul><li><a href=
 }
 
 {
+  const { html, target } = renderMarkdown([
+    '```js"onmouseover="alert(1)',
+    'code',
+    '```'
+  ].join('\n'));
+  assert.doesNotMatch(html, /onmouseover/u);
+  assert.doesNotMatch(html, /language-js"/u);
+  assertRawMarkdownHtmlIsSafe(html);
+  assert.equal(collectElements(target, 'code').length, 1);
+  assertNoEventHandlerAttributes(target);
+}
+
+{
   const { main, toc, effects } = createNativeRuntime();
   const result = effects.renderPostView({
     containers: { mainElement: main, tocElement: toc },

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -90,7 +90,7 @@ assert.notEqual(tocBoundGuard, -1, 'press-toc should keep a listener binding gua
 assert.ok(tocMapSet < tocBoundGuard, 'press-toc should rebuild _idToLink before skipping already-bound anchors');
 
 assert.match(main, /import '\.\/js\/components\.js';/, 'main should register custom elements before theme layout mounting');
-assert.match(main, /from '\.\/js\/markdown\.js\?v=katex-math-20260510';/, 'main should cache-bust markdown parser when sanitizer boundaries change');
+assert.match(main, /from '\.\/js\/markdown\.js\?v=markdown-security-20260512';/, 'main should cache-bust markdown parser when sanitizer boundaries change');
 assert.match(main, /from '\.\/js\/safe-html\.js\?v=katex-math-20260510';/, 'main should cache-bust sanitizer when rendered Markdown allowlist changes');
 assert.match(main, /from '\.\/js\/math-render\.js\?v=katex-math-20260510';/, 'main should cache-bust math renderer when KaTeX support changes');
 assert.match(mathRender, /querySelectorAll\('\.press-math\[data-tex\]'\)/, 'math renderer should only target parser-generated math nodes');
@@ -148,8 +148,8 @@ assert.match(theme, /NATIVE_STYLE_CACHE_KEY = 'encrypted-demo-20260508'/, 'theme
 assert.match(themeLayout, /NATIVE_STYLE_CACHE_KEY = 'encrypted-demo-20260508'/, 'theme layout should cache-bust manifest-applied native stylesheet changes');
 assert.match(read('assets/themes/native/theme.css'), /@import "\.\/base\.css\?v=encrypted-demo-20260508";/, 'native theme.css should cache-bust the imported base stylesheet');
 assert.match(themeLayout, /const cacheKey = pack === DEFAULT_PACK \? NATIVE_MODULE_CACHE_KEY : getManifestCacheKey\(pack, manifest\);[\s\S]*appendImportCacheKey\(safeEntry, cacheKey\)/, 'theme layout should apply the native module cache key at import time');
-assert.match(indexHtml, /src="assets\/main\.js\?v=theme-layout-generation-20260510"/, 'index should bump the main module URL when runtime imports change');
-assert.match(composer, /src="assets\/main\.js\?v=theme-layout-generation-20260510"/, 'composer export template should use the same main module URL as index');
+assert.match(indexHtml, /src="assets\/main\.js\?v=markdown-security-20260512"/, 'index should bump the main module URL when runtime imports change');
+assert.match(composer, /src="assets\/main\.js\?v=markdown-security-20260512"/, 'composer export template should use the same main module URL as index');
 assert.match(themeBoot, /pack !== 'native'[\s\S]*return;/, 'theme boot should not eagerly apply unvalidated external theme CSS');
 assert.doesNotMatch(themeLayout, /loadThemePack\(DEFAULT_PACK\)/, 'theme layout fallback should not persist Native over a failed external pack');
 assert.match(themeLayout, /clearFailedThemeArtifacts\(pack\)/, 'theme layout fallback should clear partial external theme DOM and styles');


### PR DESCRIPTION
## Summary
- constrain Markdown code-fence language tokens before rendering them into language-* classes
- bump runtime cache keys and Press system manifest to v3.4.2
- add regression coverage for the injected event-attribute payload

## Tests
- node --experimental-default-type=module scripts/test-markdown-security.js
- node scripts/test-frontmatter-roundtrip.js
- node scripts/test-ui-components.js
- node scripts/test-composer-identity-grid.js
- node --experimental-default-type=module scripts/test-theme-contracts.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- node --experimental-default-type=module scripts/test-system-updates.js
- node scripts/test-content-model.js
- bash scripts/test-main-guard.sh