### PR TITLE
Extract Connect-first publish transports

### DIFF
--- a/assets/i18n/cht-hk.js
+++ b/assets/i18n/cht-hk.js
@@ -1,4 +1,4 @@
-import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.16';
+import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.17';
 
 export const languageMeta = { label: '繁體中文（香港）' };
 

--- a/assets/i18n/languages.json
+++ b/assets/i18n/languages.json
@@ -1,7 +1,7 @@
 [
-  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.16" },
-  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.16" },
-  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.16" },
-  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.16" },
-  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.16" }
+  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.17" },
+  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.17" },
+  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.17" },
+  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.17" },
+  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.17" }
 ]

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8,24 +8,35 @@ import {
   resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.16';
-import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.16';
-import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.16';
-import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.16';
-import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.16';
+import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.17';
+import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.17';
+import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.17';
+import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.17';
+import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.17';
 import { computeReadTime, extractExcerpt, parseFrontMatter } from './content.js';
 import {
   decryptMarkdownDocument,
   encryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope
-} from './encrypted-content.js?v=press-system-v3.4.16';
+} from './encrypted-content.js?v=press-system-v3.4.17';
 import {
   collectLocalMarkdownAssetReferences,
   collectManagedMarkdownReferences,
   listLocalMarkdownAssetReferences,
   planManagedContentDeletions,
   resolveLocalMarkdownAssetReference
-} from './repository-deletions.js?v=press-system-v3.4.16';
+} from './repository-deletions.js?v=press-system-v3.4.17';
+import {
+  CONNECT_PUBLISH_PRESETS,
+  createPublishSettingsStore,
+  getDefaultConnectPublishBaseUrl,
+  normalizeConnectPublishBaseUrl
+} from './publish/settings-store.js?v=press-system-v3.4.17';
+import {
+  createConnectPublishCommit,
+  ensureConnectPublishGrant as authorizeConnectPublishGrant
+} from './publish/transports/connect-transport.js?v=press-system-v3.4.17';
+import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.17';
 
 // Utility helpers
 const $ = (s, r = document) => r.querySelector(s);
@@ -147,6 +158,11 @@ function scopedEditorStorageKey(key) {
   return `${key}:${EDITOR_STORAGE_SCOPE}`;
 }
 
+const publishSettingsStore = createPublishSettingsStore({
+  windowRef: window,
+  scopeKey: scopedEditorStorageKey
+});
+
 // Track additional markdown editor tabs spawned from Composer
 const dynamicEditorTabs = new Map();            // modeId -> { path, button, content, loaded, baseDir }
 const dynamicEditorTabsByLookupKey = new Map(); // lookupKey -> modeId
@@ -244,15 +260,6 @@ const MARKDOWN_SAVE_TOOLTIP_KEYS = {
   empty: 'editor.composer.markdown.save.tooltips.empty',
   clean: 'editor.composer.markdown.save.tooltips.clean'
 };
-const GITHUB_PAT_STORAGE_KEY = 'press_fg_pat_cache';
-const CONNECT_PUBLISH_GRANT_STORAGE_KEY = 'press_connect_publish_grant_cache';
-const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';
-const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';
-const CONNECT_PUBLISH_MESSAGE_TYPE = 'press-connect-publish-authorized';
-const CONNECT_PUBLISH_PRESETS = [
-  { value: 'https://connect-8mr.pages.dev', label: 'Ekily Connect' },
-  { value: 'http://127.0.0.1:8788', label: 'Local Connect' }
-];
 const ANNOTATE_DISCUSSION_CATEGORY_PRESETS = [
   { value: 'General', label: 'General' }
 ];
@@ -262,9 +269,6 @@ let markdownDiscardButton = null;
 let markdownSaveButton = null;
 let markdownProtectionButton = null;
 let gitHubCommitInFlight = false;
-let cachedFineGrainedTokenMemory = '';
-let cachedConnectPublishGrantMemory = null;
-let cachedConnectPublishSettingsMemory = null;
 
 let activeComposerState = null;
 let remoteBaseline = { index: null, tabs: null, site: null };
@@ -1772,39 +1776,16 @@ function handlePopupBlocked(href, options = {}) {
   });
 }
 
-function sleep(ms) {
-  const timeout = Math.max(0, Number(ms) || 0);
-  return new Promise((resolve) => { setTimeout(resolve, timeout); });
-}
-
 function getCachedFineGrainedToken() {
-  try {
-    const value = sessionStorage.getItem(scopedEditorStorageKey(GITHUB_PAT_STORAGE_KEY));
-    if (typeof value === 'string' && value) {
-      cachedFineGrainedTokenMemory = value;
-      return value;
-    }
-  } catch (_) {
-    /* ignore unavailable storage */
-  }
-  return cachedFineGrainedTokenMemory || '';
+  return publishSettingsStore.getCachedFineGrainedToken();
 }
 
 function setCachedFineGrainedToken(token) {
-  const trimmed = String(token || '').trim();
-  cachedFineGrainedTokenMemory = trimmed;
-  try {
-    if (trimmed) sessionStorage.setItem(scopedEditorStorageKey(GITHUB_PAT_STORAGE_KEY), trimmed);
-    else sessionStorage.removeItem(scopedEditorStorageKey(GITHUB_PAT_STORAGE_KEY));
-  } catch (_) {
-    /* ignore storage errors */
-  }
+  publishSettingsStore.setCachedFineGrainedToken(token);
 }
 
 function clearCachedFineGrainedToken() {
-  cachedFineGrainedTokenMemory = '';
-  try { sessionStorage.removeItem(scopedEditorStorageKey(GITHUB_PAT_STORAGE_KEY)); }
-  catch (_) { /* ignore */ }
+  publishSettingsStore.clearCachedFineGrainedToken();
 }
 
 function getFineGrainedTokenValue() {
@@ -1813,66 +1794,21 @@ function getFineGrainedTokenValue() {
   return value || getCachedFineGrainedToken();
 }
 
-function getDefaultConnectPublishBaseUrl() {
-  return CONNECT_PUBLISH_PRESETS[0].value;
-}
-
-function normalizeConnectPublishBaseUrl(value) {
-  const rawBaseUrl = safeString(value || '').trim();
-  if (!rawBaseUrl) return null;
-  try {
-    const url = new URL(rawBaseUrl);
-    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLocalhostHost(url.hostname))) return null;
-    return url.origin;
-  } catch (_) {
-    return null;
-  }
-}
-
 function getStoredConnectPublishSettings() {
-  if (cachedConnectPublishSettingsMemory && typeof cachedConnectPublishSettingsMemory === 'object') {
-    return { ...cachedConnectPublishSettingsMemory };
-  }
-  const settings = {
-    enabled: true,
-    baseUrl: getDefaultConnectPublishBaseUrl()
-  };
-  try {
-    const enabledRaw = window.localStorage.getItem(scopedEditorStorageKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
-    if (enabledRaw === '0') settings.enabled = false;
-    else if (enabledRaw === '1') settings.enabled = true;
-    const baseUrlRaw = window.localStorage.getItem(scopedEditorStorageKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
-    if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
-  } catch (_) {
-    /* ignore unavailable storage */
-  }
-  cachedConnectPublishSettingsMemory = { ...settings };
-  return settings;
+  return publishSettingsStore.getStoredConnectPublishSettings();
 }
 
 function setStoredConnectPublishSettings(next) {
-  const previous = getStoredConnectPublishSettings();
-  const settings = {
-    enabled: typeof next.enabled === 'boolean' ? next.enabled : previous.enabled,
-    baseUrl: safeString(next.baseUrl != null ? next.baseUrl : previous.baseUrl).trim() || getDefaultConnectPublishBaseUrl()
-  };
-  const previousBase = normalizeConnectPublishBaseUrl(previous.baseUrl);
-  const nextBase = normalizeConnectPublishBaseUrl(settings.baseUrl);
-  cachedConnectPublishSettingsMemory = { ...settings };
-  try {
-    window.localStorage.setItem(scopedEditorStorageKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY), settings.enabled ? '1' : '0');
-    window.localStorage.setItem(scopedEditorStorageKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
-  } catch (_) {
-    /* ignore storage errors */
-  }
-  if (previousBase !== nextBase) clearCachedConnectPublishGrant();
-  return settings;
+  return publishSettingsStore.setStoredConnectPublishSettings(next);
 }
 
 function getConnectPublishSettings() {
   const settings = getStoredConnectPublishSettings();
   const enabledInput = document.getElementById('syncConnectPublishEnabledInput');
-  if (enabledInput) settings.enabled = !!enabledInput.checked;
+  if (enabledInput) {
+    settings.enabled = !!enabledInput.checked;
+    settings.mode = settings.enabled ? 'connect' : 'pat';
+  }
   const baseInput = document.getElementById('syncConnectBaseUrlInput');
   if (baseInput && typeof baseInput.value === 'string') settings.baseUrl = baseInput.value.trim();
   return settings;
@@ -1881,7 +1817,8 @@ function getConnectPublishSettings() {
 function setConnectPublishEnabled(enabled) {
   return setStoredConnectPublishSettings({
     ...getStoredConnectPublishSettings(),
-    enabled: !!enabled
+    enabled: !!enabled,
+    mode: enabled ? 'connect' : 'pat'
   });
 }
 
@@ -1892,80 +1829,29 @@ function setConnectPublishBaseUrl(baseUrl) {
   });
 }
 
-function getConnectPublishConfig() {
-  const settings = getConnectPublishSettings();
-  if (!settings.enabled) return null;
-  const baseUrl = normalizeConnectPublishBaseUrl(settings.baseUrl);
-  return baseUrl ? { baseUrl } : null;
-}
-
 function getCachedConnectPublishGrant() {
-  if (cachedConnectPublishGrantMemory && isUsableConnectPublishGrant(cachedConnectPublishGrantMemory)) {
-    return cachedConnectPublishGrantMemory;
-  }
-  try {
-    const raw = sessionStorage.getItem(scopedEditorStorageKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (isUsableConnectPublishGrant(parsed)) {
-      cachedConnectPublishGrantMemory = parsed;
-      return parsed;
-    }
-  } catch (_) {
-    /* ignore unavailable storage */
-  }
-  return null;
+  return publishSettingsStore.getCachedConnectPublishGrant();
 }
 
 function setCachedConnectPublishGrant(grant) {
-  cachedConnectPublishGrantMemory = grant && typeof grant === 'object' ? { ...grant } : null;
-  try {
-    if (cachedConnectPublishGrantMemory) {
-      sessionStorage.setItem(scopedEditorStorageKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY), JSON.stringify(cachedConnectPublishGrantMemory));
-    } else {
-      sessionStorage.removeItem(scopedEditorStorageKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
-    }
-  } catch (_) {
-    /* ignore storage errors */
-  }
+  publishSettingsStore.setCachedConnectPublishGrant(grant);
 }
 
 function clearCachedConnectPublishGrant() {
-  cachedConnectPublishGrantMemory = null;
-  try { sessionStorage.removeItem(scopedEditorStorageKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY)); }
-  catch (_) { /* ignore */ }
+  publishSettingsStore.clearCachedConnectPublishGrant();
 }
 
-function isUsableConnectPublishGrant(grant) {
-  if (!grant || typeof grant !== 'object' || !grant.token) return false;
-  const expiresAt = Number(grant.expiresAt || 0);
-  return Number.isFinite(expiresAt) && expiresAt > Math.floor(Date.now() / 1000) + 30;
+function getMatchingConnectPublishGrant(connect, repo = getActiveSiteRepoConfig()) {
+  const cached = getCachedConnectPublishGrant();
+  if (!cached || !connect || !connect.baseUrl || !repo || !repo.owner || !repo.name) return null;
+  const branch = repo.branch || 'main';
+  if (cached.baseUrl !== connect.baseUrl) return null;
+  if (cached.owner !== repo.owner || cached.name !== repo.name || cached.branch !== branch) return null;
+  return cached;
 }
 
 function resolvePublishTransport() {
-  const settings = getConnectPublishSettings();
-  if (settings.enabled) {
-    const baseUrl = normalizeConnectPublishBaseUrl(settings.baseUrl);
-    if (!baseUrl) {
-      return {
-        type: 'connect',
-        invalid: true,
-        rawBaseUrl: settings.baseUrl
-      };
-    }
-    return {
-      type: 'connect',
-      connect: { baseUrl }
-    };
-  }
-  return {
-    type: 'pat'
-  };
-}
-
-function isLocalhostHost(hostname) {
-  const value = String(hostname || '').toLowerCase();
-  return value === 'localhost' || value === '127.0.0.1' || value === '::1' || value === '[::1]';
+  return publishSettingsStore.resolvePublishTransport(getConnectPublishSettings());
 }
 
 function renderFineGrainedTokenSettings(host) {
@@ -2129,7 +2015,7 @@ function renderPublishTransportSettings(host) {
     } else if (!baseUrl) {
       state.textContent = t('editor.composer.github.modal.connectInvalidUrl');
     } else {
-      const cached = getCachedConnectPublishGrant();
+      const cached = getMatchingConnectPublishGrant({ baseUrl });
       state.textContent = cached
         ? t('editor.composer.github.modal.connectConnected')
         : t('editor.composer.github.modal.connectHelp', { baseUrl });
@@ -5877,11 +5763,11 @@ function buildDefaultIndexHtml(metaBlock, lang) {
   html += '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n\n';
   html += metaSection;
   html += '  <!-- Note: Structured data is dynamically generated by the SEO system -->\n\n';
-  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.16"></script>\n';
+  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.17"></script>\n';
   html += '  <link rel="stylesheet" id="theme-pack">\n';
   html += '</head>\n\n';
   html += '<body>\n';
-  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.16"></script>\n';
+  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.17"></script>\n';
   html += '</body>\n\n';
   html += '</html>\n';
   return html;
@@ -6300,46 +6186,6 @@ async function gatherLocalChangesForCommit(options = {}) {
   return { files };
 }
 
-async function githubGraphqlRequest(token, query, variables = {}) {
-  const trimmedToken = String(token || '').trim();
-  if (!trimmedToken) throw new Error('GitHub token is required.');
-  const headers = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${trimmedToken}`,
-    'Accept': 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28'
-  };
-  const body = JSON.stringify({ query, variables });
-  let response;
-  try {
-    response = await fetch('https://api.github.com/graphql', { method: 'POST', headers, body });
-  } catch (err) {
-    const error = new Error('Network error while reaching GitHub.');
-    error.cause = err;
-    throw error;
-  }
-  let payload = null;
-  try {
-    payload = await response.json();
-  } catch (_) {
-    payload = null;
-  }
-  if (!response.ok) {
-    const error = new Error((payload && payload.message) || `GitHub API error (${response.status})`);
-    error.status = response.status;
-    error.response = payload;
-    throw error;
-  }
-  if (payload && Array.isArray(payload.errors) && payload.errors.length) {
-    const first = payload.errors[0];
-    const error = new Error((first && first.message) || 'GitHub GraphQL error.');
-    error.status = response.status;
-    error.response = payload;
-    throw error;
-  }
-  return payload ? payload.data : null;
-}
-
 function describeSummaryEntry(entry) {
   if (!entry) return '';
   const base = entry.label || entry.path || entry.kind || '';
@@ -6599,7 +6445,7 @@ function appendPublishTransportStatus(host) {
     if (transport.invalid) {
       note.textContent = t('editor.composer.github.modal.connectInvalidUrl');
     } else {
-      const cached = getCachedConnectPublishGrant();
+      const cached = getMatchingConnectPublishGrant(transport.connect);
       note.textContent = cached
         ? t('editor.composer.github.modal.connectConnected')
         : t('editor.composer.github.modal.connectReady');
@@ -6764,180 +6610,12 @@ function scheduleSyncCommitPanelRefresh() {
 }
 
 async function waitForRemotePropagation(files = []) {
-  if (!Array.isArray(files) || !files.length) return { canceled: false };
-
-  const normalizedRoot = (() => {
-    try {
-      const root = (window.__press_content_root || 'wwwroot').replace(/\\+/g, '/').replace(/^\/+|\/+$/g, '');
-      return root;
-    } catch (_) {
-      return 'wwwroot';
-    }
-  })();
-
-  const toLivePath = (path) => {
-    const clean = String(path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
-    if (!clean) return '';
-    if (normalizedRoot && clean.startsWith(`${normalizedRoot}/`)) {
-      return clean.slice(normalizedRoot.length + 1);
-    }
-    if (normalizedRoot && clean === normalizedRoot) return '';
-    return clean;
-  };
-
-  const arrayBufferToBase64 = (buffer) => {
-    if (!buffer) return '';
-    try {
-      const bytes = new Uint8Array(buffer);
-      const chunk = 0x8000;
-      let binary = '';
-      for (let i = 0; i < bytes.length; i += chunk) {
-        const slice = bytes.subarray(i, i + chunk);
-        binary += String.fromCharCode.apply(null, slice);
-      }
-      return btoa(binary);
-    } catch (_) {
-      try {
-        return btoa(String.fromCharCode.apply(null, new Uint8Array(buffer)));
-      } catch (err) {
-        console.error('Failed to encode array buffer to base64', err);
-        return '';
-      }
-    }
-  };
-
-  const buildCheckPaths = (file) => {
-    const paths = [];
-    const commitPath = String(file.path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
-    const livePath = toLivePath(commitPath);
-    if (file.assetRelativePath && file.markdownPath) {
-      const base = String(file.markdownPath || '').replace(/\\+/g, '/').replace(/^\/+/, '');
-      const idx = base.lastIndexOf('/');
-      const baseDir = idx >= 0 ? base.slice(0, idx + 1) : '';
-      const rel = String(file.assetRelativePath || '').replace(/\\+/g, '/').replace(/^\/+/, '');
-      const combined = `${baseDir}${rel}`.replace(/\/+/g, '/').replace(/^\/+/, '');
-      if (combined && !paths.includes(combined)) paths.push(combined);
-    }
-    if (livePath && !paths.includes(livePath)) paths.push(livePath);
-    if (commitPath && !paths.includes(commitPath)) paths.push(commitPath);
-    return paths;
-  };
-
-  const unique = [];
-  const seen = new Set();
-  files.forEach((file) => {
-    if (!file || !file.path) return;
-    const normalized = String(file.path).replace(/\\+/g, '/').replace(/^\/+/, '');
-    if (!normalized || normalized === 'site.yaml' || seen.has(normalized)) return;
-    seen.add(normalized);
-    unique.push({ ...file, path: normalized });
+  return waitForPublishedFiles(files, {
+    windowRef: window,
+    fetchImpl: fetch,
+    setStatus: setSyncOverlayStatus,
+    setCancelHandler: setSyncOverlayCancelHandler
   });
-
-  const checkIntervalMs = 30000;
-  const countdownStepMs = 1000;
-  const maxAttempts = 10;
-  let canceled = false;
-  let timedOut = false;
-
-  const cancelHandler = () => {
-    if (canceled) return;
-    canceled = true;
-    setSyncOverlayStatus('Stopping remote checks…');
-  };
-  setSyncOverlayCancelHandler(cancelHandler, true);
-
-  for (const file of unique) {
-    if (canceled || timedOut) break;
-    const displayLabel = String(file.label || file.path || '').trim() || file.path;
-    const expectedText = normalizeMarkdownContent(file.content || '');
-      const expectedBase64 = typeof file.base64 === 'string'
-        ? file.base64.replace(/\s+/g, '')
-        : '';
-      const candidates = buildCheckPaths(file);
-      let attempt = 0;
-      let confirmed = false;
-      while (!canceled && attempt < maxAttempts) {
-        attempt += 1;
-        setSyncOverlayStatus(`Checking ${displayLabel} (attempt ${attempt})…`);
-        let ok = false;
-        if (file.deleted) {
-          let checked = false;
-          let stillExists = false;
-          let indeterminate = false;
-          for (const path of candidates) {
-            if (!path) continue;
-            try {
-              const url = `${path}?ts=${Date.now()}`;
-              const resp = await fetch(url, { cache: 'no-store' });
-              checked = true;
-              if (resp.ok) {
-                stillExists = true;
-                break;
-              }
-              if (resp.status !== 404 && resp.status !== 410) {
-                indeterminate = true;
-              }
-            } catch (_) {
-              indeterminate = true;
-            }
-          }
-          ok = checked && !stillExists && !indeterminate;
-        } else {
-          for (const path of candidates) {
-            if (!path) continue;
-            try {
-              const url = `${path}?ts=${Date.now()}`;
-              const resp = await fetch(url, { cache: 'no-store' });
-              if (!resp.ok) {
-                ok = false;
-                continue;
-              }
-              if (file.binary) {
-                const buffer = await resp.arrayBuffer();
-                const remoteBase64 = arrayBufferToBase64(buffer);
-                if (remoteBase64 && expectedBase64 && remoteBase64 === expectedBase64) {
-                  ok = true;
-                  break;
-                }
-              } else {
-                const text = normalizeMarkdownContent(await resp.text());
-                if (text === expectedText) {
-                  ok = true;
-                  break;
-                }
-              }
-            } catch (_) {
-              ok = false;
-            }
-          }
-        }
-        if (canceled) break;
-        if (ok) {
-        confirmed = true;
-        break;
-      }
-      for (let remaining = checkIntervalMs; remaining > 0; remaining -= countdownStepMs) {
-        if (canceled) break;
-        const seconds = Math.ceil(remaining / 1000);
-        setSyncOverlayStatus(`Attempt ${attempt} did not match for ${displayLabel}. Next check in ${seconds}s…`);
-        await sleep(Math.min(countdownStepMs, remaining));
-        if (canceled) break;
-      }
-    }
-    if (!canceled && !confirmed) {
-      timedOut = true;
-      setSyncOverlayStatus(`Could not confirm ${displayLabel} after ${maxAttempts} attempts.`);
-    }
-  }
-  setSyncOverlayCancelHandler(null, true);
-  if (canceled) {
-    return { canceled: true };
-  }
-  if (timedOut) {
-    return { canceled: false, timedOut: true };
-  }
-  setSyncOverlayStatus('All files confirmed on site.');
-  return { canceled: false, timedOut: false };
 }
 
 function getActiveSiteRepoConfig() {
@@ -7145,9 +6823,28 @@ async function performPublishCommit(transport, summaryEntries = []) {
 
     const headline = `chore: sync ${files.length === 1 ? 'draft' : 'drafts'} via Press`;
     if (transport && transport.type === 'connect') {
-      await createConnectPublishCommit(transport.connect, { owner, name, branch, headline, files });
+      setSyncOverlayStatus(t('editor.composer.github.modal.connectAuthorizing'));
+      const grant = await ensureConnectPublishGrant(transport.connect, { owner, name, branch });
+      setSyncOverlayStatus(t('editor.composer.github.modal.connectPublishing'));
+      await createConnectPublishCommit({
+        connect: transport.connect,
+        repo: { owner, name, branch },
+        headline,
+        files,
+        grant,
+        contentRoot: getTrackedPublishContentRoot(),
+        translate: t
+      });
     } else {
-      await createFineGrainedTokenCommit(transport && transport.token, { owner, name, branch, headline, files });
+      const { createFineGrainedTokenCommit } = await import('./publish/transports/github-pat-transport.js?v=press-system-v3.4.17');
+      await createFineGrainedTokenCommit(transport && transport.token, {
+        owner,
+        name,
+        branch,
+        headline,
+        files,
+        onStatus: setSyncOverlayStatus
+      });
     }
 
     setSyncOverlayStatus('Updating editor state…');
@@ -7170,8 +6867,12 @@ async function performPublishCommit(transport, summaryEntries = []) {
     hideSyncOverlay();
     let message = err && err.message ? err.message : t('editor.toasts.githubCommitFailed');
     if (err && err.status === 401) {
-      clearCachedFineGrainedToken();
-      message = t('editor.toasts.githubTokenRejected');
+      if (transport && transport.type === 'connect') {
+        clearCachedConnectPublishGrant();
+      } else {
+        clearCachedFineGrainedToken();
+        message = t('editor.toasts.githubTokenRejected');
+      }
     }
     console.error('Press GitHub commit failed', err);
     showToast('error', message, { duration: 5200 });
@@ -7180,201 +6881,15 @@ async function performPublishCommit(transport, summaryEntries = []) {
   }
 }
 
-async function createFineGrainedTokenCommit(token, { owner, name, branch, headline, files }) {
-  const branchRef = branch.startsWith('refs/') ? branch : `refs/heads/${branch}`;
-  setSyncOverlayStatus('Fetching repository state…');
-  const headQuery = `
-    query($owner:String!, $name:String!, $ref:String!) {
-      repository(owner:$owner, name:$name) {
-        ref(qualifiedName:$ref) {
-          target {
-            ... on Commit { oid }
-          }
-        }
-      }
-    }
-  `;
-  const headData = await githubGraphqlRequest(token, headQuery, { owner, name, ref: branchRef });
-  const refInfo = headData && headData.repository && headData.repository.ref;
-  const expectedHeadOid = refInfo && refInfo.target && refInfo.target.oid;
-  if (!expectedHeadOid) throw new Error('Unable to resolve the branch head on GitHub.');
-
-  setSyncOverlayStatus('Encoding files…');
-  const fileChanges = buildGithubFileChanges(files);
-  const commitMutation = `
-    mutation($input: CreateCommitOnBranchInput!) {
-      createCommitOnBranch(input: $input) {
-        commit { oid }
-      }
-    }
-  `;
-  const mutationInput = {
-    branch: { repositoryNameWithOwner: `${owner}/${name}`, branchName: branch },
-    message: { headline },
-    expectedHeadOid,
-    fileChanges
-  };
-
-  setSyncOverlayStatus('Creating commit…');
-  await githubGraphqlRequest(token, commitMutation, { input: mutationInput });
-}
-
-async function createConnectPublishCommit(connect, { owner, name, branch, headline, files }) {
-  if (!connect || !connect.baseUrl) {
-    throw new Error(t('editor.composer.github.modal.connectMissing'));
-  }
-  setSyncOverlayStatus(t('editor.composer.github.modal.connectAuthorizing'));
-  const grant = await ensureConnectPublishGrant(connect, { owner, name, branch });
-  const endpoint = new URL('/api/press/publish', connect.baseUrl);
-  const body = {
-    repository: { owner, name, branch },
-    contentRoot: getTrackedPublishContentRoot(),
-    message: { headline },
-    files: files.map(serializeConnectPublishFile)
-  };
-  setSyncOverlayStatus(t('editor.composer.github.modal.connectPublishing'));
-  let response = null;
-  let payload = null;
-  try {
-    response = await fetch(endpoint.href, {
-      method: 'POST',
-      referrerPolicy: 'unsafe-url',
-      headers: {
-        'Authorization': `Bearer ${grant.token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    });
-    payload = await response.json().catch(() => null);
-  } catch (err) {
-    const error = new Error(t('editor.composer.github.modal.connectNetworkError'));
-    error.cause = err;
-    throw error;
-  }
-  if (!response.ok || !payload || payload.ok === false) {
-    const error = new Error(payload && payload.error && payload.error.message
-      ? payload.error.message
-      : t('editor.composer.github.modal.connectPublishFailed'));
-    error.status = response.status;
-    error.response = payload;
-    if (response.status === 401) clearCachedConnectPublishGrant();
-    throw error;
-  }
-}
-
-function buildGithubFileChanges(files) {
-  const additions = files.filter((file) => !file.deleted).map((file) => {
-    const path = String(file.path || '').replace(/^\/+/, '');
-    if (file.base64) {
-      return { path, contents: String(file.base64) };
-    }
-    return { path, contents: encodeContentToBase64(file.content || '') };
-  });
-  const deletions = files.filter((file) => file && file.deleted).map((file) => ({
-    path: String(file.path || '').replace(/^\/+/, '')
-  })).filter((file) => file.path);
-  const fileChanges = {};
-  if (additions.length) fileChanges.additions = additions;
-  if (deletions.length) fileChanges.deletions = deletions;
-  if (!additions.length && !deletions.length) throw new Error('No file changes to commit.');
-  return fileChanges;
-}
-
-function serializeConnectPublishFile(file) {
-  const out = {
-    path: String(file.path || '').replace(/^\/+/, '')
-  };
-  if (file.kind) out.kind = file.kind;
-  if (file.deleted) {
-    out.deleted = true;
-    return out;
-  }
-  if (file.base64) {
-    out.base64 = String(file.base64 || '');
-    if (file.mime) out.mime = file.mime;
-    out.binary = true;
-  } else {
-    out.content = String(file.content || '');
-  }
-  return out;
-}
-
 async function ensureConnectPublishGrant(connect, repo) {
-  const cached = getCachedConnectPublishGrant();
-  if (cached
-    && cached.baseUrl === connect.baseUrl
-    && cached.owner === repo.owner
-    && cached.name === repo.name
-    && cached.branch === repo.branch) {
-    return cached;
-  }
-  return requestConnectPublishGrant(connect, repo);
-}
-
-function requestConnectPublishGrant(connect, repo) {
-  const startUrl = new URL('/github/press/start', connect.baseUrl);
-  startUrl.searchParams.set('origin', window.location.origin);
-  startUrl.searchParams.set('owner', repo.owner);
-  startUrl.searchParams.set('repo', repo.name);
-  startUrl.searchParams.set('branch', repo.branch || 'main');
-
-  const popupName = 'pressConnectPublish';
-  const popup = window.open('', popupName, 'popup,width=520,height=720');
-  if (!popup) {
-    return Promise.reject(new Error(t('editor.toasts.popupBlocked')));
-  }
-  const link = document.createElement('a');
-  link.href = startUrl.href;
-  link.target = popupName;
-  link.referrerPolicy = 'unsafe-url';
-  link.rel = 'opener';
-  link.style.display = 'none';
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-
-  const connectOrigin = new URL(connect.baseUrl).origin;
-  return new Promise((resolve, reject) => {
-    let timer = 0;
-    let closeTimer = 0;
-    const cleanup = () => {
-      window.removeEventListener('message', onMessage);
-      if (timer) window.clearTimeout(timer);
-      if (closeTimer) window.clearInterval(closeTimer);
-    };
-    const onMessage = (event) => {
-      if (!event || event.origin !== connectOrigin) return;
-      const data = event.data && typeof event.data === 'object' ? event.data : null;
-      if (!data || data.type !== CONNECT_PUBLISH_MESSAGE_TYPE) return;
-      cleanup();
-      if (!data.ok || !data.grant || !data.grant.token) {
-        reject(new Error(data.error && data.error.message ? data.error.message : t('editor.composer.github.modal.connectAuthorizationFailed')));
-        return;
-      }
-      const grant = {
-        ...data.grant,
-        baseUrl: connect.baseUrl,
-        owner: repo.owner,
-        name: repo.name,
-        branch: repo.branch || 'main'
-      };
-      setCachedConnectPublishGrant(grant);
-      resolve(grant);
-    };
-    window.addEventListener('message', onMessage);
-    closeTimer = window.setInterval(() => {
-      try {
-        if (!popup.closed) return;
-      } catch (_) {
-        return;
-      }
-      cleanup();
-      reject(new Error(t('editor.composer.github.modal.connectAuthorizationCanceled')));
-    }, 500);
-    timer = window.setTimeout(() => {
-      cleanup();
-      reject(new Error(t('editor.composer.github.modal.connectAuthorizationTimedOut')));
-    }, 5 * 60 * 1000);
+  return authorizeConnectPublishGrant({
+    connect,
+    repo,
+    getCachedGrant: getCachedConnectPublishGrant,
+    setCachedGrant: setCachedConnectPublishGrant,
+    windowRef: window,
+    documentRef: document,
+    translate: t
   });
 }
 

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,4 +1,4 @@
-import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.16';
+import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.17';
 
 // Helpers for generating excerpts/snippets from markdown
 export function stripMarkdownToText(md) {

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -1,5 +1,5 @@
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.16';
-import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.16';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
+import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.17';
 
 const BLOCK_TYPES = new Set(['paragraph', 'heading', 'image', 'list', 'quote', 'code', 'math', 'card', 'table', 'source', 'blank']);
 const CODE_LANGUAGE_OPTIONS = [

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.16';
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.17';
 
 function applyAttributeTranslation(el, target, value) {
   if (value == null) return;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,6 +1,6 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.16';
-import { createHiEditor } from './hieditor.js?v=press-system-v3.4.16';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.17';
+import { createHiEditor } from './hieditor.js?v=press-system-v3.4.17';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
 import {
   FRONT_MATTER_FIELD_DEFS,
@@ -10,12 +10,12 @@ import {
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings,
   valueIsPresent
-} from './frontmatter-document.js?v=press-system-v3.4.16';
-import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.16';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.16';
+} from './frontmatter-document.js?v=press-system-v3.4.17';
+import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.17';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.17';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.16';
-import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.16';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.17';
+import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.17';
 
 const LS_WRAP_KEY = 'press_editor_wrap_enabled';
 const LS_VIEW_KEY = 'press_editor_markdown_view_v2';

--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -1,25 +1,25 @@
 import './components.js';
-import { mdParse } from './markdown.js?v=press-system-v3.4.16';
+import { mdParse } from './markdown.js?v=press-system-v3.4.17';
 import { createContentModel } from './content-model.js';
 import { parseFrontMatter } from './content.js';
-import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.16';
+import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.17';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from './post-render.js';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.16';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.17';
 import { applyLangHints } from './typography.js';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.16';
-import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.16';
-import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.16';
-import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.16';
-import { renderPostNav } from './post-nav.js?v=press-system-v3.4.16';
-import { renderTagSidebar } from './tags.js?v=press-system-v3.4.16';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
+import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.17';
+import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.17';
+import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.17';
+import { renderPostNav } from './post-nav.js?v=press-system-v3.4.17';
+import { renderTagSidebar } from './tags.js?v=press-system-v3.4.17';
 import { getArticleTitleFromMain } from './dom-utils.js';
-import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.16';
+import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.17';
 
 const RENDER_MESSAGE = 'press-editor-preview-render';
 const READY_MESSAGE = 'press-editor-preview-ready';
 const RENDERED_MESSAGE = 'press-editor-preview-rendered';
 const ERROR_MESSAGE = 'press-editor-preview-error';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.16';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
 
 let activePack = '';
 let latestRenderRequestId = 0;

--- a/assets/js/encrypted-content.js
+++ b/assets/js/encrypted-content.js
@@ -3,7 +3,7 @@ import {
   cloneFrontMatterData,
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings
-} from './frontmatter-document.js?v=press-system-v3.4.16';
+} from './frontmatter-document.js?v=press-system-v3.4.17';
 
 export const ENCRYPTED_MARKDOWN_FORMAT = 'press-encrypted-markdown-v1';
 export const ENCRYPTED_MARKDOWN_FENCE = 'press-encrypted-markdown-v1';

--- a/assets/js/errors.js
+++ b/assets/js/errors.js
@@ -1,5 +1,5 @@
 // errors.js — lightweight global error overlay and reporter
-import { t } from './i18n.js?v=press-system-v3.4.16';
+import { t } from './i18n.js?v=press-system-v3.4.17';
 
 let reporterConfig = {
   reportUrl: null,

--- a/assets/js/hieditor.js
+++ b/assets/js/hieditor.js
@@ -1,4 +1,4 @@
-import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.16';
+import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.17';
 
 function escapeHtmlInline(text) {
   if (!text) return '';

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -10,11 +10,11 @@
 // - Friendly language names come from assets/i18n/languages.json (or the language module's metadata).
 
 import { parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.16';
+import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.17';
 import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 import { getThemeRegion } from './theme-regions.js';
-import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.16';
+import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.17';
 
 // Content fetch cache modes are normalized by cache-control.js.
 

--- a/assets/js/link-cards.js
+++ b/assets/js/link-cards.js
@@ -1,6 +1,6 @@
 import { renderTags, escapeHtml, formatDisplayDate, cardImageSrc, fallbackCover, getContentRoot } from './utils.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.16';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.17';
 import { hydrateCardCovers } from './post-render.js';
 
 const DEFAULT_STRINGS = {

--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,4 +1,4 @@
-import { withLangParam, t } from './i18n.js?v=press-system-v3.4.16';
+import { withLangParam, t } from './i18n.js?v=press-system-v3.4.17';
 import { escapeHtml } from './utils.js';
 
 export function renderPostNav(container, postsIndex, postname) {

--- a/assets/js/publish/propagation-watcher.js
+++ b/assets/js/publish/propagation-watcher.js
@@ -163,7 +163,6 @@ export async function waitForRemotePropagation(files = [], options = {}) {
         break;
       }
       for (let remaining = checkIntervalMs; remaining > 0; remaining -= countdownStepMs) {
-        if (canceled) break;
         const seconds = Math.ceil(remaining / 1000);
         setStatus(`Attempt ${attempt} did not match for ${displayLabel}. Next check in ${seconds}s...`);
         await sleep(Math.min(countdownStepMs, remaining));

--- a/assets/js/publish/propagation-watcher.js
+++ b/assets/js/publish/propagation-watcher.js
@@ -1,0 +1,187 @@
+import { normalizeMarkdownDraftContent } from '../composer-markdown-save.js';
+
+function sleep(ms) {
+  const timeout = Math.max(0, Number(ms) || 0);
+  return new Promise((resolve) => { setTimeout(resolve, timeout); });
+}
+
+function arrayBufferToBase64(buffer) {
+  if (!buffer) return '';
+  try {
+    const bytes = new Uint8Array(buffer);
+    const chunk = 0x8000;
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += chunk) {
+      const slice = bytes.subarray(i, i + chunk);
+      binary += String.fromCharCode.apply(null, slice);
+    }
+    return btoa(binary);
+  } catch (_) {
+    try {
+      return btoa(String.fromCharCode.apply(null, new Uint8Array(buffer)));
+    } catch (err) {
+      console.error('Failed to encode array buffer to base64', err);
+      return '';
+    }
+  }
+}
+
+export async function waitForRemotePropagation(files = [], options = {}) {
+  if (!Array.isArray(files) || !files.length) return { canceled: false };
+  const windowRef = options.windowRef || window;
+  const fetchImpl = options.fetchImpl || fetch;
+  const setStatus = typeof options.setStatus === 'function' ? options.setStatus : () => {};
+  const setCancelHandler = typeof options.setCancelHandler === 'function' ? options.setCancelHandler : () => {};
+
+  const normalizedRoot = (() => {
+    try {
+      const root = (windowRef.__press_content_root || 'wwwroot').replace(/\\+/g, '/').replace(/^\/+|\/+$/g, '');
+      return root;
+    } catch (_) {
+      return 'wwwroot';
+    }
+  })();
+
+  const toLivePath = (path) => {
+    const clean = String(path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+    if (!clean) return '';
+    if (normalizedRoot && clean.startsWith(`${normalizedRoot}/`)) {
+      return clean.slice(normalizedRoot.length + 1);
+    }
+    if (normalizedRoot && clean === normalizedRoot) return '';
+    return clean;
+  };
+
+  const buildCheckPaths = (file) => {
+    const paths = [];
+    const commitPath = String(file.path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+    const livePath = toLivePath(commitPath);
+    if (file.assetRelativePath && file.markdownPath) {
+      const base = String(file.markdownPath || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+      const idx = base.lastIndexOf('/');
+      const baseDir = idx >= 0 ? base.slice(0, idx + 1) : '';
+      const rel = String(file.assetRelativePath || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+      const combined = `${baseDir}${rel}`.replace(/\/+/g, '/').replace(/^\/+/, '');
+      if (combined && !paths.includes(combined)) paths.push(combined);
+    }
+    if (livePath && !paths.includes(livePath)) paths.push(livePath);
+    if (commitPath && !paths.includes(commitPath)) paths.push(commitPath);
+    return paths;
+  };
+
+  const unique = [];
+  const seen = new Set();
+  files.forEach((file) => {
+    if (!file || !file.path) return;
+    const normalized = String(file.path).replace(/\\+/g, '/').replace(/^\/+/, '');
+    if (!normalized || normalized === 'site.yaml' || seen.has(normalized)) return;
+    seen.add(normalized);
+    unique.push({ ...file, path: normalized });
+  });
+
+  const checkIntervalMs = 30000;
+  const countdownStepMs = 1000;
+  const maxAttempts = 10;
+  let canceled = false;
+  let timedOut = false;
+
+  const cancelHandler = () => {
+    if (canceled) return;
+    canceled = true;
+    setStatus('Stopping remote checks...');
+  };
+  setCancelHandler(cancelHandler, true);
+
+  for (const file of unique) {
+    if (canceled || timedOut) break;
+    const displayLabel = String(file.label || file.path || '').trim() || file.path;
+    const expectedText = normalizeMarkdownDraftContent(file.content || '');
+    const expectedBase64 = typeof file.base64 === 'string'
+      ? file.base64.replace(/\s+/g, '')
+      : '';
+    const candidates = buildCheckPaths(file);
+    let attempt = 0;
+    let confirmed = false;
+    while (!canceled && attempt < maxAttempts) {
+      attempt += 1;
+      setStatus(`Checking ${displayLabel} (attempt ${attempt})...`);
+      let ok = false;
+      if (file.deleted) {
+        let checked = false;
+        let stillExists = false;
+        let indeterminate = false;
+        for (const path of candidates) {
+          if (!path) continue;
+          try {
+            const url = `${path}?ts=${Date.now()}`;
+            const resp = await fetchImpl(url, { cache: 'no-store' });
+            checked = true;
+            if (resp.ok) {
+              stillExists = true;
+              break;
+            }
+            if (resp.status !== 404 && resp.status !== 410) {
+              indeterminate = true;
+            }
+          } catch (_) {
+            indeterminate = true;
+          }
+        }
+        ok = checked && !stillExists && !indeterminate;
+      } else {
+        for (const path of candidates) {
+          if (!path) continue;
+          try {
+            const url = `${path}?ts=${Date.now()}`;
+            const resp = await fetchImpl(url, { cache: 'no-store' });
+            if (!resp.ok) {
+              ok = false;
+              continue;
+            }
+            if (file.binary) {
+              const buffer = await resp.arrayBuffer();
+              const remoteBase64 = arrayBufferToBase64(buffer);
+              if (remoteBase64 && expectedBase64 && remoteBase64 === expectedBase64) {
+                ok = true;
+                break;
+              }
+            } else {
+              const text = normalizeMarkdownDraftContent(await resp.text());
+              if (text === expectedText) {
+                ok = true;
+                break;
+              }
+            }
+          } catch (_) {
+            ok = false;
+          }
+        }
+      }
+      if (canceled) break;
+      if (ok) {
+        confirmed = true;
+        break;
+      }
+      for (let remaining = checkIntervalMs; remaining > 0; remaining -= countdownStepMs) {
+        if (canceled) break;
+        const seconds = Math.ceil(remaining / 1000);
+        setStatus(`Attempt ${attempt} did not match for ${displayLabel}. Next check in ${seconds}s...`);
+        await sleep(Math.min(countdownStepMs, remaining));
+        if (canceled) break;
+      }
+    }
+    if (!canceled && !confirmed) {
+      timedOut = true;
+      setStatus(`Could not confirm ${displayLabel} after ${maxAttempts} attempts.`);
+    }
+  }
+  setCancelHandler(null, true);
+  if (canceled) {
+    return { canceled: true };
+  }
+  if (timedOut) {
+    return { canceled: false, timedOut: true };
+  }
+  setStatus('All files confirmed on site.');
+  return { canceled: false, timedOut: false };
+}

--- a/assets/js/publish/settings-store.js
+++ b/assets/js/publish/settings-store.js
@@ -1,0 +1,227 @@
+export const GITHUB_PAT_STORAGE_KEY = 'press_fg_pat_cache';
+export const CONNECT_PUBLISH_GRANT_STORAGE_KEY = 'press_connect_publish_grant_cache';
+export const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';
+export const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';
+export const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';
+export const CONNECT_PUBLISH_MESSAGE_TYPE = 'press-connect-publish-authorized';
+export const CONNECT_PUBLISH_PRESETS = [
+  { value: 'https://connect-8mr.pages.dev', label: 'Ekily Connect' },
+  { value: 'http://127.0.0.1:8788', label: 'Local Connect' }
+];
+
+export function isLocalhostHost(hostname) {
+  const value = String(hostname || '').toLowerCase();
+  return value === 'localhost' || value === '127.0.0.1' || value === '::1' || value === '[::1]';
+}
+
+export function getDefaultConnectPublishBaseUrl() {
+  return CONNECT_PUBLISH_PRESETS[0].value;
+}
+
+export function normalizeConnectPublishBaseUrl(value) {
+  const rawBaseUrl = String(value || '').trim();
+  if (!rawBaseUrl) return null;
+  try {
+    const url = new URL(rawBaseUrl);
+    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLocalhostHost(url.hostname))) return null;
+    return url.origin;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function isUsableConnectPublishGrant(grant) {
+  if (!grant || typeof grant !== 'object' || !grant.token) return false;
+  const expiresAt = Number(grant.expiresAt || 0);
+  return Number.isFinite(expiresAt) && expiresAt > Math.floor(Date.now() / 1000) + 30;
+}
+
+export function createPublishSettingsStore(options = {}) {
+  const windowRef = options.windowRef || (typeof window !== 'undefined' ? window : null);
+  const scopeKey = typeof options.scopeKey === 'function' ? options.scopeKey : (key) => key;
+  let cachedFineGrainedTokenMemory = '';
+  let cachedConnectPublishGrantMemory = null;
+  let cachedConnectPublishSettingsMemory = null;
+
+  const session = () => windowRef && windowRef.sessionStorage ? windowRef.sessionStorage : null;
+  const local = () => windowRef && windowRef.localStorage ? windowRef.localStorage : null;
+  const scopedKey = (key) => scopeKey(key);
+
+  function getCachedFineGrainedToken() {
+    try {
+      const storage = session();
+      const value = storage ? storage.getItem(scopedKey(GITHUB_PAT_STORAGE_KEY)) : '';
+      if (typeof value === 'string' && value) {
+        cachedFineGrainedTokenMemory = value;
+        return value;
+      }
+    } catch (_) {
+      /* ignore unavailable storage */
+    }
+    return cachedFineGrainedTokenMemory || '';
+  }
+
+  function setCachedFineGrainedToken(token) {
+    const trimmed = String(token || '').trim();
+    cachedFineGrainedTokenMemory = trimmed;
+    try {
+      const storage = session();
+      if (!storage) return;
+      if (trimmed) storage.setItem(scopedKey(GITHUB_PAT_STORAGE_KEY), trimmed);
+      else storage.removeItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
+    } catch (_) {
+      /* ignore storage errors */
+    }
+  }
+
+  function clearCachedFineGrainedToken() {
+    cachedFineGrainedTokenMemory = '';
+    try {
+      const storage = session();
+      if (storage) storage.removeItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
+  function getStoredConnectPublishSettings() {
+    if (cachedConnectPublishSettingsMemory && typeof cachedConnectPublishSettingsMemory === 'object') {
+      return { ...cachedConnectPublishSettingsMemory };
+    }
+    const settings = {
+      mode: 'connect',
+      enabled: true,
+      baseUrl: getDefaultConnectPublishBaseUrl()
+    };
+    try {
+      const storage = local();
+      if (storage) {
+        const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
+        if (modeRaw === 'connect' || modeRaw === 'pat') {
+          settings.mode = modeRaw;
+          settings.enabled = modeRaw === 'connect';
+        } else {
+          const enabledRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+          if (enabledRaw === '0') {
+            settings.mode = 'pat';
+            settings.enabled = false;
+          } else if (enabledRaw === '1') {
+            settings.mode = 'connect';
+            settings.enabled = true;
+          }
+        }
+        const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
+        if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
+      }
+    } catch (_) {
+      /* ignore unavailable storage */
+    }
+    cachedConnectPublishSettingsMemory = { ...settings };
+    return settings;
+  }
+
+  function setStoredConnectPublishSettings(next = {}) {
+    const previous = getStoredConnectPublishSettings();
+    const mode = next.mode === 'connect' || next.mode === 'pat'
+      ? next.mode
+      : (typeof next.enabled === 'boolean'
+          ? (next.enabled ? 'connect' : 'pat')
+          : (previous.mode === 'pat' ? 'pat' : 'connect'));
+    const settings = {
+      mode,
+      enabled: mode === 'connect',
+      baseUrl: String(next.baseUrl != null ? next.baseUrl : previous.baseUrl || '').trim() || getDefaultConnectPublishBaseUrl()
+    };
+    const previousBase = normalizeConnectPublishBaseUrl(previous.baseUrl);
+    const nextBase = normalizeConnectPublishBaseUrl(settings.baseUrl);
+    cachedConnectPublishSettingsMemory = { ...settings };
+    try {
+      const storage = local();
+      if (storage) {
+        storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
+        storage.setItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY), settings.enabled ? '1' : '0');
+        storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
+      }
+    } catch (_) {
+      /* ignore storage errors */
+    }
+    if (previousBase !== nextBase) clearCachedConnectPublishGrant();
+    return settings;
+  }
+
+  function getCachedConnectPublishGrant() {
+    if (cachedConnectPublishGrantMemory && isUsableConnectPublishGrant(cachedConnectPublishGrantMemory)) {
+      return cachedConnectPublishGrantMemory;
+    }
+    try {
+      const storage = session();
+      const raw = storage ? storage.getItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY)) : '';
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (isUsableConnectPublishGrant(parsed)) {
+        cachedConnectPublishGrantMemory = parsed;
+        return parsed;
+      }
+    } catch (_) {
+      /* ignore unavailable storage */
+    }
+    return null;
+  }
+
+  function setCachedConnectPublishGrant(grant) {
+    cachedConnectPublishGrantMemory = grant && typeof grant === 'object' ? { ...grant } : null;
+    try {
+      const storage = session();
+      if (!storage) return;
+      if (cachedConnectPublishGrantMemory) {
+        storage.setItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY), JSON.stringify(cachedConnectPublishGrantMemory));
+      } else {
+        storage.removeItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
+      }
+    } catch (_) {
+      /* ignore storage errors */
+    }
+  }
+
+  function clearCachedConnectPublishGrant() {
+    cachedConnectPublishGrantMemory = null;
+    try {
+      const storage = session();
+      if (storage) storage.removeItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
+  function resolvePublishTransport(settings = getStoredConnectPublishSettings()) {
+    if (settings.enabled !== false && settings.mode !== 'pat') {
+      const baseUrl = normalizeConnectPublishBaseUrl(settings.baseUrl);
+      if (!baseUrl) {
+        return {
+          type: 'connect',
+          invalid: true,
+          rawBaseUrl: settings.baseUrl
+        };
+      }
+      return {
+        type: 'connect',
+        connect: { baseUrl }
+      };
+    }
+    return {
+      type: 'pat'
+    };
+  }
+
+  return {
+    getCachedFineGrainedToken,
+    setCachedFineGrainedToken,
+    clearCachedFineGrainedToken,
+    getStoredConnectPublishSettings,
+    setStoredConnectPublishSettings,
+    getCachedConnectPublishGrant,
+    setCachedConnectPublishGrant,
+    clearCachedConnectPublishGrant,
+    resolvePublishTransport
+  };
+}

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -1,0 +1,183 @@
+import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js?v=press-system-v3.4.17';
+
+export function serializeConnectPublishFile(file) {
+  const out = {
+    path: String(file && file.path || '').replace(/^\/+/, '')
+  };
+  if (file && file.kind) out.kind = file.kind;
+  if (file && file.deleted) {
+    out.deleted = true;
+    return out;
+  }
+  if (file && file.base64) {
+    out.base64 = String(file.base64 || '');
+    if (file.mime) out.mime = file.mime;
+    out.binary = true;
+  } else {
+    out.content = String(file && file.content || '');
+  }
+  return out;
+}
+
+export async function createConnectPublishCommit({
+  connect,
+  repo,
+  headline,
+  files,
+  contentRoot,
+  grant,
+  fetchImpl = fetch,
+  translate = (key) => key
+} = {}) {
+  const message = (key, fallback) => {
+    const value = typeof translate === 'function' ? translate(key) : '';
+    return value && value !== key ? value : fallback;
+  };
+  if (!connect || !connect.baseUrl) {
+    throw new Error(message('editor.composer.github.modal.connectMissing', 'Connect publish settings are missing.'));
+  }
+  if (!grant || !grant.token) {
+    throw new Error(message('editor.composer.github.modal.connectAuthorizationFailed', 'Connect publish authorization is missing.'));
+  }
+  const owner = repo && repo.owner ? String(repo.owner) : '';
+  const name = repo && repo.name ? String(repo.name) : '';
+  const branch = repo && repo.branch ? String(repo.branch) : 'main';
+  const endpoint = new URL('/api/press/publish', connect.baseUrl);
+  const body = {
+    repository: { owner, name, branch },
+    contentRoot: contentRoot || 'wwwroot',
+    message: { headline },
+    files: (Array.isArray(files) ? files : []).map(serializeConnectPublishFile)
+  };
+  let response = null;
+  let payload = null;
+  try {
+    response = await fetchImpl(endpoint.href, {
+      method: 'POST',
+      referrerPolicy: 'unsafe-url',
+      headers: {
+        'Authorization': `Bearer ${grant.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    payload = await response.json().catch(() => null);
+  } catch (err) {
+    const error = new Error(message('editor.composer.github.modal.connectNetworkError', 'Network error while reaching Connect.'));
+    error.cause = err;
+    throw error;
+  }
+  if (!response.ok || !payload || payload.ok === false) {
+    const error = new Error(payload && payload.error && payload.error.message
+      ? payload.error.message
+      : message('editor.composer.github.modal.connectPublishFailed', 'Connect could not publish this commit.'));
+    error.status = response.status;
+    error.response = payload;
+    throw error;
+  }
+  return payload;
+}
+
+export async function ensureConnectPublishGrant({
+  connect,
+  repo,
+  getCachedGrant,
+  setCachedGrant,
+  windowRef = window,
+  documentRef = document,
+  translate = (key) => key,
+  messageType = CONNECT_PUBLISH_MESSAGE_TYPE
+} = {}) {
+  const cached = typeof getCachedGrant === 'function' ? getCachedGrant() : null;
+  if (cached
+    && cached.baseUrl === connect.baseUrl
+    && cached.owner === repo.owner
+    && cached.name === repo.name
+    && cached.branch === repo.branch) {
+    return cached;
+  }
+  return requestConnectPublishGrant({
+    connect,
+    repo,
+    setCachedGrant,
+    windowRef,
+    documentRef,
+    translate,
+    messageType
+  });
+}
+
+export function requestConnectPublishGrant({
+  connect,
+  repo,
+  setCachedGrant,
+  windowRef = window,
+  documentRef = document,
+  translate = (key) => key,
+  messageType = CONNECT_PUBLISH_MESSAGE_TYPE
+} = {}) {
+  const startUrl = new URL('/github/press/start', connect.baseUrl);
+  startUrl.searchParams.set('origin', windowRef.location.origin);
+  startUrl.searchParams.set('owner', repo.owner);
+  startUrl.searchParams.set('repo', repo.name);
+  startUrl.searchParams.set('branch', repo.branch || 'main');
+
+  const popupName = 'pressConnectPublish';
+  const popup = windowRef.open('', popupName, 'popup,width=520,height=720');
+  if (!popup) {
+    return Promise.reject(new Error(translate('editor.toasts.popupBlocked')));
+  }
+  const link = documentRef.createElement('a');
+  link.href = startUrl.href;
+  link.target = popupName;
+  link.referrerPolicy = 'unsafe-url';
+  link.rel = 'opener';
+  link.style.display = 'none';
+  documentRef.body.appendChild(link);
+  link.click();
+  link.remove();
+
+  const connectOrigin = new URL(connect.baseUrl).origin;
+  return new Promise((resolve, reject) => {
+    let timer = 0;
+    let closeTimer = 0;
+    const cleanup = () => {
+      windowRef.removeEventListener('message', onMessage);
+      if (timer) windowRef.clearTimeout(timer);
+      if (closeTimer) windowRef.clearInterval(closeTimer);
+    };
+    const onMessage = (event) => {
+      if (!event || event.origin !== connectOrigin) return;
+      const data = event.data && typeof event.data === 'object' ? event.data : null;
+      if (!data || data.type !== messageType) return;
+      cleanup();
+      if (!data.ok || !data.grant || !data.grant.token) {
+        reject(new Error(data.error && data.error.message ? data.error.message : translate('editor.composer.github.modal.connectAuthorizationFailed')));
+        return;
+      }
+      const grant = {
+        ...data.grant,
+        baseUrl: connect.baseUrl,
+        owner: repo.owner,
+        name: repo.name,
+        branch: repo.branch || 'main'
+      };
+      if (typeof setCachedGrant === 'function') setCachedGrant(grant);
+      resolve(grant);
+    };
+    windowRef.addEventListener('message', onMessage);
+    closeTimer = windowRef.setInterval(() => {
+      try {
+        if (!popup.closed) return;
+      } catch (_) {
+        return;
+      }
+      cleanup();
+      reject(new Error(translate('editor.composer.github.modal.connectAuthorizationCanceled')));
+    }, 500);
+    timer = windowRef.setTimeout(() => {
+      cleanup();
+      reject(new Error(translate('editor.composer.github.modal.connectAuthorizationTimedOut')));
+    }, 5 * 60 * 1000);
+  });
+}

--- a/assets/js/publish/transports/github-pat-transport.js
+++ b/assets/js/publish/transports/github-pat-transport.js
@@ -1,0 +1,130 @@
+function encodeContentToBase64(text) {
+  const input = String(text == null ? '' : text);
+  if (typeof window !== 'undefined' && typeof window.TextEncoder === 'function') {
+    try {
+      const encoder = new TextEncoder();
+      const bytes = encoder.encode(input);
+      const chunkSize = 0x8000;
+      let binary = '';
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        const slice = bytes.subarray(i, i + chunkSize);
+        binary += String.fromCharCode.apply(null, slice);
+      }
+      return btoa(binary);
+    } catch (_) {
+      /* fall through to fallback */
+    }
+  }
+  try {
+    return btoa(unescape(encodeURIComponent(input)));
+  } catch (_) {
+    let binary = '';
+    for (let i = 0; i < input.length; i += 1) {
+      const code = input.charCodeAt(i);
+      if (code > 0xFF) {
+        binary += String.fromCharCode(code >> 8, code & 0xFF);
+      } else {
+        binary += String.fromCharCode(code);
+      }
+    }
+    return btoa(binary);
+  }
+}
+
+export function buildGithubFileChanges(files) {
+  const additions = (Array.isArray(files) ? files : []).filter((file) => !file.deleted).map((file) => {
+    const path = String(file.path || '').replace(/^\/+/, '');
+    if (file.base64) {
+      return { path, contents: String(file.base64) };
+    }
+    return { path, contents: encodeContentToBase64(file.content || '') };
+  });
+  const deletions = (Array.isArray(files) ? files : []).filter((file) => file && file.deleted).map((file) => ({
+    path: String(file.path || '').replace(/^\/+/, '')
+  })).filter((file) => file.path);
+  const fileChanges = {};
+  if (additions.length) fileChanges.additions = additions;
+  if (deletions.length) fileChanges.deletions = deletions;
+  if (!additions.length && !deletions.length) throw new Error('No file changes to commit.');
+  return fileChanges;
+}
+
+export async function githubGraphqlRequest(token, query, variables = {}, fetchImpl = fetch) {
+  const trimmedToken = String(token || '').trim();
+  if (!trimmedToken) throw new Error('GitHub token is required.');
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${trimmedToken}`,
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28'
+  };
+  const body = JSON.stringify({ query, variables });
+  let response;
+  try {
+    response = await fetchImpl('https://api.github.com/graphql', { method: 'POST', headers, body });
+  } catch (err) {
+    const error = new Error('Network error while reaching GitHub.');
+    error.cause = err;
+    throw error;
+  }
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (_) {
+    payload = null;
+  }
+  if (!response.ok) {
+    const error = new Error((payload && payload.message) || `GitHub API error (${response.status})`);
+    error.status = response.status;
+    error.response = payload;
+    throw error;
+  }
+  if (payload && Array.isArray(payload.errors) && payload.errors.length) {
+    const first = payload.errors[0];
+    const error = new Error((first && first.message) || 'GitHub GraphQL error.');
+    error.status = response.status;
+    error.response = payload;
+    throw error;
+  }
+  return payload ? payload.data : null;
+}
+
+export async function createFineGrainedTokenCommit(token, { owner, name, branch, headline, files, onStatus } = {}) {
+  const reportStatus = typeof onStatus === 'function' ? onStatus : () => {};
+  const branchRef = String(branch || '').startsWith('refs/') ? branch : `refs/heads/${branch}`;
+  reportStatus('Fetching repository state...');
+  const headQuery = `
+    query($owner:String!, $name:String!, $ref:String!) {
+      repository(owner:$owner, name:$name) {
+        ref(qualifiedName:$ref) {
+          target {
+            ... on Commit { oid }
+          }
+        }
+      }
+    }
+  `;
+  const headData = await githubGraphqlRequest(token, headQuery, { owner, name, ref: branchRef });
+  const refInfo = headData && headData.repository && headData.repository.ref;
+  const expectedHeadOid = refInfo && refInfo.target && refInfo.target.oid;
+  if (!expectedHeadOid) throw new Error('Unable to resolve the branch head on GitHub.');
+
+  reportStatus('Encoding files...');
+  const fileChanges = buildGithubFileChanges(files);
+  const commitMutation = `
+    mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit { oid }
+      }
+    }
+  `;
+  const mutationInput = {
+    branch: { repositoryNameWithOwner: `${owner}/${name}`, branchName: branch },
+    message: { headline },
+    expectedHeadOid,
+    fileChanges
+  };
+
+  reportStatus('Creating commit...');
+  await githubGraphqlRequest(token, commitMutation, { input: mutationInput });
+}

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,8 +1,8 @@
 // seo.js - Dynamic SEO meta tag management for client-side routing
 // This maintains SEO benefits while keeping the "no compilation needed" philosophy
 
-import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.16';
-import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.16';
+import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.17';
+import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.17';
 import { parseFrontMatter } from './content.js';
 
 function ensureTrailingSlash(value) {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,7 +1,7 @@
-import { mdParse } from './markdown.js?v=press-system-v3.4.16';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.16';
-import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.16';
-import { t } from './i18n.js?v=press-system-v3.4.16';
+import { mdParse } from './markdown.js?v=press-system-v3.4.17';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
+import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.17';
+import { t } from './i18n.js?v=press-system-v3.4.17';
 import {
   compareSemver,
   isUpgradeAllowed,
@@ -10,7 +10,7 @@ import {
   normalizeSemver,
   normalizeUpgradeFrom,
   semverToTag
-} from './press-version.js?v=press-system-v3.4.16';
+} from './press-version.js?v=press-system-v3.4.17';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([

--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -1,5 +1,5 @@
 // Tag utilities: aggregation, rendering (collapsible), and tooltips for truncated tags
-import { t, withLangParam } from './i18n.js?v=press-system-v3.4.16';
+import { t, withLangParam } from './i18n.js?v=press-system-v3.4.17';
 import { getThemeRegion } from './theme-regions.js';
 import { getQueryVariable, escapeHtml } from './utils.js';
 

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,5 +1,5 @@
 // Template renderers (pure functions returning HTML strings)
-import { t } from './i18n.js?v=press-system-v3.4.16';
+import { t } from './i18n.js?v=press-system-v3.4.17';
 import { computeReadTime } from './content.js';
 import { escapeHtml, renderTags, formatDisplayDate } from './utils.js';
 

--- a/assets/js/theme-boot.js
+++ b/assets/js/theme-boot.js
@@ -18,7 +18,7 @@
     pack = String(pack || '').toLowerCase().trim().replace(/[^a-z0-9_-]/g, '') || 'native';
   } catch (_) { pack = 'native'; }
   if (pack !== 'native') return;
-  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.16';
+  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.17';
   window.__themePackHref = href;
 
   // If the link tag exists already, set it; otherwise try briefly until it does

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -4,7 +4,7 @@ import {
   getRequestedThemePack,
   setThemePackStylesheet,
   suppressThemePack
-} from './theme.js?v=press-system-v3.4.16';
+} from './theme.js?v=press-system-v3.4.17';
 import {
   t,
   withLangParam,
@@ -13,7 +13,7 @@ import {
   ensureLanguageBundle,
   getAvailableLangs,
   getLanguageLabel
-} from './i18n.js?v=press-system-v3.4.16';
+} from './i18n.js?v=press-system-v3.4.17';
 import {
   createThemeRegionRegistry,
   ensureThemeRegionRegistry,
@@ -29,8 +29,8 @@ let layoutMountGeneration = 0;
 
 const DEFAULT_PACK = 'native';
 const CONTRACT_VERSION = 1;
-const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.16';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.16';
+const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.17';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
 
 const EFFECT_VIEW_NAMES = {
   renderPostView: 'post',

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,5 +1,5 @@
-import { t } from './i18n.js?v=press-system-v3.4.16';
-import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.16';
+import { t } from './i18n.js?v=press-system-v3.4.17';
+import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.17';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,10 +1,10 @@
-import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.16';
+import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.17';
 import { getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';
 const THEME_CONTROLS_BOUND = Symbol('pressThemeControlsBound');
 const THEME_CONTROLS_I18N_BOUND = Symbol('pressThemeControlsI18nBound');
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.16';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
 const THEME_PACK_KEY = 'themePack';
 const THEME_PACK_PENDING_KEY = 'themePackPending';
 const suppressedThemePacks = new Set();

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=press-system-v3.4.16';
+import { t } from './i18n.js?v=press-system-v3.4.17';
 import { getThemeRegion } from './theme-regions.js';
 
 // Anchors and Table of Contents enhancements

--- a/assets/main.js
+++ b/assets/main.js
@@ -5,13 +5,13 @@ import {
   decryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope,
   stripEncryptedBodyForPublicUse
-} from './js/encrypted-content.js?v=press-system-v3.4.16';
-import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.16';
-import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.16';
-import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.16';
+} from './js/encrypted-content.js?v=press-system-v3.4.17';
+import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.17';
+import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.17';
+import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.17';
 import { setupSearch } from './js/search.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './js/content.js';
-import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.16';
+import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.17';
 import { getQueryVariable, setDocTitle, setBaseSiteTitle, slugifyTab, isModifiedClick } from './js/utils.js';
 import {
   initI18n,
@@ -23,13 +23,13 @@ import {
   getCurrentLang,
   normalizeLangKey,
   POSTS_METADATA_READY_EVENT
-} from './js/i18n.js?v=press-system-v3.4.16';
-import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.16';
-import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.16';
+} from './js/i18n.js?v=press-system-v3.4.17';
+import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.17';
+import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.17';
 import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
-import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.16';
-import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.16';
+import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.17';
+import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.17';
 import { getArticleTitleFromMain } from './js/dom-utils.js';
 import { applyLangHints } from './js/typography.js';
 
@@ -80,7 +80,7 @@ function cacheDynamicImport(importer, getCached, setCached) {
 
 function loadMarkdownModule() {
   return cacheDynamicImport(
-    () => import('./js/markdown.js?v=press-system-v3.4.16'),
+    () => import('./js/markdown.js?v=press-system-v3.4.17'),
     () => markdownModulePromise,
     (promise) => { markdownModulePromise = promise; }
   );
@@ -88,7 +88,7 @@ function loadMarkdownModule() {
 
 function loadSyntaxHighlightModule() {
   return cacheDynamicImport(
-    () => import('./js/syntax-highlight.js?v=press-system-v3.4.16'),
+    () => import('./js/syntax-highlight.js?v=press-system-v3.4.17'),
     () => syntaxHighlightModulePromise,
     (promise) => { syntaxHighlightModulePromise = promise; }
   );
@@ -96,7 +96,7 @@ function loadSyntaxHighlightModule() {
 
 function loadMathRenderModule() {
   return cacheDynamicImport(
-    () => import('./js/math-render.js?v=press-system-v3.4.16'),
+    () => import('./js/math-render.js?v=press-system-v3.4.17'),
     () => mathRenderModulePromise,
     (promise) => { mathRenderModulePromise = promise; }
   );
@@ -104,7 +104,7 @@ function loadMathRenderModule() {
 
 function loadAnnotateModule() {
   return cacheDynamicImport(
-    () => import('./js/annotate.js?v=press-system-v3.4.16'),
+    () => import('./js/annotate.js?v=press-system-v3.4.17'),
     () => annotateModulePromise,
     (promise) => { annotateModulePromise = promise; }
   );
@@ -112,7 +112,7 @@ function loadAnnotateModule() {
 
 function loadLinkCardsModule() {
   return cacheDynamicImport(
-    () => import('./js/link-cards.js?v=press-system-v3.4.16'),
+    () => import('./js/link-cards.js?v=press-system-v3.4.17'),
     () => linkCardsModulePromise,
     (promise) => { linkCardsModulePromise = promise; }
   );

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.16",
-  "tag": "v3.4.16",
+  "version": "3.4.17",
+  "tag": "v3.4.17",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.15 <3.4.16"
+      ">=3.4.16 <3.4.17"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.15 first."
+    "message": "Update to v3.4.16 first."
   }
 }

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1,16 +1,16 @@
 import { installLightbox } from '../../../js/lightbox.js';
 import { sanitizeImageUrl, setSafeHtml } from '../../../js/safe-html.js';
 import { slugifyTab, escapeHtml, getQueryVariable, renderTags, cardImageSrc, fallbackCover, formatDisplayDate, formatBytes, renderSkeletonArticle } from '../../../js/utils.js';
-import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.16';
+import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.17';
 import { prefersReducedMotion, getArticleTitleFromMain } from '../../../js/dom-utils.js';
-import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.16';
-import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.16';
-import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.16';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.17';
+import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.17';
+import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.17';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
 import { applyLangHints } from '../../../js/typography.js';
 import { renderPressPostCardHtml } from '../../../js/post-card-html.js';
-import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.16';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.16';
+import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.17';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.17';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
@@ -21,7 +21,7 @@ let nativeLinkCardsModulePromise = null;
 
 function loadNativeLinkCardsModule() {
   if (!nativeLinkCardsModulePromise) {
-    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.16').catch((err) => {
+    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.17').catch((err) => {
       nativeLinkCardsModulePromise = null;
       throw err;
     });

--- a/assets/themes/native/theme.css
+++ b/assets/themes/native/theme.css
@@ -1,7 +1,7 @@
 /* Native theme pack - 原生 */
 /* Load base layout styles that used to live in assets/styles.css so the native theme
    owns all presentation concerns. */
-@import "./base.css?v=press-system-v3.4.16";
+@import "./base.css?v=press-system-v3.4.17";
 
 :root {
   /* 极简色彩 - 浅色模式 */

--- a/index.html
+++ b/index.html
@@ -69,11 +69,11 @@
       }
     }
   </style>
-  <script src="assets/js/theme-boot.js?v=press-system-v3.4.16"></script>
+  <script src="assets/js/theme-boot.js?v=press-system-v3.4.17"></script>
   <link rel="stylesheet" id="theme-pack">
 </head>
 <body>
   <div id="press-boot-progress" aria-hidden="true"><span></span></div>
-  <script type="module" src="assets/main.js?v=press-system-v3.4.16"></script>
+  <script type="module" src="assets/main.js?v=press-system-v3.4.17"></script>
 </body>
 </html>

--- a/index_editor.html
+++ b/index_editor.html
@@ -18,7 +18,7 @@
       } catch (_) { /* ignore */ }
     })();
   </script>
-  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.16" data-editor-native-theme>
+  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.17" data-editor-native-theme>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     html { height: 100%; }
@@ -2587,9 +2587,9 @@
       updateOffset();
     })();
   </script>
-  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.16"></script>
-  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.16"></script>
-  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.16"></script>
+  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.17"></script>
+  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.17"></script>
+  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.17"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/index_editor_preview.html
+++ b/index_editor_preview.html
@@ -13,6 +13,6 @@
 </head>
 <body>
   <div class="editor-preview-status" id="editorPreviewStatus">Loading preview...</div>
-  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.16"></script>
+  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.17"></script>
 </body>
 </html>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -2,9 +2,14 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { createPublishSettingsStore } from '../assets/js/publish/settings-store.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const composerPath = resolve(here, '../assets/js/composer.js');
+const publishSettingsPath = resolve(here, '../assets/js/publish/settings-store.js');
+const connectTransportPath = resolve(here, '../assets/js/publish/transports/connect-transport.js');
+const patTransportPath = resolve(here, '../assets/js/publish/transports/github-pat-transport.js');
+const propagationWatcherPath = resolve(here, '../assets/js/publish/propagation-watcher.js');
 const mainPath = resolve(here, '../assets/main.js');
 const hiEditorPath = resolve(here, '../assets/js/hieditor.js');
 const editorMainPath = resolve(here, '../assets/js/editor-main.js');
@@ -21,6 +26,10 @@ const jaI18nPath = resolve(here, '../assets/i18n/ja.js');
 const languagesManifestPath = resolve(here, '../assets/i18n/languages.json');
 const i18nPath = resolve(here, '../assets/js/i18n.js');
 const source = readFileSync(composerPath, 'utf8');
+const publishSettingsSource = readFileSync(publishSettingsPath, 'utf8');
+const connectTransportSource = readFileSync(connectTransportPath, 'utf8');
+const patTransportSource = readFileSync(patTransportPath, 'utf8');
+const propagationWatcherSource = readFileSync(propagationWatcherPath, 'utf8');
 const mainSource = readFileSync(mainPath, 'utf8');
 const hiEditorSource = readFileSync(hiEditorPath, 'utf8');
 const editorMainSource = readFileSync(editorMainPath, 'utf8');
@@ -242,8 +251,7 @@ assert.match(
   'LS_KEYS.systemTreeExpanded',
   'LS_KEYS.cfile',
   'DRAFT_STORAGE_KEY',
-  'MARKDOWN_DRAFT_STORAGE_KEY',
-  'GITHUB_PAT_STORAGE_KEY'
+  'MARKDOWN_DRAFT_STORAGE_KEY'
 ].forEach((keyName) => {
   assert.match(
     source,
@@ -251,6 +259,38 @@ assert.match(
     `${keyName} should use site-scoped browser storage`
   );
 });
+
+assert.match(
+  publishSettingsSource,
+  /scopeKey[\s\S]*GITHUB_PAT_STORAGE_KEY/,
+  'publish settings store should keep the PAT fallback token site-scoped'
+);
+
+function createMemoryStorage(seed = {}) {
+  const data = new Map(Object.entries(seed));
+  return {
+    getItem: (key) => data.has(key) ? data.get(key) : null,
+    setItem: (key, value) => { data.set(key, String(value)); },
+    removeItem: (key) => { data.delete(key); },
+    dump: () => Object.fromEntries(data.entries())
+  };
+}
+
+{
+  const localStorage = createMemoryStorage({
+    'press_connect_publish_enabled:scope': '0'
+  });
+  const sessionStorage = createMemoryStorage();
+  const store = createPublishSettingsStore({
+    windowRef: { localStorage, sessionStorage },
+    scopeKey: (key) => `${key}:scope`
+  });
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'legacy Connect opt-out should migrate to PAT fallback mode');
+  store.setStoredConnectPublishSettings({ baseUrl: 'http://127.0.0.1:8788' });
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'editing the Connect URL should not silently leave PAT fallback mode');
+  store.setStoredConnectPublishSettings({ enabled: true });
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'connect', 'enabling Connect should persist Connect as the default publish mode');
+}
 
 assert.deepEqual(
   repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/test1/index_editor.html'),
@@ -1898,25 +1938,43 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /function requestConnectPublishGrant\(connect, repo\) \{[\s\S]*window\.open\('', popupName, 'popup,width=520,height=720'\)[\s\S]*link\.referrerPolicy = 'unsafe-url'[\s\S]*link\.click\(\);/,
+  connectTransportSource,
+  /function requestConnectPublishGrant\([\s\S]*windowRef\.open\('', popupName, 'popup,width=520,height=720'\)[\s\S]*link\.referrerPolicy = 'unsafe-url'[\s\S]*link\.click\(\);/,
   'Connect publish authorization should send a full browser Referrer so Connect can bind project Pages paths'
 );
 
 assert.match(
-  source,
-  /async function createConnectPublishCommit\(connect,[\s\S]*fetch\(endpoint\.href, \{[\s\S]*referrerPolicy: 'unsafe-url'[\s\S]*Authorization/,
+  connectTransportSource,
+  /async function createConnectPublishCommit\([\s\S]*fetchImpl\(endpoint\.href, \{[\s\S]*referrerPolicy: 'unsafe-url'[\s\S]*Authorization/,
   'Connect publish POST should send a full browser Referrer so grants stay bound to the editor path'
 );
 
 assert.match(
-  source,
-  /const additions = files\.filter\(\(file\) => !file\.deleted\)[\s\S]*const deletions = files\.filter\(\(file\) => file && file\.deleted\)[\s\S]*if \(deletions\.length\) fileChanges\.deletions = deletions;[\s\S]*fileChanges/,
+  patTransportSource,
+  /const additions = [\s\S]*\.filter\(\(file\) => !file\.deleted\)[\s\S]*const deletions = [\s\S]*\.filter\(\(file\) => file && file\.deleted\)[\s\S]*if \(deletions\.length\) fileChanges\.deletions = deletions;[\s\S]*fileChanges/,
   'GitHub commit payload should include deletions as well as additions'
+);
+
+assert.doesNotMatch(
+  source,
+  /async function githubGraphqlRequest|async function createFineGrainedTokenCommit|async function createConnectPublishCommit|function requestConnectPublishGrant/,
+  'composer should not directly own Connect or GitHub commit transport implementations'
 );
 
 assert.match(
   source,
+  /import\('\.\/publish\/transports\/github-pat-transport\.js\?v=[\w.-]+'\)/,
+  'PAT fallback transport should be loaded only when the user explicitly selects the PAT path'
+);
+
+assert.match(
+  propagationWatcherSource,
+  /export async function waitForRemotePropagation[\s\S]*setCancelHandler\(cancelHandler, true\)[\s\S]*setStatus\('All files confirmed on site\.'\)/,
+  'remote propagation checks should live outside composer behind the publish watcher boundary'
+);
+
+assert.match(
+  propagationWatcherSource,
   /files\.forEach\(\(file\) => \{[\s\S]*unique\.push\(\{ \.\.\.file, path: normalized \}\);[\s\S]*if \(file\.deleted\) \{[\s\S]*resp\.status !== 404 && resp\.status !== 410[\s\S]*ok = checked && !stillExists && !indeterminate;/,
   'remote propagation checks should verify deleted commit entries disappear'
 );
@@ -3287,8 +3345,14 @@ assert.match(
 
 assert.match(
   source,
-  /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
-  'Connect publish settings should use scoped local browser storage with built-in remote presets'
+  /function getMatchingConnectPublishGrant\(connect, repo = getActiveSiteRepoConfig\(\)\) \{[\s\S]*cached\.baseUrl !== connect\.baseUrl[\s\S]*cached\.owner !== repo\.owner \|\| cached\.name !== repo\.name \|\| cached\.branch !== branch[\s\S]*return cached;/,
+  'Connect connected UI should only trust cached grants that match the selected repo, branch, and base URL'
+);
+
+assert.match(
+  publishSettingsSource,
+  /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
+  'Connect publish settings should keep legacy storage compatibility while defaulting to a transport mode key'
 );
 
 assert.match(
@@ -3298,15 +3362,15 @@ assert.match(
 );
 
 assert.match(
-  source,
+  publishSettingsSource,
   /function normalizeConnectPublishBaseUrl\(value\) \{[\s\S]*const url = new URL\(rawBaseUrl\);[\s\S]*url\.protocol !== 'https:' && !\(url\.protocol === 'http:' && isLocalhostHost\(url\.hostname\)\)[\s\S]*return url\.origin;/,
   'Connect publish URL normalization should require absolute HTTPS or localhost HTTP URLs'
 );
 
 assert.match(
-  source,
-  /function resolvePublishTransport\(\) \{[\s\S]*const settings = getConnectPublishSettings\(\);[\s\S]*if \(settings\.enabled\) \{[\s\S]*invalid: true[\s\S]*type: 'connect'[\s\S]*\}\s*return \{\s*type: 'pat'\s*\};/,
-  'Publish transport should use Connect only when browser-local Connect mode is enabled'
+  publishSettingsSource,
+  /mode: 'connect'[\s\S]*const modeRaw = storage\.getItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\)\)[\s\S]*enabledRaw === '0'[\s\S]*mode = 'pat'[\s\S]*function resolvePublishTransport/,
+  'Publish transport should default to Connect while preserving legacy opt-out to PAT fallback'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -4,7 +4,7 @@ import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
 import {
   satisfiesSemverRange,
   setPressSystemManifestForTests
-} from '../assets/js/press-version.js?v=press-system-v3.4.16';
+} from '../assets/js/press-version.js?v=press-system-v3.4.17';
 
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 if (!globalThis.btoa) {


### PR DESCRIPTION
## Summary
- make Connect the default publish transport while preserving PAT as the explicit fallback mode
- move publish settings, Connect grant/publish calls, PAT GraphQL commit logic, and propagation polling out of composer.js
- bump Press system to v3.4.17 and sync runtime cache keys for release packaging

## Review
- subagent architecture/security review: no blocking findings
- subagent release/cache/package review: no blocking findings
- subagent editor UX review plus follow-up grant-state review: no blocking findings

## Tests
- node scripts/sync-runtime-cache-keys.mjs --check
- node --check assets/js/composer.js && node --check assets/js/publish/settings-store.js && node --check assets/js/publish/transports/connect-transport.js && node --check assets/js/publish/transports/github-pat-transport.js && node --check assets/js/publish/propagation-watcher.js
- node scripts/test-composer-identity-grid.js
- node scripts/test-ui-components.js
- node --experimental-default-type=module scripts/test-system-updates.js
- node --experimental-default-type=module scripts/test-theme-manager.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-main-guard.sh
- node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js
- bash scripts/test-frontmatter-roundtrip.sh
- node scripts/test-content-model.js
- cd ../Connect && npm test

## Release impact
- Press system release surface changes and should publish v3.4.17 after merge.
- Connect backend code is unchanged; Connect tests were rerun because this changes the browser-to-Connect publish boundary.