### PR TITLE
Guide Connect failures to PAT fallback

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -826,6 +826,7 @@ const translations = {
             connectInvalidUrl: '请输入有效的 Connect URL。除 localhost 外必须使用 HTTPS。',
             connectFallback: '改用精细化个人访问令牌',
             connectFallbackActive: '本次发布将使用精细化令牌回退方式。',
+            connectFallbackHint: '如果 Connect 不可用或你的账号未获授权，请切换到个人令牌回退方式。',
             connectMissing: '此站点尚未配置 Connect 发布。',
             connectAuthorizing: '正在通过 Connect 授权…',
             connectPublishing: '正在通过 Connect 创建提交…',

--- a/assets/i18n/cht-hk.js
+++ b/assets/i18n/cht-hk.js
@@ -1,4 +1,4 @@
-import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.17';
+import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.18';
 
 export const languageMeta = { label: '繁體中文（香港）' };
 

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -826,6 +826,7 @@ const translations = {
             connectInvalidUrl: '請輸入有效的 Connect URL。除 localhost 外必須使用 HTTPS。',
             connectFallback: '改用精細化個人訪問令牌',
             connectFallbackActive: '本次發布將使用精細化令牌備援方式。',
+            connectFallbackHint: '如果 Connect 無法使用或你的帳號未獲授權，請切換到個人令牌備援方式。',
             connectMissing: '此站點尚未設定 Connect 發布。',
             connectAuthorizing: '正在透過 Connect 授權…',
             connectPublishing: '正在透過 Connect 建立提交…',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -833,6 +833,7 @@ const translations = {
             connectInvalidUrl: 'Enter a valid Connect URL. HTTPS is required unless the host is localhost.',
             connectFallback: 'Use a Fine-grained Personal Access Token instead',
             connectFallbackActive: 'Fine-grained token fallback is active for this publish.',
+            connectFallbackHint: 'If Connect is unavailable or your account is not authorized, switch to the personal token fallback.',
             connectMissing: 'Connect publishing is not configured for this site.',
             connectAuthorizing: 'Authorizing with Connect…',
             connectPublishing: 'Creating commit through Connect…',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -826,6 +826,7 @@ const translations = {
             connectInvalidUrl: '有効な Connect URL を入力してください。localhost 以外では HTTPS が必要です。',
             connectFallback: '代わりにファイングレインド Personal Access Token を使用',
             connectFallbackActive: 'この公開ではファイングレインドトークンのフォールバックが有効です。',
+            connectFallbackHint: 'Connect が利用できない、またはアカウントが認可されていない場合は、Personal Token フォールバックに切り替えてください。',
             connectMissing: 'このサイトでは Connect 公開が設定されていません。',
             connectAuthorizing: 'Connect で認可しています…',
             connectPublishing: 'Connect 経由でコミットを作成しています…',

--- a/assets/i18n/languages.json
+++ b/assets/i18n/languages.json
@@ -1,7 +1,7 @@
 [
-  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.17" },
-  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.17" },
-  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.17" },
-  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.17" },
-  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.17" }
+  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.18" },
+  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.18" },
+  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.18" },
+  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.18" },
+  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.18" }
 ]

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1829,8 +1829,13 @@ function setConnectPublishBaseUrl(baseUrl) {
   });
 }
 
+function getVisibleFineGrainedTokenInput() {
+  const inputs = Array.from(document.querySelectorAll('#syncGithubTokenInput'));
+  return inputs.find(input => input && input.offsetParent !== null) || inputs[0] || null;
+}
+
 function focusFineGrainedTokenInput() {
-  const input = document.getElementById('syncGithubTokenInput');
+  const input = getVisibleFineGrainedTokenInput();
   if (!input || typeof input.focus !== 'function') return false;
   try { input.focus({ preventScroll: true }); }
   catch (_) { input.focus(); }
@@ -1855,9 +1860,11 @@ function updatePublishTransportSettingsDomForPatFallback() {
 function openComposerSettingsForPatFallback() {
   try {
     applyMode('composer', { preserveTreeExpansion: true });
+    try { applyComposerFile('site', { force: true, immediate: true }); } catch (_) {}
     return;
   } catch (_) {}
   try { showEditorSystemPanel('composer'); } catch (_) {}
+  try { applyComposerFile('site', { force: true, immediate: true }); } catch (_) {}
 }
 
 function switchToPatFallbackAndFocusToken() {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1789,7 +1789,7 @@ function clearCachedFineGrainedToken() {
 }
 
 function getFineGrainedTokenValue() {
-  const input = document.getElementById('syncGithubTokenInput');
+  const input = getVisibleFineGrainedTokenInput();
   const value = input && typeof input.value === 'string' ? input.value.trim() : '';
   return value || getCachedFineGrainedToken();
 }
@@ -1857,24 +1857,28 @@ function updatePublishTransportSettingsDomForPatFallback() {
   if (patPanel) patPanel.hidden = false;
 }
 
-function openComposerSettingsForPatFallback() {
+function openSyncPanelForPatFallback() {
   try {
-    applyMode('composer', { preserveTreeExpansion: true });
-    try { applyComposerFile('site', { force: true, immediate: true }); } catch (_) {}
+    applyMode('sync', { preserveTreeExpansion: true });
     return;
   } catch (_) {}
-  try { showEditorSystemPanel('composer'); } catch (_) {}
-  try { applyComposerFile('site', { force: true, immediate: true }); } catch (_) {}
+  try { showEditorSystemPanel('sync'); } catch (_) {}
 }
 
 function switchToPatFallbackAndFocusToken() {
   setConnectPublishEnabled(false);
-  openComposerSettingsForPatFallback();
+  openSyncPanelForPatFallback();
   updatePublishTransportSettingsDomForPatFallback();
-  scheduleSyncCommitPanelRefresh();
+  try {
+    const refresh = refreshSyncCommitPanel({ focusToken: true });
+    if (refresh && typeof refresh.then === 'function') refresh.then(
+      () => focusFineGrainedTokenInput(),
+      () => focusFineGrainedTokenInput()
+    );
+  } catch (_) {}
   const focusLater = () => {
     if (focusFineGrainedTokenInput()) return;
-    openComposerSettingsForPatFallback();
+    openSyncPanelForPatFallback();
     updatePublishTransportSettingsDomForPatFallback();
     focusFineGrainedTokenInput();
   };
@@ -6580,6 +6584,9 @@ async function refreshSyncCommitPanel(options = {}) {
   const summaryBlock = document.createElement('div');
   summaryBlock.className = 'sync-commit-summary';
   appendPublishTransportStatus(form);
+  if (resolvePublishTransport().type === 'pat') {
+    renderFineGrainedTokenSettings(form);
+  }
   appendGithubCommitSummary(summaryBlock, commitFiles, seoFiles, summaryEntries);
   form.appendChild(summaryBlock);
 
@@ -6619,7 +6626,7 @@ async function refreshSyncCommitPanel(options = {}) {
     }
     const transport = resolvePublishTransport();
     if (transport.type === 'pat') {
-      const input = document.getElementById('syncGithubTokenInput');
+      const input = getVisibleFineGrainedTokenInput();
       const value = getFineGrainedTokenValue();
       if (!value) {
         showError(t('editor.composer.github.modal.errorRequired'));
@@ -6664,13 +6671,9 @@ async function refreshSyncCommitPanel(options = {}) {
   });
 
   if (options.focusToken) {
-    const input = document.getElementById('syncGithubTokenInput');
-    if (input && input.offsetParent) {
-      try { input.focus({ preventScroll: true }); }
-      catch (_) { input.focus(); }
-    }
+    focusFineGrainedTokenInput();
   }
-  return { panel, input: document.getElementById('syncGithubTokenInput'), form };
+  return { panel, input: getVisibleFineGrainedTokenInput(), form };
 }
 
 function scheduleSyncCommitPanelRefresh() {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1834,6 +1834,19 @@ function getVisibleFineGrainedTokenInput() {
   return inputs.find(input => input && input.offsetParent !== null) || inputs[0] || null;
 }
 
+function syncFineGrainedTokenInputs(value, sourceInput = null) {
+  const nextValue = typeof value === 'string' ? value : '';
+  document.querySelectorAll('#syncGithubTokenInput').forEach(input => {
+    if (input !== sourceInput) input.value = nextValue;
+    const wrapper = input.closest ? input.closest('.cs-token-settings') : null;
+    const clear = wrapper && wrapper.querySelector ? wrapper.querySelector('.cs-token-clear') : null;
+    if (!clear) return;
+    const hasValue = !!String(input.value || '').trim();
+    clear.setAttribute('aria-disabled', hasValue ? 'false' : 'true');
+    clear.tabIndex = hasValue ? 0 : -1;
+  });
+}
+
 function focusFineGrainedTokenInput() {
   const input = getVisibleFineGrainedTokenInput();
   if (!input || typeof input.focus !== 'function') return false;
@@ -1956,17 +1969,13 @@ function renderFineGrainedTokenSettings(host) {
 
   input.addEventListener('input', () => {
     setCachedFineGrainedToken(input.value);
-    const hasValue = !!String(input.value || '').trim();
-    btnForget.setAttribute('aria-disabled', hasValue ? 'false' : 'true');
-    btnForget.tabIndex = hasValue ? 0 : -1;
+    syncFineGrainedTokenInputs(input.value, input);
   });
 
   const clearToken = () => {
     if (btnForget.getAttribute('aria-disabled') === 'true') return;
     clearCachedFineGrainedToken();
-    input.value = '';
-    btnForget.setAttribute('aria-disabled', 'true');
-    btnForget.tabIndex = -1;
+    syncFineGrainedTokenInputs('');
     try { input.focus({ preventScroll: true }); }
     catch (_) { input.focus(); }
   };

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1883,11 +1883,9 @@ function switchToPatFallbackAndFocusToken() {
   openSyncPanelForPatFallback();
   updatePublishTransportSettingsDomForPatFallback();
   try {
-    const refresh = refreshSyncCommitPanel({ focusToken: true });
-    if (refresh && typeof refresh.then === 'function') refresh.then(
-      () => focusFineGrainedTokenInput(),
-      () => focusFineGrainedTokenInput()
-    );
+    refreshSyncCommitPanel({ focusToken: true })
+      .then(() => focusFineGrainedTokenInput())
+      .catch(() => focusFineGrainedTokenInput());
   } catch (_) {}
   const focusLater = () => {
     if (focusFineGrainedTokenInput()) return;

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8,35 +8,35 @@ import {
   resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.17';
-import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.17';
-import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.17';
-import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.17';
-import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.17';
+import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.18';
+import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.18';
+import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.18';
+import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.18';
+import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.18';
 import { computeReadTime, extractExcerpt, parseFrontMatter } from './content.js';
 import {
   decryptMarkdownDocument,
   encryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope
-} from './encrypted-content.js?v=press-system-v3.4.17';
+} from './encrypted-content.js?v=press-system-v3.4.18';
 import {
   collectLocalMarkdownAssetReferences,
   collectManagedMarkdownReferences,
   listLocalMarkdownAssetReferences,
   planManagedContentDeletions,
   resolveLocalMarkdownAssetReference
-} from './repository-deletions.js?v=press-system-v3.4.17';
+} from './repository-deletions.js?v=press-system-v3.4.18';
 import {
   CONNECT_PUBLISH_PRESETS,
   createPublishSettingsStore,
   getDefaultConnectPublishBaseUrl,
   normalizeConnectPublishBaseUrl
-} from './publish/settings-store.js?v=press-system-v3.4.17';
+} from './publish/settings-store.js?v=press-system-v3.4.18';
 import {
   createConnectPublishCommit,
   ensureConnectPublishGrant as authorizeConnectPublishGrant
-} from './publish/transports/connect-transport.js?v=press-system-v3.4.17';
-import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.17';
+} from './publish/transports/connect-transport.js?v=press-system-v3.4.18';
+import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.18';
 
 // Utility helpers
 const $ = (s, r = document) => r.querySelector(s);
@@ -1827,6 +1827,56 @@ function setConnectPublishBaseUrl(baseUrl) {
     ...getStoredConnectPublishSettings(),
     baseUrl
   });
+}
+
+function focusFineGrainedTokenInput() {
+  const input = document.getElementById('syncGithubTokenInput');
+  if (!input || typeof input.focus !== 'function') return false;
+  try { input.focus({ preventScroll: true }); }
+  catch (_) { input.focus(); }
+  return true;
+}
+
+function updatePublishTransportSettingsDomForPatFallback() {
+  const enabledInput = document.getElementById('syncConnectPublishEnabledInput');
+  if (!enabledInput) return;
+  enabledInput.checked = false;
+  const method = enabledInput.closest ? enabledInput.closest('.cs-publish-method-switch') : null;
+  if (method) method.dataset.state = 'off';
+  const methodText = method && method.querySelector ? method.querySelector('.cs-switch-label') : null;
+  if (methodText) methodText.textContent = t('editor.composer.github.modal.publishMethodPat');
+  const wrapper = enabledInput.closest ? enabledInput.closest('.cs-publish-transport-settings') : null;
+  const connectPanel = wrapper && wrapper.querySelector ? wrapper.querySelector('.cs-connect-publish-settings') : null;
+  const patPanel = wrapper && wrapper.querySelector ? wrapper.querySelector('.cs-pat-publish-settings') : null;
+  if (connectPanel) connectPanel.hidden = true;
+  if (patPanel) patPanel.hidden = false;
+}
+
+function openComposerSettingsForPatFallback() {
+  try {
+    applyMode('composer', { preserveTreeExpansion: true });
+    return;
+  } catch (_) {}
+  try { showEditorSystemPanel('composer'); } catch (_) {}
+}
+
+function switchToPatFallbackAndFocusToken() {
+  setConnectPublishEnabled(false);
+  openComposerSettingsForPatFallback();
+  updatePublishTransportSettingsDomForPatFallback();
+  scheduleSyncCommitPanelRefresh();
+  const focusLater = () => {
+    if (focusFineGrainedTokenInput()) return;
+    openComposerSettingsForPatFallback();
+    updatePublishTransportSettingsDomForPatFallback();
+    focusFineGrainedTokenInput();
+  };
+  try {
+    requestAnimationFrame(() => requestAnimationFrame(focusLater));
+  } catch (_) {
+    setTimeout(focusLater, 0);
+  }
+  setTimeout(focusLater, 120);
 }
 
 function getCachedConnectPublishGrant() {
@@ -5763,11 +5813,11 @@ function buildDefaultIndexHtml(metaBlock, lang) {
   html += '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n\n';
   html += metaSection;
   html += '  <!-- Note: Structured data is dynamically generated by the SEO system -->\n\n';
-  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.17"></script>\n';
+  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.18"></script>\n';
   html += '  <link rel="stylesheet" id="theme-pack">\n';
   html += '</head>\n\n';
   html += '<body>\n';
-  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.17"></script>\n';
+  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.18"></script>\n';
   html += '</body>\n\n';
   html += '</html>\n';
   return html;
@@ -6509,7 +6559,7 @@ async function refreshSyncCommitPanel(options = {}) {
   form.className = 'sync-commit-form comp-guide';
   form.setAttribute('novalidate', 'novalidate');
 
-  const errorText = document.createElement('p');
+  const errorText = document.createElement('div');
   errorText.className = 'sync-commit-error';
   errorText.hidden = true;
   form.appendChild(errorText);
@@ -6528,8 +6578,26 @@ async function refreshSyncCommitPanel(options = {}) {
 
   panel.appendChild(form);
 
-  const showError = (message) => {
-    errorText.textContent = message;
+  const showError = (message, options = {}) => {
+    errorText.textContent = '';
+    const text = document.createElement('span');
+    text.className = 'sync-commit-error-text';
+    text.textContent = message;
+    errorText.appendChild(text);
+    if (options && options.connectFallback) {
+      const hint = document.createElement('span');
+      hint.className = 'sync-commit-error-hint';
+      hint.textContent = t('editor.composer.github.modal.connectFallbackHint');
+      const action = document.createElement('button');
+      action.type = 'button';
+      action.className = 'btn-tertiary sync-connect-fallback-action';
+      action.textContent = t('editor.composer.github.modal.connectFallback');
+      action.addEventListener('click', () => {
+        errorText.hidden = true;
+        switchToPatFallbackAndFocusToken();
+      });
+      errorText.append(hint, action);
+    }
     errorText.hidden = false;
   };
 
@@ -6569,7 +6637,9 @@ async function refreshSyncCommitPanel(options = {}) {
       try {
         await ensureConnectPublishGrant(transport.connect, getActiveSiteRepoConfig());
       } catch (err) {
-        showError(err && err.message ? err.message : t('editor.composer.github.modal.connectAuthorizationFailed'));
+        showError(err && err.message ? err.message : t('editor.composer.github.modal.connectAuthorizationFailed'), {
+          connectFallback: true
+        });
         return;
       }
     }
@@ -6813,6 +6883,7 @@ async function performPublishCommit(transport, summaryEntries = []) {
     cancelable: false
   });
 
+  let connectFallbackActionAvailable = false;
   try {
     const { files } = await gatherCommitPayload({ showSeoStatus: true });
     if (!files.length) {
@@ -6824,6 +6895,7 @@ async function performPublishCommit(transport, summaryEntries = []) {
     const headline = `chore: sync ${files.length === 1 ? 'draft' : 'drafts'} via Press`;
     if (transport && transport.type === 'connect') {
       setSyncOverlayStatus(t('editor.composer.github.modal.connectAuthorizing'));
+      connectFallbackActionAvailable = true;
       const grant = await ensureConnectPublishGrant(transport.connect, { owner, name, branch });
       setSyncOverlayStatus(t('editor.composer.github.modal.connectPublishing'));
       await createConnectPublishCommit({
@@ -6835,8 +6907,9 @@ async function performPublishCommit(transport, summaryEntries = []) {
         contentRoot: getTrackedPublishContentRoot(),
         translate: t
       });
+      connectFallbackActionAvailable = false;
     } else {
-      const { createFineGrainedTokenCommit } = await import('./publish/transports/github-pat-transport.js?v=press-system-v3.4.17');
+      const { createFineGrainedTokenCommit } = await import('./publish/transports/github-pat-transport.js?v=press-system-v3.4.18');
       await createFineGrainedTokenCommit(transport && transport.token, {
         owner,
         name,
@@ -6875,7 +6948,18 @@ async function performPublishCommit(transport, summaryEntries = []) {
       }
     }
     console.error('Press GitHub commit failed', err);
-    showToast('error', message, { duration: 5200 });
+    const toastOptions = { duration: 5200 };
+    if (transport && transport.type === 'connect' && connectFallbackActionAvailable) {
+      toastOptions.duration = 9000;
+      toastOptions.action = {
+        label: t('editor.composer.github.modal.connectFallback'),
+        onClick: (event) => {
+          if (event && typeof event.preventDefault === 'function') event.preventDefault();
+          switchToPatFallbackAndFocusToken();
+        }
+      };
+    }
+    showToast('error', message, toastOptions);
   } finally {
     gitHubCommitInFlight = false;
   }

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,4 +1,4 @@
-import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.17';
+import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.18';
 
 // Helpers for generating excerpts/snippets from markdown
 export function stripMarkdownToText(md) {

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -1,5 +1,5 @@
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
-import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.17';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.18';
+import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.18';
 
 const BLOCK_TYPES = new Set(['paragraph', 'heading', 'image', 'list', 'quote', 'code', 'math', 'card', 'table', 'source', 'blank']);
 const CODE_LANGUAGE_OPTIONS = [

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.17';
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.18';
 
 function applyAttributeTranslation(el, target, value) {
   if (value == null) return;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,6 +1,6 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.17';
-import { createHiEditor } from './hieditor.js?v=press-system-v3.4.17';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.18';
+import { createHiEditor } from './hieditor.js?v=press-system-v3.4.18';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
 import {
   FRONT_MATTER_FIELD_DEFS,
@@ -10,12 +10,12 @@ import {
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings,
   valueIsPresent
-} from './frontmatter-document.js?v=press-system-v3.4.17';
-import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.17';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.17';
+} from './frontmatter-document.js?v=press-system-v3.4.18';
+import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.18';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.18';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.17';
-import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.17';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.18';
+import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.18';
 
 const LS_WRAP_KEY = 'press_editor_wrap_enabled';
 const LS_VIEW_KEY = 'press_editor_markdown_view_v2';

--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -1,25 +1,25 @@
 import './components.js';
-import { mdParse } from './markdown.js?v=press-system-v3.4.17';
+import { mdParse } from './markdown.js?v=press-system-v3.4.18';
 import { createContentModel } from './content-model.js';
 import { parseFrontMatter } from './content.js';
-import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.17';
+import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.18';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from './post-render.js';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.17';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.18';
 import { applyLangHints } from './typography.js';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
-import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.17';
-import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.17';
-import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.17';
-import { renderPostNav } from './post-nav.js?v=press-system-v3.4.17';
-import { renderTagSidebar } from './tags.js?v=press-system-v3.4.17';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.18';
+import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.18';
+import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.18';
+import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.18';
+import { renderPostNav } from './post-nav.js?v=press-system-v3.4.18';
+import { renderTagSidebar } from './tags.js?v=press-system-v3.4.18';
 import { getArticleTitleFromMain } from './dom-utils.js';
-import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.17';
+import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.18';
 
 const RENDER_MESSAGE = 'press-editor-preview-render';
 const READY_MESSAGE = 'press-editor-preview-ready';
 const RENDERED_MESSAGE = 'press-editor-preview-rendered';
 const ERROR_MESSAGE = 'press-editor-preview-error';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.18';
 
 let activePack = '';
 let latestRenderRequestId = 0;

--- a/assets/js/encrypted-content.js
+++ b/assets/js/encrypted-content.js
@@ -3,7 +3,7 @@ import {
   cloneFrontMatterData,
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings
-} from './frontmatter-document.js?v=press-system-v3.4.17';
+} from './frontmatter-document.js?v=press-system-v3.4.18';
 
 export const ENCRYPTED_MARKDOWN_FORMAT = 'press-encrypted-markdown-v1';
 export const ENCRYPTED_MARKDOWN_FENCE = 'press-encrypted-markdown-v1';

--- a/assets/js/errors.js
+++ b/assets/js/errors.js
@@ -1,5 +1,5 @@
 // errors.js — lightweight global error overlay and reporter
-import { t } from './i18n.js?v=press-system-v3.4.17';
+import { t } from './i18n.js?v=press-system-v3.4.18';
 
 let reporterConfig = {
   reportUrl: null,

--- a/assets/js/hieditor.js
+++ b/assets/js/hieditor.js
@@ -1,4 +1,4 @@
-import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.17';
+import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.18';
 
 function escapeHtmlInline(text) {
   if (!text) return '';

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -10,11 +10,11 @@
 // - Friendly language names come from assets/i18n/languages.json (or the language module's metadata).
 
 import { parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.17';
+import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.18';
 import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 import { getThemeRegion } from './theme-regions.js';
-import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.17';
+import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.18';
 
 // Content fetch cache modes are normalized by cache-control.js.
 

--- a/assets/js/link-cards.js
+++ b/assets/js/link-cards.js
@@ -1,6 +1,6 @@
 import { renderTags, escapeHtml, formatDisplayDate, cardImageSrc, fallbackCover, getContentRoot } from './utils.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.17';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.18';
 import { hydrateCardCovers } from './post-render.js';
 
 const DEFAULT_STRINGS = {

--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,4 +1,4 @@
-import { withLangParam, t } from './i18n.js?v=press-system-v3.4.17';
+import { withLangParam, t } from './i18n.js?v=press-system-v3.4.18';
 import { escapeHtml } from './utils.js';
 
 export function renderPostNav(container, postsIndex, postname) {

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -1,4 +1,4 @@
-import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js?v=press-system-v3.4.17';
+import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js?v=press-system-v3.4.18';
 
 export function serializeConnectPublishFile(file) {
   const out = {

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,8 +1,8 @@
 // seo.js - Dynamic SEO meta tag management for client-side routing
 // This maintains SEO benefits while keeping the "no compilation needed" philosophy
 
-import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.17';
-import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.17';
+import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.18';
+import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.18';
 import { parseFrontMatter } from './content.js';
 
 function ensureTrailingSlash(value) {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,7 +1,7 @@
-import { mdParse } from './markdown.js?v=press-system-v3.4.17';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.17';
-import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.17';
-import { t } from './i18n.js?v=press-system-v3.4.17';
+import { mdParse } from './markdown.js?v=press-system-v3.4.18';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.18';
+import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.18';
+import { t } from './i18n.js?v=press-system-v3.4.18';
 import {
   compareSemver,
   isUpgradeAllowed,
@@ -10,7 +10,7 @@ import {
   normalizeSemver,
   normalizeUpgradeFrom,
   semverToTag
-} from './press-version.js?v=press-system-v3.4.17';
+} from './press-version.js?v=press-system-v3.4.18';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([

--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -1,5 +1,5 @@
 // Tag utilities: aggregation, rendering (collapsible), and tooltips for truncated tags
-import { t, withLangParam } from './i18n.js?v=press-system-v3.4.17';
+import { t, withLangParam } from './i18n.js?v=press-system-v3.4.18';
 import { getThemeRegion } from './theme-regions.js';
 import { getQueryVariable, escapeHtml } from './utils.js';
 

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,5 +1,5 @@
 // Template renderers (pure functions returning HTML strings)
-import { t } from './i18n.js?v=press-system-v3.4.17';
+import { t } from './i18n.js?v=press-system-v3.4.18';
 import { computeReadTime } from './content.js';
 import { escapeHtml, renderTags, formatDisplayDate } from './utils.js';
 

--- a/assets/js/theme-boot.js
+++ b/assets/js/theme-boot.js
@@ -18,7 +18,7 @@
     pack = String(pack || '').toLowerCase().trim().replace(/[^a-z0-9_-]/g, '') || 'native';
   } catch (_) { pack = 'native'; }
   if (pack !== 'native') return;
-  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.17';
+  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.18';
   window.__themePackHref = href;
 
   // If the link tag exists already, set it; otherwise try briefly until it does

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -4,7 +4,7 @@ import {
   getRequestedThemePack,
   setThemePackStylesheet,
   suppressThemePack
-} from './theme.js?v=press-system-v3.4.17';
+} from './theme.js?v=press-system-v3.4.18';
 import {
   t,
   withLangParam,
@@ -13,7 +13,7 @@ import {
   ensureLanguageBundle,
   getAvailableLangs,
   getLanguageLabel
-} from './i18n.js?v=press-system-v3.4.17';
+} from './i18n.js?v=press-system-v3.4.18';
 import {
   createThemeRegionRegistry,
   ensureThemeRegionRegistry,
@@ -29,8 +29,8 @@ let layoutMountGeneration = 0;
 
 const DEFAULT_PACK = 'native';
 const CONTRACT_VERSION = 1;
-const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.17';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
+const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.18';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.18';
 
 const EFFECT_VIEW_NAMES = {
   renderPostView: 'post',

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,5 +1,5 @@
-import { t } from './i18n.js?v=press-system-v3.4.17';
-import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.17';
+import { t } from './i18n.js?v=press-system-v3.4.18';
+import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.18';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,10 +1,10 @@
-import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.17';
+import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.18';
 import { getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';
 const THEME_CONTROLS_BOUND = Symbol('pressThemeControlsBound');
 const THEME_CONTROLS_I18N_BOUND = Symbol('pressThemeControlsI18nBound');
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.17';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.18';
 const THEME_PACK_KEY = 'themePack';
 const THEME_PACK_PENDING_KEY = 'themePackPending';
 const suppressedThemePacks = new Set();

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=press-system-v3.4.17';
+import { t } from './i18n.js?v=press-system-v3.4.18';
 import { getThemeRegion } from './theme-regions.js';
 
 // Anchors and Table of Contents enhancements

--- a/assets/main.js
+++ b/assets/main.js
@@ -5,13 +5,13 @@ import {
   decryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope,
   stripEncryptedBodyForPublicUse
-} from './js/encrypted-content.js?v=press-system-v3.4.17';
-import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.17';
-import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.17';
-import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.17';
+} from './js/encrypted-content.js?v=press-system-v3.4.18';
+import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.18';
+import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.18';
+import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.18';
 import { setupSearch } from './js/search.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './js/content.js';
-import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.17';
+import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.18';
 import { getQueryVariable, setDocTitle, setBaseSiteTitle, slugifyTab, isModifiedClick } from './js/utils.js';
 import {
   initI18n,
@@ -23,13 +23,13 @@ import {
   getCurrentLang,
   normalizeLangKey,
   POSTS_METADATA_READY_EVENT
-} from './js/i18n.js?v=press-system-v3.4.17';
-import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.17';
-import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.17';
+} from './js/i18n.js?v=press-system-v3.4.18';
+import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.18';
+import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.18';
 import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
-import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.17';
-import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.17';
+import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.18';
+import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.18';
 import { getArticleTitleFromMain } from './js/dom-utils.js';
 import { applyLangHints } from './js/typography.js';
 
@@ -80,7 +80,7 @@ function cacheDynamicImport(importer, getCached, setCached) {
 
 function loadMarkdownModule() {
   return cacheDynamicImport(
-    () => import('./js/markdown.js?v=press-system-v3.4.17'),
+    () => import('./js/markdown.js?v=press-system-v3.4.18'),
     () => markdownModulePromise,
     (promise) => { markdownModulePromise = promise; }
   );
@@ -88,7 +88,7 @@ function loadMarkdownModule() {
 
 function loadSyntaxHighlightModule() {
   return cacheDynamicImport(
-    () => import('./js/syntax-highlight.js?v=press-system-v3.4.17'),
+    () => import('./js/syntax-highlight.js?v=press-system-v3.4.18'),
     () => syntaxHighlightModulePromise,
     (promise) => { syntaxHighlightModulePromise = promise; }
   );
@@ -96,7 +96,7 @@ function loadSyntaxHighlightModule() {
 
 function loadMathRenderModule() {
   return cacheDynamicImport(
-    () => import('./js/math-render.js?v=press-system-v3.4.17'),
+    () => import('./js/math-render.js?v=press-system-v3.4.18'),
     () => mathRenderModulePromise,
     (promise) => { mathRenderModulePromise = promise; }
   );
@@ -104,7 +104,7 @@ function loadMathRenderModule() {
 
 function loadAnnotateModule() {
   return cacheDynamicImport(
-    () => import('./js/annotate.js?v=press-system-v3.4.17'),
+    () => import('./js/annotate.js?v=press-system-v3.4.18'),
     () => annotateModulePromise,
     (promise) => { annotateModulePromise = promise; }
   );
@@ -112,7 +112,7 @@ function loadAnnotateModule() {
 
 function loadLinkCardsModule() {
   return cacheDynamicImport(
-    () => import('./js/link-cards.js?v=press-system-v3.4.17'),
+    () => import('./js/link-cards.js?v=press-system-v3.4.18'),
     () => linkCardsModulePromise,
     (promise) => { linkCardsModulePromise = promise; }
   );

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.17",
-  "tag": "v3.4.17",
+  "version": "3.4.18",
+  "tag": "v3.4.18",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.16 <3.4.17"
+      ">=3.4.17 <3.4.18"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.16 first."
+    "message": "Update to v3.4.17 first."
   }
 }

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1,16 +1,16 @@
 import { installLightbox } from '../../../js/lightbox.js';
 import { sanitizeImageUrl, setSafeHtml } from '../../../js/safe-html.js';
 import { slugifyTab, escapeHtml, getQueryVariable, renderTags, cardImageSrc, fallbackCover, formatDisplayDate, formatBytes, renderSkeletonArticle } from '../../../js/utils.js';
-import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.17';
+import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.18';
 import { prefersReducedMotion, getArticleTitleFromMain } from '../../../js/dom-utils.js';
-import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.17';
-import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.17';
-import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.17';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.18';
+import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.18';
+import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.18';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
 import { applyLangHints } from '../../../js/typography.js';
 import { renderPressPostCardHtml } from '../../../js/post-card-html.js';
-import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.17';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.17';
+import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.18';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.18';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
@@ -21,7 +21,7 @@ let nativeLinkCardsModulePromise = null;
 
 function loadNativeLinkCardsModule() {
   if (!nativeLinkCardsModulePromise) {
-    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.17').catch((err) => {
+    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.18').catch((err) => {
       nativeLinkCardsModulePromise = null;
       throw err;
     });

--- a/assets/themes/native/theme.css
+++ b/assets/themes/native/theme.css
@@ -1,7 +1,7 @@
 /* Native theme pack - 原生 */
 /* Load base layout styles that used to live in assets/styles.css so the native theme
    owns all presentation concerns. */
-@import "./base.css?v=press-system-v3.4.17";
+@import "./base.css?v=press-system-v3.4.18";
 
 :root {
   /* 极简色彩 - 浅色模式 */

--- a/index.html
+++ b/index.html
@@ -69,11 +69,11 @@
       }
     }
   </style>
-  <script src="assets/js/theme-boot.js?v=press-system-v3.4.17"></script>
+  <script src="assets/js/theme-boot.js?v=press-system-v3.4.18"></script>
   <link rel="stylesheet" id="theme-pack">
 </head>
 <body>
   <div id="press-boot-progress" aria-hidden="true"><span></span></div>
-  <script type="module" src="assets/main.js?v=press-system-v3.4.17"></script>
+  <script type="module" src="assets/main.js?v=press-system-v3.4.18"></script>
 </body>
 </html>

--- a/index_editor.html
+++ b/index_editor.html
@@ -468,6 +468,9 @@
       gap:.55rem;
       flex-wrap:wrap;
     }
+    .sync-commit-error[hidden] {
+      display:none !important;
+    }
     .sync-commit-error-text {
       flex:1 1 220px;
     }

--- a/index_editor.html
+++ b/index_editor.html
@@ -18,7 +18,7 @@
       } catch (_) { /* ignore */ }
     })();
   </script>
-  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.17" data-editor-native-theme>
+  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.18" data-editor-native-theme>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     html { height: 100%; }
@@ -463,6 +463,21 @@
       color:#dc2626;
       font-size:.88rem;
       line-height:1.4;
+      display:flex;
+      align-items:center;
+      gap:.55rem;
+      flex-wrap:wrap;
+    }
+    .sync-commit-error-text {
+      flex:1 1 220px;
+    }
+    .sync-commit-error-hint {
+      color:color-mix(in srgb, #dc2626 76%, var(--muted));
+    }
+    .sync-connect-fallback-action {
+      flex:0 0 auto;
+      border-color:color-mix(in srgb, #dc2626 28%, var(--border));
+      color:color-mix(in srgb, #dc2626 82%, var(--text));
     }
     .sync-commit-actions {
       display:flex;
@@ -2587,9 +2602,9 @@
       updateOffset();
     })();
   </script>
-  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.17"></script>
-  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.17"></script>
-  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.17"></script>
+  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.18"></script>
+  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.18"></script>
+  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.18"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/index_editor_preview.html
+++ b/index_editor_preview.html
@@ -13,6 +13,6 @@
 </head>
 <body>
   <div class="editor-preview-status" id="editorPreviewStatus">Loading preview...</div>
-  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.17"></script>
+  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.18"></script>
 </body>
 </html>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3350,6 +3350,37 @@ assert.match(
 );
 
 assert.match(
+  source,
+  /function openComposerSettingsForPatFallback\(\) \{[\s\S]*applyMode\('composer', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('composer'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openComposerSettingsForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*scheduleSyncCommitPanelRefresh\(\)[\s\S]*focusFineGrainedTokenInput\(\);/,
+  'Connect failure fallback action should switch to PAT mode through the normal editor mode path, refresh publish state, and focus the PAT token input'
+);
+
+assert.match(
+  source,
+  /const showError = \(message, options = \{\}\) => \{[\s\S]*sync-commit-error-hint[\s\S]*connectFallbackHint[\s\S]*sync-connect-fallback-action[\s\S]*switchToPatFallbackAndFocusToken\(\);/,
+  'inline Connect authorization errors should render an explicit PAT fallback action'
+);
+
+assert.match(
+  source,
+  /let connectFallbackActionAvailable = false;[\s\S]*const \{ files \} = await gatherCommitPayload\(\{ showSeoStatus: true \}\);[\s\S]*connectFallbackActionAvailable = true;[\s\S]*await ensureConnectPublishGrant\(transport\.connect[\s\S]*await createConnectPublishCommit\([\s\S]*connectFallbackActionAvailable = false;[\s\S]*if \(transport && transport\.type === 'connect' && connectFallbackActionAvailable\) \{[\s\S]*toastOptions\.action = \{[\s\S]*connectFallback[\s\S]*switchToPatFallbackAndFocusToken\(\);[\s\S]*showToast\('error', message, toastOptions\);/,
+  'Only Connect authorization and publish failures should expose a toast action that switches to PAT fallback'
+);
+
+[
+  ['English', enI18nSource],
+  ['Simplified Chinese', chsI18nSource],
+  ['Traditional Chinese', chtTwI18nSource],
+  ['Japanese', jaI18nSource]
+].forEach(([label, localeSource]) => {
+  assert.match(
+    localeSource,
+    /connectFallbackHint:/,
+    `${label} translations should explain when to use the PAT fallback after Connect failures`
+  );
+});
+
+assert.match(
   publishSettingsSource,
   /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
   'Connect publish settings should keep legacy storage compatibility while defaulting to a transport mode key'

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3351,8 +3351,14 @@ assert.match(
 
 assert.match(
   source,
-  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function openSyncPanelForPatFallback\(\) \{[\s\S]*applyMode\('sync', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('sync'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openSyncPanelForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*refreshSyncCommitPanel\(\{ focusToken: true \}\)[\s\S]*focusFineGrainedTokenInput\(\);/,
+  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function syncFineGrainedTokenInputs\(value, sourceInput = null\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*if \(input !== sourceInput\) input\.value = nextValue;[\s\S]*function openSyncPanelForPatFallback\(\) \{[\s\S]*applyMode\('sync', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('sync'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openSyncPanelForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*refreshSyncCommitPanel\(\{ focusToken: true \}\)[\s\S]*focusFineGrainedTokenInput\(\);/,
   'Connect failure fallback action should switch to PAT mode through the normal Publish panel path, refresh publish state, and focus the visible PAT token input'
+);
+
+assert.match(
+  source,
+  /input\.addEventListener\('input', \(\) => \{[\s\S]*setCachedFineGrainedToken\(input\.value\);[\s\S]*syncFineGrainedTokenInputs\(input\.value, input\);[\s\S]*const clearToken = \(\) => \{[\s\S]*clearCachedFineGrainedToken\(\);[\s\S]*syncFineGrainedTokenInputs\(''\);/,
+  'Multiple PAT token inputs should stay synchronized so clearing one cannot resurrect a stale session token'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3351,8 +3351,8 @@ assert.match(
 
 assert.match(
   source,
-  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function openComposerSettingsForPatFallback\(\) \{[\s\S]*applyMode\('composer', \{ preserveTreeExpansion: true \}\);[\s\S]*applyComposerFile\('site', \{ force: true, immediate: true \}\);[\s\S]*showEditorSystemPanel\('composer'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openComposerSettingsForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*scheduleSyncCommitPanelRefresh\(\)[\s\S]*focusFineGrainedTokenInput\(\);/,
-  'Connect failure fallback action should switch to PAT mode through the normal editor mode path, refresh publish state, and focus the PAT token input'
+  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function openSyncPanelForPatFallback\(\) \{[\s\S]*applyMode\('sync', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('sync'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openSyncPanelForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*refreshSyncCommitPanel\(\{ focusToken: true \}\)[\s\S]*focusFineGrainedTokenInput\(\);/,
+  'Connect failure fallback action should switch to PAT mode through the normal Publish panel path, refresh publish state, and focus the visible PAT token input'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3351,7 +3351,7 @@ assert.match(
 
 assert.match(
   source,
-  /function openComposerSettingsForPatFallback\(\) \{[\s\S]*applyMode\('composer', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('composer'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openComposerSettingsForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*scheduleSyncCommitPanelRefresh\(\)[\s\S]*focusFineGrainedTokenInput\(\);/,
+  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function openComposerSettingsForPatFallback\(\) \{[\s\S]*applyMode\('composer', \{ preserveTreeExpansion: true \}\);[\s\S]*applyComposerFile\('site', \{ force: true, immediate: true \}\);[\s\S]*showEditorSystemPanel\('composer'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openComposerSettingsForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*scheduleSyncCommitPanelRefresh\(\)[\s\S]*focusFineGrainedTokenInput\(\);/,
   'Connect failure fallback action should switch to PAT mode through the normal editor mode path, refresh publish state, and focus the PAT token input'
 );
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3351,7 +3351,7 @@ assert.match(
 
 assert.match(
   source,
-  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function syncFineGrainedTokenInputs\(value, sourceInput = null\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*if \(input !== sourceInput\) input\.value = nextValue;[\s\S]*function openSyncPanelForPatFallback\(\) \{[\s\S]*applyMode\('sync', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('sync'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openSyncPanelForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*refreshSyncCommitPanel\(\{ focusToken: true \}\)[\s\S]*focusFineGrainedTokenInput\(\);/,
+  /function getVisibleFineGrainedTokenInput\(\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*offsetParent !== null[\s\S]*function syncFineGrainedTokenInputs\(value, sourceInput = null\) \{[\s\S]*document\.querySelectorAll\('#syncGithubTokenInput'\)[\s\S]*if \(input !== sourceInput\) input\.value = nextValue;[\s\S]*function openSyncPanelForPatFallback\(\) \{[\s\S]*applyMode\('sync', \{ preserveTreeExpansion: true \}\);[\s\S]*showEditorSystemPanel\('sync'\);[\s\S]*function switchToPatFallbackAndFocusToken\(\) \{[\s\S]*setConnectPublishEnabled\(false\);[\s\S]*openSyncPanelForPatFallback\(\);[\s\S]*updatePublishTransportSettingsDomForPatFallback\(\);[\s\S]*refreshSyncCommitPanel\(\{ focusToken: true \}\)[\s\S]*\.then\(\(\) => focusFineGrainedTokenInput\(\)\)[\s\S]*\.catch\(\(\) => focusFineGrainedTokenInput\(\)\);/,
   'Connect failure fallback action should switch to PAT mode through the normal Publish panel path, refresh publish state, and focus the visible PAT token input'
 );
 
@@ -3365,6 +3365,12 @@ assert.match(
   source,
   /const showError = \(message, options = \{\}\) => \{[\s\S]*sync-commit-error-hint[\s\S]*connectFallbackHint[\s\S]*sync-connect-fallback-action[\s\S]*switchToPatFallbackAndFocusToken\(\);/,
   'inline Connect authorization errors should render an explicit PAT fallback action'
+);
+
+assert.match(
+  editorSource,
+  /\.sync-commit-error\s*\{[\s\S]*display:flex;[\s\S]*\.sync-commit-error\[hidden\]\s*\{[\s\S]*display:none !important;/,
+  'sync commit fallback errors should still obey the hidden attribute after flex styling'
 );
 
 assert.match(

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -4,7 +4,7 @@ import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
 import {
   satisfiesSemverRange,
   setPressSystemManifestForTests
-} from '../assets/js/press-version.js?v=press-system-v3.4.17';
+} from '../assets/js/press-version.js?v=press-system-v3.4.18';
 
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 if (!globalThis.btoa) {


### PR DESCRIPTION
## Summary
- Adds explicit Personal token fallback actions when Connect authorization or Connect publish fails.
- Keeps Connect as the default publishing path and requires a user click before switching to PAT.
- Bumps the Press system release surface to v3.4.18 and syncs runtime cache keys.

## Behavior
- Connect authorization failures in the Publish panel now render the original error plus a PAT fallback button.
- Connect publish failures show a toast action for PAT fallback, scoped only to Connect auth/publish stages.
- The fallback action opens Site Settings through the normal editor mode path and focuses the Fine-grained PAT input.
- PAT token storage/session behavior and Connect API/site.yaml remain unchanged.

## Validation
- node scripts/sync-runtime-cache-keys.mjs --check
- node --check assets/js/composer.js
- node --check assets/js/publish/transports/connect-transport.js
- node scripts/test-composer-identity-grid.js
- node scripts/test-ui-components.js
- node --experimental-default-type=module scripts/test-system-updates.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- cd ../Connect && npm test
- Browser spot check: default Connect remains enabled; unreachable Connect URL shows fallback action; clicking it switches to Personal token settings and focuses the token input.

## Reviews
- Subagent frontend review found two P2 issues; both were fixed and re-reviewed with no findings.
- Subagent release/cache-key review: no findings.
- Subagent security/public-interface review: no findings.

## Release Impact
- Press system patch release: v3.4.18.
- Expected downstream sync targets after merge: YAP, Press-Theme-Starter, and official theme demo branches.