### PR TITLE
[codex] Lazy-load public runtime features

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -45,29 +45,56 @@ let mathRenderModulePromise = null;
 let annotateModulePromise = null;
 let linkCardsModulePromise = null;
 
+function cacheDynamicImport(importer, getCached, setCached) {
+  let promise = getCached();
+  if (!promise) {
+    promise = importer().catch((err) => {
+      setCached(null);
+      throw err;
+    });
+    setCached(promise);
+  }
+  return promise;
+}
+
 function loadMarkdownModule() {
-  if (!markdownModulePromise) markdownModulePromise = import('./js/markdown.js?v=press-system-v3.4.5');
-  return markdownModulePromise;
+  return cacheDynamicImport(
+    () => import('./js/markdown.js?v=press-system-v3.4.5'),
+    () => markdownModulePromise,
+    (promise) => { markdownModulePromise = promise; }
+  );
 }
 
 function loadSyntaxHighlightModule() {
-  if (!syntaxHighlightModulePromise) syntaxHighlightModulePromise = import('./js/syntax-highlight.js?v=press-system-v3.4.5');
-  return syntaxHighlightModulePromise;
+  return cacheDynamicImport(
+    () => import('./js/syntax-highlight.js?v=press-system-v3.4.5'),
+    () => syntaxHighlightModulePromise,
+    (promise) => { syntaxHighlightModulePromise = promise; }
+  );
 }
 
 function loadMathRenderModule() {
-  if (!mathRenderModulePromise) mathRenderModulePromise = import('./js/math-render.js?v=press-system-v3.4.5');
-  return mathRenderModulePromise;
+  return cacheDynamicImport(
+    () => import('./js/math-render.js?v=press-system-v3.4.5'),
+    () => mathRenderModulePromise,
+    (promise) => { mathRenderModulePromise = promise; }
+  );
 }
 
 function loadAnnotateModule() {
-  if (!annotateModulePromise) annotateModulePromise = import('./js/annotate.js?v=press-system-v3.4.5');
-  return annotateModulePromise;
+  return cacheDynamicImport(
+    () => import('./js/annotate.js?v=press-system-v3.4.5'),
+    () => annotateModulePromise,
+    (promise) => { annotateModulePromise = promise; }
+  );
 }
 
 function loadLinkCardsModule() {
-  if (!linkCardsModulePromise) linkCardsModulePromise = import('./js/link-cards.js?v=press-system-v3.4.5');
-  return linkCardsModulePromise;
+  return cacheDynamicImport(
+    () => import('./js/link-cards.js?v=press-system-v3.4.5'),
+    () => linkCardsModulePromise,
+    (promise) => { linkCardsModulePromise = promise; }
+  );
 }
 
 function queryScopeHas(scope, selector) {

--- a/assets/main.js
+++ b/assets/main.js
@@ -6,7 +6,6 @@ import {
   parseEncryptedMarkdownEnvelope,
   stripEncryptedBodyForPublicUse
 } from './js/encrypted-content.js?v=press-system-v3.4.5';
-import { mdParse } from './js/markdown.js?v=press-system-v3.4.5';
 import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.5';
 import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.5';
 import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.5';
@@ -27,22 +26,114 @@ import {
 } from './js/i18n.js?v=press-system-v3.4.5';
 import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.5';
 import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.5';
-import { initSyntaxHighlighting } from './js/syntax-highlight.js?v=press-system-v3.4.5';
-import { renderPressMath } from './js/math-render.js?v=press-system-v3.4.5';
 import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
 import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.5';
 import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.5';
 import { getArticleTitleFromMain } from './js/dom-utils.js';
 import { applyLangHints } from './js/typography.js';
-import { mountAnnotateComments, resolveAnnotateArticleContext } from './js/annotate.js?v=press-system-v3.4.5';
 
 import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos, hydrateCardCovers } from './js/post-render.js';
-import { hydrateInternalLinkCards } from './js/link-cards.js?v=press-system-v3.4.5';
 
 // Lightweight content fetch helper; cache mode is normalized by cache-control.js.
 const getFile = (filename) => fetch(String(filename || ''), { cache: 'no-store' })
   .then(resp => { if (!resp.ok) throw new Error(`HTTP ${resp.status}`); return resp.text(); });
+
+let markdownModulePromise = null;
+let syntaxHighlightModulePromise = null;
+let mathRenderModulePromise = null;
+let annotateModulePromise = null;
+let linkCardsModulePromise = null;
+
+function loadMarkdownModule() {
+  if (!markdownModulePromise) markdownModulePromise = import('./js/markdown.js?v=press-system-v3.4.5');
+  return markdownModulePromise;
+}
+
+function loadSyntaxHighlightModule() {
+  if (!syntaxHighlightModulePromise) syntaxHighlightModulePromise = import('./js/syntax-highlight.js?v=press-system-v3.4.5');
+  return syntaxHighlightModulePromise;
+}
+
+function loadMathRenderModule() {
+  if (!mathRenderModulePromise) mathRenderModulePromise = import('./js/math-render.js?v=press-system-v3.4.5');
+  return mathRenderModulePromise;
+}
+
+function loadAnnotateModule() {
+  if (!annotateModulePromise) annotateModulePromise = import('./js/annotate.js?v=press-system-v3.4.5');
+  return annotateModulePromise;
+}
+
+function loadLinkCardsModule() {
+  if (!linkCardsModulePromise) linkCardsModulePromise = import('./js/link-cards.js?v=press-system-v3.4.5');
+  return linkCardsModulePromise;
+}
+
+function queryScopeHas(scope, selector) {
+  try {
+    return !!(scope && typeof scope.querySelector === 'function' && scope.querySelector(selector));
+  } catch (_) {
+    return false;
+  }
+}
+
+function hasInternalLinkCardCandidates(scope) {
+  try {
+    if (!scope || typeof scope.querySelectorAll !== 'function') return false;
+    const anchors = Array.from(scope.querySelectorAll('a[href]'));
+    return anchors.some((anchor) => {
+      const href = String(anchor.getAttribute('href') || '').trim();
+      if (!href || href.startsWith('#') || /^(mailto:|javascript:)/i.test(href)) return false;
+      const startsWithQuery = href.startsWith('?');
+      let url;
+      try {
+        url = new URL(href, window.location.href);
+      } catch (_) {
+        return false;
+      }
+      if (!startsWithQuery && url.origin !== window.location.origin) return false;
+      if (!url.searchParams.get('id')) return false;
+      const titleAttr = String(anchor.getAttribute('title') || '').trim();
+      if (/\b(card|preview)\b/i.test(titleAttr) || anchor.hasAttribute('data-card') || anchor.classList.contains('card')) return true;
+      const parent = anchor.parentElement;
+      if (!parent || !['P', 'LI', 'DIV'].includes(parent.tagName)) return false;
+      const nodes = Array.from(parent.childNodes || []);
+      return nodes.every(node => node === anchor || (node.nodeType === Node.TEXT_NODE && !String(node.textContent || '').trim()));
+    });
+  } catch (_) {
+    return false;
+  }
+}
+
+async function initSyntaxHighlighting(root = document) {
+  try {
+    const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    if (!queryScopeHas(scope, 'pre code')) return;
+    const mod = await loadSyntaxHighlightModule();
+    if (mod && typeof mod.initSyntaxHighlighting === 'function') mod.initSyntaxHighlighting(scope);
+  } catch (_) {}
+}
+
+async function renderPressMath(root = document) {
+  try {
+    const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    if (!queryScopeHas(scope, '.press-math[data-tex]')) return;
+    const mod = await loadMathRenderModule();
+    if (mod && typeof mod.renderPressMath === 'function') mod.renderPressMath(scope);
+  } catch (_) {}
+}
+
+async function hydrateInternalLinkCards(container, options = {}) {
+  try {
+    const scope = container && typeof container.querySelectorAll === 'function' ? container : document;
+    if (!hasInternalLinkCardCandidates(scope)) return;
+    const mod = await loadLinkCardsModule();
+    if (mod && typeof mod.hydrateInternalLinkCards === 'function') {
+      return mod.hydrateInternalLinkCards(container, options);
+    }
+  } catch (_) {}
+}
 
 const RAW_INDEX_METADATA_KEYS = new Set([
   'tag',
@@ -533,6 +624,19 @@ function postsEnabled() {
     if (siteConfig && typeof siteConfig.disableAllPosts === 'boolean') return !siteConfig.disableAllPosts;
   } catch (_) {}
   return true; // default: enabled
+}
+
+function isAnnotateConfigured(cfg = siteConfig) {
+  try {
+    const annotate = cfg && typeof cfg.annotate === 'object' && !Array.isArray(cfg.annotate) ? cfg.annotate : null;
+    if (!annotate) return false;
+    const enabled = annotate.enabled === true || ['true', '1', 'yes', 'y', 'on', 'enabled'].includes(String(annotate.enabled ?? '').trim().toLowerCase());
+    if (!enabled) return false;
+    const repo = cfg && typeof cfg.repo === 'object' && !Array.isArray(cfg.repo) ? cfg.repo : null;
+    return !!(String(annotate.connectBaseUrl || '').trim() && repo && String(repo.owner || '').trim() && String(repo.name || '').trim());
+  } catch (_) {
+    return false;
+  }
 }
 
 function resolveLandingSlug() {
@@ -1030,7 +1134,7 @@ function displayPost(postname, options = {}) {
     ? Promise.resolve(String(options.markdown || ''))
     : getFile(`${getContentRoot()}/${postname}`);
 
-  return markdownSource.then(markdown => {
+  return markdownSource.then(async markdown => {
     // Ignore stale responses if a newer navigation started
     if (reqId !== __activePostRequestId) return;
     const encryptedEnvelope = parseEncryptedMarkdownEnvelope(markdown);
@@ -1091,6 +1195,8 @@ function displayPost(postname, options = {}) {
 
     const dir = (postname.lastIndexOf('/') >= 0) ? postname.slice(0, postname.lastIndexOf('/') + 1) : '';
     const baseDir = `${getContentRoot()}/${dir}`;
+    const { mdParse } = await loadMarkdownModule();
+    if (reqId !== __activePostRequestId) return;
     const output = mdParse(markdownForRender, baseDir);
     const fallbackTitle = postsByLocationTitle[postname] || postname;
     const frontMatterMetadata = (() => {
@@ -1216,6 +1322,9 @@ function displayPost(postname, options = {}) {
     }
 
     try {
+      if (!isAnnotateConfigured(siteConfig)) throw new Error('annotate disabled');
+      const { mountAnnotateComments, resolveAnnotateArticleContext } = await loadAnnotateModule();
+      if (reqId !== __activePostRequestId) return;
       const mainEl = containers.mainElement || getViewContainer('post', 'main');
       const annotateContext = resolveAnnotateArticleContext({
         rawIndex: rawIndexCache,
@@ -1617,12 +1726,13 @@ function displayStaticTab(slug) {
   notifyThemeViewChange('tab', { showSearch: false, showTags: false });
   renderTabs(slug);
   getFile(`${getContentRoot()}/${tab.location}`)
-    .then(md => {
+    .then(async md => {
       // 移除加载状态类
       updateLayoutLoadingState('tab', false, containers);
 
       const dir = (tab.location.lastIndexOf('/') >= 0) ? tab.location.slice(0, tab.location.lastIndexOf('/') + 1) : '';
       const baseDir = `${getContentRoot()}/${dir}`;
+      const { mdParse } = await loadMarkdownModule();
       const output = mdParse(md, baseDir);
       const content = createContentModel({
         rawMarkdown: md,

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -20,7 +20,12 @@ let activeRegions = null;
 let nativeLinkCardsModulePromise = null;
 
 function loadNativeLinkCardsModule() {
-  if (!nativeLinkCardsModulePromise) nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.5');
+  if (!nativeLinkCardsModulePromise) {
+    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.5').catch((err) => {
+      nativeLinkCardsModulePromise = null;
+      throw err;
+    });
+  }
   return nativeLinkCardsModulePromise;
 }
 

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -7,7 +7,6 @@ import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js
 import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.5';
 import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.5';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
-import { hydrateInternalLinkCards } from '../../../js/link-cards.js?v=press-system-v3.4.5';
 import { applyLangHints } from '../../../js/typography.js';
 import { renderPressPostCardHtml } from '../../../js/post-card-html.js';
 import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.5';
@@ -18,6 +17,21 @@ const defaultDocument = typeof document !== 'undefined' ? document : undefined;
 
 let themeI18n = null;
 let activeRegions = null;
+let nativeLinkCardsModulePromise = null;
+
+function loadNativeLinkCardsModule() {
+  if (!nativeLinkCardsModulePromise) nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.5');
+  return nativeLinkCardsModulePromise;
+}
+
+async function hydrateInternalLinkCardsFallback(container, options = {}) {
+  try {
+    const mod = await loadNativeLinkCardsModule();
+    if (mod && typeof mod.hydrateInternalLinkCards === 'function') {
+      return mod.hydrateInternalLinkCards(container, options);
+    }
+  } catch (_) {}
+}
 
 function setThemeI18n(context = {}) {
   themeI18n = context && context.i18n && typeof context.i18n === 'object' ? context.i18n : null;
@@ -1215,7 +1229,7 @@ function renderPostViewNative(params = {}, documentRef = defaultDocument, window
     warnLargeImagesInNative(container, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
 
-  const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCards(selector, opts));
+  const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCardsFallback(selector, opts));
   const fetchMarkdown = getUtility(params, 'fetchMarkdown', () => Promise.resolve(''));
   const makeHref = getUtility(params, 'makeLangHref', (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`));
   try {
@@ -1324,7 +1338,7 @@ function renderStaticTabViewNative(params = {}, documentRef = defaultDocument, w
     warnLargeImagesInNative(container, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
 
-  const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCards(selector, opts));
+  const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCardsFallback(selector, opts));
   const fetchMarkdown = getUtility(params, 'fetchMarkdown', () => Promise.resolve(''));
   const makeHref = getUtility(params, 'makeLangHref', (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`));
   try {

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -122,6 +122,7 @@ assert.doesNotMatch(main, /from '\.\/js\/annotate\.js\?v=[\w.-]+';/, 'main shoul
 assert.match(main, /import\('\.\/js\/annotate\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust annotate runtime helpers when comments are mounted');
 assert.match(main, /function hydrateInternalLinkCards\(container, options = \{\}\)[\s\S]*loadLinkCardsModule/, 'main should keep a stable lazy link-card utility facade for themes');
 assert.match(main, /function initSyntaxHighlighting\(root = document\)[\s\S]*queryScopeHas\(scope, 'pre code'\)[\s\S]*loadSyntaxHighlightModule/, 'main should keep a stable lazy syntax-highlighting utility facade for themes');
+assert.match(main, /function cacheDynamicImport\(importer, getCached, setCached\)[\s\S]*importer\(\)\.catch\(\(err\) => \{[\s\S]*setCached\(null\);[\s\S]*throw err;/, 'main lazy module loaders should retry after a transient dynamic import failure');
 assert.match(main, /function getRawIndexVariantLocation\(value\)[\s\S]*value\.location \|\| value\.path[\s\S]*function collectRawIndexVariants\(entry, options = \{\}\)/, 'main should read object variant locations from raw index arrays');
 assert.match(main, /const pickPreferred = \(entry\) => \{[\s\S]*const variants = collectRawIndexVariants\(entry\);[\s\S]*const cand = findBy\(\[curNorm\]\) \|\| findBy\(\[defNorm\]\)/, 'main should preserve homepage order for object version arrays in raw index data');
 assert.match(composer, /from '\.\/i18n\.js\?v=[\w.-]+';/, 'composer should share the repository deletion docs i18n cache key');
@@ -223,6 +224,7 @@ assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/errors\.js\?v=[\w.
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/post-nav\.js\?v=[\w.-]+'/, 'native interactions should cache-bust post navigation helper imports');
 assert.doesNotMatch(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=[\w.-]+'/, 'native interactions should not statically load internal link-card hydration');
 assert.match(nativeInteractions, /import\('\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=[\w.-]+'\)/, 'native interactions should lazy-load and cache-bust internal link-card hydration');
+assert.match(nativeInteractions, /nativeLinkCardsModulePromise = null;[\s\S]*throw err;/, 'native lazy link-card fallback should retry after a transient dynamic import failure');
 assert.match(nativeInteractions, /const refreshMasonry = \(el\) => \{[\s\S]*updateMasonryItem/, 'native cards should keep masonry refresh centralized');
 assert.match(nativeInteractions, /if \(meta && meta\.protected\) \{[\s\S]*ui\.protectedExcerpt[\s\S]*refreshMasonry\(el\);[\s\S]*return;/, 'native cards should not fetch protected article bodies for previews and should refresh masonry spans');
 assert.match(nativeInteractions, /const inlineMinutes = readMinutesFromMeta\(meta\);[\s\S]*if \(inlineMinutes > 0\) \{[\s\S]*updateMetaLine\(el, meta, inlineMinutes, false\);[\s\S]*refreshMasonry\(el\);[\s\S]*\}\s*if \(typeof context\.getFile/, 'native cards should use index readTime immediately but still fetch Markdown to verify encryption state');

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -90,12 +90,16 @@ assert.notEqual(tocBoundGuard, -1, 'press-toc should keep a listener binding gua
 assert.ok(tocMapSet < tocBoundGuard, 'press-toc should rebuild _idToLink before skipping already-bound anchors');
 
 assert.match(main, /import '\.\/js\/components\.js';/, 'main should register custom elements before theme layout mounting');
-assert.match(main, /from '\.\/js\/markdown\.js\?v=[\w.-]+';/, 'main should cache-bust markdown parser when sanitizer boundaries change');
+assert.doesNotMatch(main, /import \{ mdParse \} from '\.\/js\/markdown\.js\?v=[\w.-]+';/, 'main should not statically load the markdown parser on the public homepage');
+assert.match(main, /import\('\.\/js\/markdown\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust markdown parser when rendering Markdown routes');
 assert.match(main, /from '\.\/js\/safe-html\.js\?v=[\w.-]+';/, 'main should cache-bust sanitizer when rendered Markdown allowlist changes');
-assert.match(main, /from '\.\/js\/math-render\.js\?v=[\w.-]+';/, 'main should cache-bust math renderer when KaTeX support changes');
+assert.doesNotMatch(main, /from '\.\/js\/math-render\.js\?v=[\w.-]+';/, 'main should not statically load the math renderer on the public homepage');
+assert.match(main, /import\('\.\/js\/math-render\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust math renderer when KaTeX support changes');
 assert.match(mathRender, /querySelectorAll\('\.press-math\[data-tex\]'\)/, 'math renderer should only target parser-generated math nodes');
 assert.doesNotMatch(mathRender, /auto-render/i, 'math renderer must not use KaTeX auto-render');
 assert.match(mathRender, /vendor\/katex\/[\s\S]*katex\.min\.css[\s\S]*katex\.min\.js/, 'math renderer should load vendored KaTeX core assets');
+assert.doesNotMatch(main, /from '\.\/js\/syntax-highlight\.js\?v=[\w.-]+';/, 'main should not statically load syntax highlighting on the public homepage');
+assert.match(main, /import\('\.\/js\/syntax-highlight\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust syntax highlighting when code blocks are present');
 assert.match(syntaxHighlight, /vendor\/highlightjs\/highlight\.min\.js/, 'syntax highlighter should load the vendored Highlight.js common bundle');
 assert.match(highlightJsBundle, /Highlight\.js v11\.11\.1/, 'vendored Highlight.js bundle should stay pinned to the reviewed common browser build');
 assert.match(editorBlocks, /from '\.\/math-render\.js\?v=[\w.-]+';/, 'block editor should reuse the vendored KaTeX math renderer');
@@ -107,13 +111,17 @@ assert.match(main, /from '\.\/js\/theme-layout\.js\?v=[\w.-]+';/, 'main should c
 assert.match(main, /from '\.\/js\/theme\.js\?v=[\w.-]+';/, 'main should cache-bust theme helpers when local theme overlays change');
 assert.match(theme, /fetchThemePackList\('assets\/themes\/packs\.local\.json', true\)/, 'main-site theme controls should allow ignored local theme-pack overlays for development');
 assert.match(main, /from '\.\/js\/i18n\.js\?v=[\w.-]+';/, 'main should use the same versioned i18n module instance as shared UI modules');
-assert.match(main, /from '\.\/js\/link-cards\.js\?v=[\w.-]+';/, 'main should cache-bust internal link cards when protected preview handling changes');
+assert.doesNotMatch(main, /from '\.\/js\/link-cards\.js\?v=[\w.-]+';/, 'main should not statically load internal link-card hydration on the public homepage');
+assert.match(main, /import\('\.\/js\/link-cards\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust internal link cards when protected preview handling changes');
 assert.match(main, /from '\.\/js\/seo\.js\?v=[\w.-]+';/, 'main should cache-bust SEO helpers after their i18n dependency changes');
 assert.match(main, /from '\.\/js\/toc\.js\?v=[\w.-]+';/, 'main should cache-bust TOC helpers after their i18n dependency changes');
 assert.match(main, /from '\.\/js\/tags\.js\?v=[\w.-]+';/, 'main should cache-bust tag helpers after their i18n dependency changes');
 assert.match(main, /from '\.\/js\/errors\.js\?v=[\w.-]+';/, 'main should cache-bust error helpers after their i18n dependency changes');
 assert.match(main, /from '\.\/js\/post-nav\.js\?v=[\w.-]+';/, 'main should cache-bust post navigation helpers after their i18n dependency changes');
-assert.match(main, /from '\.\/js\/annotate\.js\?v=[\w.-]+';/, 'main should cache-bust annotate runtime helpers when comments are mounted');
+assert.doesNotMatch(main, /from '\.\/js\/annotate\.js\?v=[\w.-]+';/, 'main should not statically load annotate runtime helpers on the public homepage');
+assert.match(main, /import\('\.\/js\/annotate\.js\?v=[\w.-]+'\)/, 'main should lazy-load and cache-bust annotate runtime helpers when comments are mounted');
+assert.match(main, /function hydrateInternalLinkCards\(container, options = \{\}\)[\s\S]*loadLinkCardsModule/, 'main should keep a stable lazy link-card utility facade for themes');
+assert.match(main, /function initSyntaxHighlighting\(root = document\)[\s\S]*queryScopeHas\(scope, 'pre code'\)[\s\S]*loadSyntaxHighlightModule/, 'main should keep a stable lazy syntax-highlighting utility facade for themes');
 assert.match(main, /function getRawIndexVariantLocation\(value\)[\s\S]*value\.location \|\| value\.path[\s\S]*function collectRawIndexVariants\(entry, options = \{\}\)/, 'main should read object variant locations from raw index arrays');
 assert.match(main, /const pickPreferred = \(entry\) => \{[\s\S]*const variants = collectRawIndexVariants\(entry\);[\s\S]*const cand = findBy\(\[curNorm\]\) \|\| findBy\(\[defNorm\]\)/, 'main should preserve homepage order for object version arrays in raw index data');
 assert.match(composer, /from '\.\/i18n\.js\?v=[\w.-]+';/, 'composer should share the repository deletion docs i18n cache key');
@@ -213,7 +221,8 @@ assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/tags\.js\?v=[\w.-]
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/templates\.js\?v=[\w.-]+'/, 'native interactions should cache-bust template helper imports');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/errors\.js\?v=[\w.-]+'/, 'native interactions should cache-bust error helper imports');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/post-nav\.js\?v=[\w.-]+'/, 'native interactions should cache-bust post navigation helper imports');
-assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=[\w.-]+'/, 'native interactions should cache-bust internal link-card hydration');
+assert.doesNotMatch(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=[\w.-]+'/, 'native interactions should not statically load internal link-card hydration');
+assert.match(nativeInteractions, /import\('\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=[\w.-]+'\)/, 'native interactions should lazy-load and cache-bust internal link-card hydration');
 assert.match(nativeInteractions, /const refreshMasonry = \(el\) => \{[\s\S]*updateMasonryItem/, 'native cards should keep masonry refresh centralized');
 assert.match(nativeInteractions, /if \(meta && meta\.protected\) \{[\s\S]*ui\.protectedExcerpt[\s\S]*refreshMasonry\(el\);[\s\S]*return;/, 'native cards should not fetch protected article bodies for previews and should refresh masonry spans');
 assert.match(nativeInteractions, /const inlineMinutes = readMinutesFromMeta\(meta\);[\s\S]*if \(inlineMinutes > 0\) \{[\s\S]*updateMetaLine\(el, meta, inlineMinutes, false\);[\s\S]*refreshMasonry\(el\);[\s\S]*\}\s*if \(typeof context\.getFile/, 'native cards should use index readTime immediately but still fetch Markdown to verify encryption state');


### PR DESCRIPTION
## Summary

- lazy-load public runtime Markdown, syntax highlighting, math rendering, annotate, and internal link-card modules
- keep stable theme utility facades so official external themes can continue calling the same helpers
- make the native theme link-card fallback lazy-load its runtime helper instead of statically pulling it onto the homepage

## Validation

- `node --check assets/main.js && node --check assets/themes/native/modules/interactions.js && node --check scripts/test-ui-components.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-content-model.js`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `bash scripts/test-system-release-package.sh`
- `node scripts/test-composer-identity-grid.js`
- local preview smoke for homepage, about tab, and docs article route

## Impact

This changes the Press system runtime package surface. Public homepages should no longer eagerly load the Markdown parser, Highlight.js bundle, math renderer, annotate runtime, or internal link-card hydrator before a route or DOM feature needs them.
