### PR TITLE
[codex] Split composer editor boundaries

### DIFF
--- a/assets/js/composer-staging.js
+++ b/assets/js/composer-staging.js
@@ -1,0 +1,99 @@
+export function createCommitFileCollector() {
+  const files = [];
+  const seenPaths = new Set();
+
+  function addFile(entry) {
+    if (!entry || !entry.path) return;
+    const key = String(entry.path || '').replace(/\\+/g, '/');
+    if (seenPaths.has(key)) return;
+    seenPaths.add(key);
+    const next = { ...entry, path: key };
+    if (entry.plaintextContent) {
+      Object.defineProperty(next, 'plaintextContent', {
+        value: String(entry.plaintextContent || ''),
+        enumerable: false,
+        configurable: true,
+        writable: true
+      });
+    }
+    files.push(next);
+  }
+
+  return {
+    addFile,
+    getFiles: () => files.slice()
+  };
+}
+
+function normalizeProviderEntries(entries, provider) {
+  return (Array.isArray(entries) ? entries : [])
+    .filter(entry => entry && typeof entry === 'object')
+    .map(entry => ({
+      ...entry,
+      providerId: entry.providerId || provider.id
+    }));
+}
+
+export function createStagingRegistry() {
+  const providers = [];
+
+  function registerStagingProvider(provider) {
+    if (!provider || !provider.id) return null;
+    const existingIndex = providers.findIndex(item => item && item.id === provider.id);
+    if (existingIndex >= 0) providers.splice(existingIndex, 1, provider);
+    else providers.push(provider);
+    return provider;
+  }
+
+  function getSummaryEntries(context = {}) {
+    const entries = [];
+    providers.forEach((provider) => {
+      if (!provider || typeof provider.getSummaryEntries !== 'function') return;
+      entries.push(...normalizeProviderEntries(provider.getSummaryEntries(context), provider));
+    });
+    return entries;
+  }
+
+  async function getCommitFiles(context = {}) {
+    const files = [];
+    const warnings = [];
+    for (const provider of providers) {
+      if (!provider || typeof provider.getCommitFiles !== 'function') continue;
+      try {
+        const result = await provider.getCommitFiles(context);
+        if (Array.isArray(result)) {
+          files.push(...normalizeProviderEntries(result, provider));
+        } else if (result && typeof result === 'object') {
+          files.push(...normalizeProviderEntries(result.files, provider));
+          if (Array.isArray(result.warnings)) warnings.push(...result.warnings);
+        }
+      } catch (err) {
+        if (provider.required) throw err;
+        warnings.push(err);
+      }
+    }
+    return { files, warnings };
+  }
+
+  function clearCommittedFiles(files = [], context = {}) {
+    const committedProviderIds = new Set(
+      (Array.isArray(files) ? files : [])
+        .map(file => file && file.providerId)
+        .filter(Boolean)
+    );
+    const cleared = new Set();
+    providers.forEach((provider) => {
+      if (!provider || !committedProviderIds.has(provider.id) || typeof provider.clear !== 'function') return;
+      provider.clear(context);
+      cleared.add(provider.id);
+    });
+    return cleared;
+  }
+
+  return {
+    registerStagingProvider,
+    getSummaryEntries,
+    getCommitFiles,
+    clearCommittedFiles
+  };
+}

--- a/assets/js/composer-sync-panel.js
+++ b/assets/js/composer-sync-panel.js
@@ -1,0 +1,194 @@
+export async function refreshSyncCommitPanelView(options = {}, deps = {}) {
+  const {
+    documentRef = document,
+    t = (key) => key,
+    getSyncCommitPanelHost,
+    nextRenderId,
+    getRenderId,
+    computeUnsyncedSummary,
+    gatherCommitPayload,
+    appendPublishTransportStatus,
+    resolvePublishTransport,
+    renderFineGrainedTokenSettings,
+    appendGithubCommitSummary,
+    getVisibleFineGrainedTokenInput,
+    getFineGrainedTokenValue,
+    setCachedFineGrainedToken,
+    ensureConnectPublishGrant,
+    getActiveSiteRepoConfig,
+    showToast,
+    performConnectGithubCommit,
+    performDirectGithubCommit,
+    switchToPatFallbackAndFocusToken,
+    refreshSyncCommitPanel
+  } = deps;
+  const panel = getSyncCommitPanelHost();
+  if (!panel) return null;
+  const headerSubmit = documentRef.getElementById('btnSyncSubmit');
+  if (headerSubmit) {
+    headerSubmit.disabled = true;
+    headerSubmit.removeAttribute('aria-busy');
+  }
+  const renderId = nextRenderId();
+  panel.innerHTML = '';
+  const loading = documentRef.createElement('p');
+  loading.className = 'muted sync-commit-loading';
+  loading.textContent = t('editor.status.checkingDrafts');
+  panel.appendChild(loading);
+
+  const summaryEntries = computeUnsyncedSummary();
+  let commitPayload;
+  try {
+    commitPayload = await gatherCommitPayload({ cleanupUnusedAssets: false, showSeoStatus: false });
+  } catch (err) {
+    if (renderId !== getRenderId()) return null;
+    panel.innerHTML = '';
+    const error = documentRef.createElement('p');
+    error.className = 'sync-commit-error';
+    error.textContent = err && err.message ? err.message : t('editor.toasts.githubCommitFailed');
+    panel.appendChild(error);
+    return null;
+  }
+  if (renderId !== getRenderId()) return null;
+
+  const commitFiles = Array.isArray(commitPayload.files) ? commitPayload.files : [];
+  const seoFiles = Array.isArray(commitPayload.seoFiles) ? commitPayload.seoFiles : [];
+  const hasPending = commitFiles.length || summaryEntries.length;
+
+  panel.innerHTML = '';
+  const form = documentRef.createElement('form');
+  form.id = 'syncCommitForm';
+  form.className = 'sync-commit-form comp-guide';
+  form.setAttribute('novalidate', 'novalidate');
+
+  const errorText = documentRef.createElement('div');
+  errorText.className = 'sync-commit-error';
+  errorText.hidden = true;
+  form.appendChild(errorText);
+
+  const btnSubmit = headerSubmit;
+  if (btnSubmit) {
+    btnSubmit.disabled = !hasPending;
+    btnSubmit.textContent = t('editor.composer.github.modal.submit');
+  }
+
+  const summaryBlock = documentRef.createElement('div');
+  summaryBlock.className = 'sync-commit-summary';
+  appendPublishTransportStatus(form);
+  if (resolvePublishTransport().type === 'pat') {
+    renderFineGrainedTokenSettings(form);
+  }
+  appendGithubCommitSummary(summaryBlock, commitFiles, seoFiles, summaryEntries);
+  form.appendChild(summaryBlock);
+
+  panel.appendChild(form);
+
+  const showError = (message, errorOptions = {}) => {
+    errorText.textContent = '';
+    const text = documentRef.createElement('span');
+    text.className = 'sync-commit-error-text';
+    text.textContent = message;
+    errorText.appendChild(text);
+    if (errorOptions && errorOptions.connectFallback) {
+      const hint = documentRef.createElement('span');
+      hint.className = 'sync-commit-error-hint';
+      hint.textContent = t('editor.composer.github.modal.connectFallbackHint');
+      const action = documentRef.createElement('button');
+      action.type = 'button';
+      action.className = 'btn-tertiary sync-connect-fallback-action';
+      action.textContent = t('editor.composer.github.modal.connectFallback');
+      action.addEventListener('click', () => {
+        errorText.hidden = true;
+        switchToPatFallbackAndFocusToken();
+      });
+      errorText.append(hint, action);
+    }
+    errorText.hidden = false;
+  };
+
+  form.addEventListener('submit', async (event) => {
+    if (event && typeof event.preventDefault === 'function') event.preventDefault();
+    errorText.hidden = true;
+    const currentSummary = computeUnsyncedSummary();
+    if (!currentSummary.length && !commitFiles.length) {
+      showToast('info', t('editor.composer.noLocalChangesToCommit'));
+      refreshSyncCommitPanel();
+      return;
+    }
+    const transport = resolvePublishTransport();
+    if (transport.type === 'pat') {
+      const input = getVisibleFineGrainedTokenInput();
+      const value = getFineGrainedTokenValue();
+      if (!value) {
+        showError(t('editor.composer.github.modal.errorRequired'));
+        if (input && input.offsetParent) {
+          try { input.focus({ preventScroll: true }); }
+          catch (_) { input.focus(); }
+        }
+        return;
+      }
+      setCachedFineGrainedToken(value);
+      transport.token = value;
+    } else {
+      if (transport.invalid || !transport.connect) {
+        showError(t('editor.composer.github.modal.connectInvalidUrl'));
+        const input = documentRef.getElementById('syncConnectBaseUrlInput');
+        if (input && input.offsetParent) {
+          try { input.focus({ preventScroll: true }); }
+          catch (_) { input.focus(); }
+        }
+        return;
+      }
+      try {
+        await ensureConnectPublishGrant(transport.connect, getActiveSiteRepoConfig());
+      } catch (err) {
+        showError(err && err.message ? err.message : t('editor.composer.github.modal.connectAuthorizationFailed'), {
+          connectFallback: true
+        });
+        return;
+      }
+    }
+    if (btnSubmit) {
+      btnSubmit.disabled = true;
+      btnSubmit.setAttribute('aria-busy', 'true');
+    }
+    try {
+      if (transport.type === 'connect') await performConnectGithubCommit(transport.connect, currentSummary);
+      else await performDirectGithubCommit(transport.token, currentSummary);
+    } finally {
+      if (btnSubmit) btnSubmit.removeAttribute('aria-busy');
+      refreshSyncCommitPanel();
+    }
+  });
+
+  if (options.focusToken) {
+    const input = getVisibleFineGrainedTokenInput();
+    if (input && typeof input.focus === 'function') {
+      try { input.focus({ preventScroll: true }); }
+      catch (_) { input.focus(); }
+    }
+  }
+  return { panel, input: getVisibleFineGrainedTokenInput(), form };
+}
+
+export function scheduleSyncCommitPanelRefreshView({
+  currentMode,
+  windowRef = window,
+  timer,
+  setTimer,
+  refreshSyncCommitPanel
+} = {}) {
+  if (currentMode !== 'sync') return timer || 0;
+  try {
+    if (timer) windowRef.clearTimeout(timer);
+    const nextTimer = windowRef.setTimeout(() => {
+      setTimer(0);
+      refreshSyncCommitPanel();
+    }, 120);
+    setTimer(nextTimer);
+    return nextTimer;
+  } catch (_) {
+    refreshSyncCommitPanel();
+    return 0;
+  }
+}

--- a/assets/js/composer-system-panel.js
+++ b/assets/js/composer-system-panel.js
@@ -1,0 +1,109 @@
+export function animateEditorSystemPanelContent({
+  windowRef = window,
+  documentRef = document
+} = {}) {
+  const panel = documentRef.getElementById('editorSystemPanel');
+  if (!panel) return;
+  try {
+    const previousTimer = panel.__pressSystemAnimationTimer;
+    if (previousTimer) windowRef.clearTimeout(previousTimer);
+  } catch (_) {}
+  panel.classList.remove('is-content-entering');
+  try { panel.getBoundingClientRect(); } catch (_) {}
+  panel.classList.add('is-content-entering');
+  try {
+    panel.__pressSystemAnimationTimer = windowRef.setTimeout(() => {
+      panel.classList.remove('is-content-entering');
+      panel.__pressSystemAnimationTimer = null;
+    }, 260);
+  } catch (_) {}
+}
+
+export function showEditorSystemPanel(mode, deps = {}) {
+  const {
+    documentRef = document,
+    treeText = (_key, fallback) => fallback,
+    mountEditorSystemPanels = () => {},
+    setEditorSystemPanelVisible = () => {},
+    getActiveComposerFile = () => '',
+    applyComposerFile = () => {},
+    resetSiteSettingsNavOnOpen = () => {},
+    refreshSyncCommitPanel = () => {},
+    animatePanel = () => animateEditorSystemPanelContent({ documentRef })
+  } = deps;
+  const nextMode = mode === 'sync' ? 'sync' : (mode === 'updates' ? 'updates' : (mode === 'themes' ? 'themes' : 'composer'));
+  mountEditorSystemPanels();
+  const panel = documentRef.getElementById('editorSystemPanel');
+  const title = documentRef.getElementById('editorSystemTitle');
+  const kicker = documentRef.getElementById('editorSystemKicker');
+  const meta = documentRef.getElementById('editorSystemMeta');
+  const actions = documentRef.getElementById('editorSystemActions');
+  const composerActions = documentRef.getElementById('editorModalComposerActions');
+  const themeActions = documentRef.getElementById('editorModalThemeActions');
+  const updateActions = documentRef.getElementById('editorModalUpdateActions');
+  const syncActions = documentRef.getElementById('editorModalSyncActions');
+  const composerPanel = documentRef.getElementById('mode-composer');
+  const themesPanel = documentRef.getElementById('mode-themes');
+  const updatesPanel = documentRef.getElementById('mode-updates');
+  const syncPanel = documentRef.getElementById('mode-sync');
+  if (!panel) return;
+
+  setEditorSystemPanelVisible(true);
+  if (kicker) kicker.textContent = treeText('system', 'System');
+  if (title) {
+    title.textContent = nextMode === 'sync'
+      ? treeText('sync', 'Publish')
+      : (nextMode === 'updates'
+        ? treeText('pressUpdates', 'Press Updates')
+        : (nextMode === 'themes'
+          ? treeText('themes', 'Themes')
+          : treeText('siteSettings', 'Site Settings')));
+  }
+  if (meta) {
+    meta.textContent = nextMode === 'sync'
+      ? treeText('syncMeta', 'Publish local changes to GitHub.')
+      : (nextMode === 'updates'
+        ? treeText('systemUpdatesMeta', 'Review and apply Press updates.')
+        : (nextMode === 'themes'
+          ? treeText('themesMeta', 'Theme packs.')
+          : treeText('siteSettingsMeta', 'Edit site.yaml settings.')));
+  }
+
+  if (actions) {
+    [
+      ['composer', composerActions],
+      ['themes', themeActions],
+      ['updates', updateActions],
+      ['sync', syncActions]
+    ].forEach(([key, actionSet]) => {
+      if (!actionSet) return;
+      if (actionSet.parentElement !== actions) actions.appendChild(actionSet);
+      const active = key === nextMode;
+      actionSet.hidden = !active;
+      actionSet.setAttribute('aria-hidden', active ? 'false' : 'true');
+    });
+  }
+
+  [
+    ['composer', composerPanel],
+    ['themes', themesPanel],
+    ['updates', updatesPanel],
+    ['sync', syncPanel]
+  ].forEach(([key, modePanel]) => {
+    const active = key === nextMode;
+    if (!modePanel) return;
+    modePanel.hidden = !active;
+    modePanel.setAttribute('aria-hidden', active ? 'false' : 'true');
+    modePanel.style.display = active ? '' : 'none';
+  });
+
+  if (nextMode === 'composer') {
+    try {
+      if (getActiveComposerFile() !== 'site') applyComposerFile('site', { force: true, immediate: true });
+    } catch (_) {}
+    resetSiteSettingsNavOnOpen();
+  } else if (nextMode === 'sync') {
+    refreshSyncCommitPanel();
+  }
+  animatePanel();
+}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -26,16 +26,28 @@ import {
   planManagedContentDeletions,
   resolveLocalMarkdownAssetReference
 } from './repository-deletions.js?v=press-system-v3.4.18';
+import { createCommitFileCollector, createStagingRegistry } from './composer-staging.js?v=press-system-v3.4.18';
+import {
+  createScopedStorageKey,
+  resolveEditorStorageScope
+} from './editor-storage.js?v=press-system-v3.4.18';
+import { createScopedDraftStore } from './editor-drafts.js?v=press-system-v3.4.18';
+import { createEditorSessionStateStore } from './editor-session-state.js?v=press-system-v3.4.18';
+import {
+  refreshSyncCommitPanelView,
+  scheduleSyncCommitPanelRefreshView
+} from './composer-sync-panel.js?v=press-system-v3.4.18';
+import {
+  animateEditorSystemPanelContent as animateSystemPanelContent,
+  showEditorSystemPanel as showComposerSystemPanel
+} from './composer-system-panel.js?v=press-system-v3.4.18';
 import {
   CONNECT_PUBLISH_PRESETS,
   createPublishSettingsStore,
   getDefaultConnectPublishBaseUrl,
   normalizeConnectPublishBaseUrl
 } from './publish/settings-store.js?v=press-system-v3.4.18';
-import {
-  createConnectPublishCommit,
-  ensureConnectPublishGrant as authorizeConnectPublishGrant
-} from './publish/transports/connect-transport.js?v=press-system-v3.4.18';
+import { ensurePublishGrant, publishCommit as publishStagedCommit } from './publish/commit-service.js?v=press-system-v3.4.18';
 import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.18';
 
 // Utility helpers
@@ -103,64 +115,47 @@ const LS_KEYS = {
 const EDITOR_STATE_VERSION = 3;
 const EDITOR_SCROLL_SAVE_DELAY = 120;
 
-function normalizeStorageScopePart(value) {
-  const raw = String(value || '').trim().toLowerCase();
-  return raw.replace(/[^a-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'root';
-}
-
-function resolveEditorStorageScope(locationLike) {
-  let protocol = '';
-  let host = '';
-  let pathname = '';
-  try {
-    if (typeof locationLike === 'string') {
-      const url = new URL(locationLike);
-      protocol = url.protocol;
-      host = url.host;
-      pathname = url.pathname;
-    } else if (locationLike && typeof locationLike === 'object') {
-      if (locationLike.href) {
-        const url = new URL(String(locationLike.href));
-        protocol = url.protocol;
-        host = url.host;
-        pathname = url.pathname;
-      } else {
-        protocol = String(locationLike.protocol || '');
-        host = String(locationLike.host || locationLike.hostname || '');
-        pathname = String(locationLike.pathname || '');
-      }
-    }
-  } catch (_) {
-    return 'unknown';
-  }
-  const path = String(pathname || '');
-  const segments = path.split('/').filter(Boolean);
-  const firstSegment = segments[0] || '';
-  const isRootIndexFile = segments.length === 1
-    && (firstSegment === 'index.html' || firstSegment === 'index_editor.html')
-    && !path.endsWith('/');
-  const sitePath = firstSegment && !isRootIndexFile ? firstSegment : 'root';
-  const protocolPart = protocol ? protocol.replace(/:$/, '') : 'site';
-  return [
-    'v2',
-    normalizeStorageScopePart(protocolPart),
-    normalizeStorageScopePart(host || 'local'),
-    normalizeStorageScopePart(sitePath)
-  ].join(':');
-}
-
 const EDITOR_STORAGE_SCOPE = (() => {
   try { return resolveEditorStorageScope(window.location); }
   catch (_) { return 'unknown'; }
 })();
 
 function scopedEditorStorageKey(key) {
-  return `${key}:${EDITOR_STORAGE_SCOPE}`;
+  return createScopedStorageKey(EDITOR_STORAGE_SCOPE, key);
 }
 
 const publishSettingsStore = createPublishSettingsStore({
   windowRef: window,
   scopeKey: scopedEditorStorageKey
+});
+const stagingRegistry = createStagingRegistry();
+stagingRegistry.registerStagingProvider({
+  id: 'system-updates',
+  getSummaryEntries: () => getSystemUpdateSummaryEntries().map(entry => ({ ...entry, kind: 'system' })),
+  getCommitFiles: () => getSystemUpdateCommitFiles().map(entry => ({ ...entry, kind: 'system' })),
+  clear: () => clearSystemUpdateState({ keepStatus: false })
+});
+stagingRegistry.registerStagingProvider({
+  id: 'themes',
+  getSummaryEntries: () => getThemeManagerSummaryEntries().map(entry => ({ ...entry, kind: 'system', category: 'theme' })),
+  getCommitFiles: () => getThemeManagerCommitFiles().map(entry => ({ ...entry, kind: 'system', category: 'theme' })),
+  clear: () => clearThemeManagerState({ keepStatus: false, keepRegistryCache: true, keepSiteThemeFallback: true })
+});
+stagingRegistry.registerStagingProvider({
+  id: 'seo',
+  async getCommitFiles(context = {}) {
+    if (context.showSeoStatus) {
+      try {
+        if (typeof context.setStatus === 'function') context.setStatus('Generating SEO files…');
+      } catch (_) { /* ignore */ }
+    }
+    return generateSeoCommitFiles();
+  }
+});
+const editorSessionStateStore = createEditorSessionStateStore({
+  storage: window.localStorage,
+  scopeKey: scopedEditorStorageKey,
+  keys: LS_KEYS
 });
 
 // Track additional markdown editor tabs spawned from Composer
@@ -178,12 +173,11 @@ let activeEditorTreeNodeId = 'welcome';
 const expandedEditorTreeNodeIds = new Set(['articles', 'pages']);
 let hasEditorStateV3Snapshot = false;
 try {
-  const rawEditorState = window.localStorage.getItem(scopedEditorStorageKey(LS_KEYS.editorState));
-  const parsedEditorState = rawEditorState ? JSON.parse(rawEditorState) : null;
+  const parsedEditorState = editorSessionStateStore.readEditorState();
   hasEditorStateV3Snapshot = !!(parsedEditorState && parsedEditorState.v === EDITOR_STATE_VERSION);
 } catch (_) {}
 try {
-  if (!hasEditorStateV3Snapshot && window.localStorage.getItem(scopedEditorStorageKey(LS_KEYS.systemTreeExpanded)) === '1') {
+  if (!hasEditorStateV3Snapshot && editorSessionStateStore.readLegacySystemTreeExpanded()) {
     expandedEditorTreeNodeIds.add('system');
   }
 } catch (_) {}
@@ -221,6 +215,16 @@ function updateDynamicTabsGroupState() {
 
 const DRAFT_STORAGE_KEY = 'press_composer_drafts_v1';
 const MARKDOWN_DRAFT_STORAGE_KEY = 'press_markdown_editor_drafts_v1';
+const composerDraftStore = createScopedDraftStore({
+  storage: window.localStorage,
+  storageKey: DRAFT_STORAGE_KEY,
+  scopeKey: scopedEditorStorageKey
+});
+const markdownDraftStore = createScopedDraftStore({
+  storage: window.localStorage,
+  storageKey: MARKDOWN_DRAFT_STORAGE_KEY,
+  scopeKey: scopedEditorStorageKey
+});
 
 // Track pending binary assets associated with markdown drafts
 const markdownAssetStore = new Map();
@@ -3453,26 +3457,11 @@ function computeTabsDiff(current, baseline) {
 }
 
 function readDraftStore() {
-  try {
-    const raw = localStorage.getItem(scopedEditorStorageKey(DRAFT_STORAGE_KEY));
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? parsed : {};
-  } catch (_) {
-    return {};
-  }
+  return composerDraftStore.read();
 }
 
 function writeDraftStore(store) {
-  try {
-    if (!store || !Object.keys(store).length) {
-      localStorage.removeItem(scopedEditorStorageKey(DRAFT_STORAGE_KEY));
-      return;
-    }
-    localStorage.setItem(scopedEditorStorageKey(DRAFT_STORAGE_KEY), JSON.stringify(store));
-  } catch (_) {
-    /* ignore storage errors */
-  }
+  composerDraftStore.write(store);
 }
 
 function normalizeMarkdownContent(text) {
@@ -4076,26 +4065,11 @@ try {
 } catch (_) {}
 
 function readMarkdownDraftStore() {
-  try {
-    const raw = localStorage.getItem(scopedEditorStorageKey(MARKDOWN_DRAFT_STORAGE_KEY));
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? parsed : {};
-  } catch (_) {
-    return {};
-  }
+  return markdownDraftStore.read();
 }
 
 function writeMarkdownDraftStore(store) {
-  try {
-    if (!store || !Object.keys(store).length) {
-      localStorage.removeItem(scopedEditorStorageKey(MARKDOWN_DRAFT_STORAGE_KEY));
-      return;
-    }
-    localStorage.setItem(scopedEditorStorageKey(MARKDOWN_DRAFT_STORAGE_KEY), JSON.stringify(store));
-  } catch (_) {
-    /* ignore storage errors */
-  }
+  markdownDraftStore.write(store);
 }
 
 async function requestPasswordForProtectedMarkdown(tab, options = {}) {
@@ -4248,11 +4222,7 @@ function saveMarkdownDraftEntry(path, content, remoteSignature = '', assets = []
 function clearMarkdownDraftEntry(path) {
   const norm = normalizeRelPath(path);
   if (!norm) return;
-  const store = readMarkdownDraftStore();
-  if (store && Object.prototype.hasOwnProperty.call(store, norm)) {
-    delete store[norm];
-    writeMarkdownDraftStore(store);
-  }
+  markdownDraftStore.removeEntry(norm);
   clearMarkdownAssetsForPath(norm);
 }
 
@@ -4995,20 +4965,7 @@ function computeUnsyncedSummary() {
       hasContentChange: true
     });
   }
-  const systemEntries = getSystemUpdateSummaryEntries();
-  if (systemEntries && systemEntries.length) {
-    systemEntries.forEach((entry) => {
-      if (!entry || typeof entry !== 'object') return;
-      entries.push({ ...entry, kind: 'system' });
-    });
-  }
-  const themeEntries = getThemeManagerSummaryEntries();
-  if (themeEntries && themeEntries.length) {
-    themeEntries.forEach((entry) => {
-      if (!entry || typeof entry !== 'object') return;
-      entries.push({ ...entry, kind: 'system', category: 'theme' });
-    });
-  }
+  entries.push(...stagingRegistry.getSummaryEntries());
   const markdownEntries = collectUnsyncedMarkdownEntries();
   if (markdownEntries.length) entries.push(...markdownEntries);
   const assetDeletionEntries = listMarkdownAssetDeletions();
@@ -5919,16 +5876,15 @@ async function gatherCommitPayload(options = {}) {
   const { showSeoStatus = false } = options;
   const base = await gatherLocalChangesForCommit(options);
   const files = Array.isArray(base.files) ? base.files.slice() : [];
-  if (showSeoStatus) {
-    try {
-      if (typeof setSyncOverlayStatus === 'function') {
-        setSyncOverlayStatus('Generating SEO files…');
-      }
-    } catch (_) { /* ignore */ }
-  }
-  const seoFiles = await generateSeoCommitFiles();
-  if (seoFiles.length) files.push(...seoFiles);
-  return { files, seoFiles };
+  const providerResult = await stagingRegistry.getCommitFiles({
+    ...options,
+    showSeoStatus,
+    setStatus: setSyncOverlayStatus
+  });
+  const providerFiles = Array.isArray(providerResult.files) ? providerResult.files : [];
+  if (providerFiles.length) files.push(...providerFiles);
+  const seoFiles = providerFiles.filter(file => file && file.kind === 'seo');
+  return { files, seoFiles, warnings: providerResult.warnings || [] };
 }
 
 function collectDirtyMarkdownPathsForDeletion() {
@@ -6017,24 +5973,8 @@ async function collectDeletedMarkdownAssetFiles(markdownDeletionFiles = [], opti
 
 async function gatherLocalChangesForCommit(options = {}) {
   const { cleanupUnusedAssets = true } = options;
-  const files = [];
-  const seenPaths = new Set();
-  const addFile = (entry) => {
-    if (!entry || !entry.path) return;
-    const key = entry.path.replace(/\\+/g, '/');
-    if (seenPaths.has(key)) return;
-    seenPaths.add(key);
-    const next = { ...entry, path: key };
-    if (entry.plaintextContent) {
-      Object.defineProperty(next, 'plaintextContent', {
-        value: String(entry.plaintextContent || ''),
-        enumerable: false,
-        configurable: true,
-        writable: true
-      });
-    }
-    files.push(next);
-  };
+  const collector = createCommitFileCollector();
+  const { addFile } = collector;
 
   try {
     const flushes = Array.from(dynamicEditorTabs.values()).map((tab) => (
@@ -6236,22 +6176,7 @@ async function gatherLocalChangesForCommit(options = {}) {
     });
   }
 
-  const systemFiles = getSystemUpdateCommitFiles();
-  if (systemFiles && systemFiles.length) {
-    systemFiles.forEach((entry) => {
-      if (!entry || typeof entry !== 'object') return;
-      addFile({ ...entry, kind: 'system' });
-    });
-  }
-  const themeFiles = getThemeManagerCommitFiles();
-  if (themeFiles && themeFiles.length) {
-    themeFiles.forEach((entry) => {
-      if (!entry || typeof entry !== 'object') return;
-      addFile({ ...entry, kind: 'system', category: 'theme' });
-    });
-  }
-
-  return { files };
+  return { files: collector.getFiles() };
 }
 
 function describeSummaryEntry(entry) {
@@ -6538,162 +6463,44 @@ function getSyncCommitPanelHost() {
 }
 
 async function refreshSyncCommitPanel(options = {}) {
-  const panel = getSyncCommitPanelHost();
-  if (!panel) return null;
-  const headerSubmit = document.getElementById('btnSyncSubmit');
-  if (headerSubmit) {
-    headerSubmit.disabled = true;
-    headerSubmit.removeAttribute('aria-busy');
-  }
-  const renderId = ++syncCommitPanelRenderSeq;
-  panel.innerHTML = '';
-  const loading = document.createElement('p');
-  loading.className = 'muted sync-commit-loading';
-  loading.textContent = t('editor.status.checkingDrafts');
-  panel.appendChild(loading);
-
-  const summaryEntries = computeUnsyncedSummary();
-  let commitPayload = { files: [], seoFiles: [] };
-  try {
-    commitPayload = await gatherCommitPayload({ cleanupUnusedAssets: false, showSeoStatus: false });
-  } catch (err) {
-    if (renderId !== syncCommitPanelRenderSeq) return null;
-    panel.innerHTML = '';
-    const error = document.createElement('p');
-    error.className = 'sync-commit-error';
-    error.textContent = err && err.message ? err.message : t('editor.toasts.githubCommitFailed');
-    panel.appendChild(error);
-    return null;
-  }
-  if (renderId !== syncCommitPanelRenderSeq) return null;
-
-  const commitFiles = Array.isArray(commitPayload.files) ? commitPayload.files : [];
-  const seoFiles = Array.isArray(commitPayload.seoFiles) ? commitPayload.seoFiles : [];
-  const hasPending = commitFiles.length || summaryEntries.length;
-
-  panel.innerHTML = '';
-  const form = document.createElement('form');
-  form.id = 'syncCommitForm';
-  form.className = 'sync-commit-form comp-guide';
-  form.setAttribute('novalidate', 'novalidate');
-
-  const errorText = document.createElement('div');
-  errorText.className = 'sync-commit-error';
-  errorText.hidden = true;
-  form.appendChild(errorText);
-
-  const btnSubmit = headerSubmit;
-  if (btnSubmit) {
-    btnSubmit.disabled = !hasPending;
-    btnSubmit.textContent = t('editor.composer.github.modal.submit');
-  }
-
-  const summaryBlock = document.createElement('div');
-  summaryBlock.className = 'sync-commit-summary';
-  appendPublishTransportStatus(form);
-  if (resolvePublishTransport().type === 'pat') {
-    renderFineGrainedTokenSettings(form);
-  }
-  appendGithubCommitSummary(summaryBlock, commitFiles, seoFiles, summaryEntries);
-  form.appendChild(summaryBlock);
-
-  panel.appendChild(form);
-
-  const showError = (message, options = {}) => {
-    errorText.textContent = '';
-    const text = document.createElement('span');
-    text.className = 'sync-commit-error-text';
-    text.textContent = message;
-    errorText.appendChild(text);
-    if (options && options.connectFallback) {
-      const hint = document.createElement('span');
-      hint.className = 'sync-commit-error-hint';
-      hint.textContent = t('editor.composer.github.modal.connectFallbackHint');
-      const action = document.createElement('button');
-      action.type = 'button';
-      action.className = 'btn-tertiary sync-connect-fallback-action';
-      action.textContent = t('editor.composer.github.modal.connectFallback');
-      action.addEventListener('click', () => {
-        errorText.hidden = true;
-        switchToPatFallbackAndFocusToken();
-      });
-      errorText.append(hint, action);
-    }
-    errorText.hidden = false;
-  };
-
-  form.addEventListener('submit', async (event) => {
-    if (event && typeof event.preventDefault === 'function') event.preventDefault();
-    errorText.hidden = true;
-    const currentSummary = computeUnsyncedSummary();
-    if (!currentSummary.length && !commitFiles.length) {
-      showToast('info', t('editor.composer.noLocalChangesToCommit'));
-      refreshSyncCommitPanel();
-      return;
-    }
-    const transport = resolvePublishTransport();
-    if (transport.type === 'pat') {
-      const input = getVisibleFineGrainedTokenInput();
-      const value = getFineGrainedTokenValue();
-      if (!value) {
-        showError(t('editor.composer.github.modal.errorRequired'));
-        if (input && input.offsetParent) {
-          try { input.focus({ preventScroll: true }); }
-          catch (_) { input.focus(); }
-        }
-        return;
-      }
-      setCachedFineGrainedToken(value);
-      transport.token = value;
-    } else {
-      if (transport.invalid || !transport.connect) {
-        showError(t('editor.composer.github.modal.connectInvalidUrl'));
-        const input = document.getElementById('syncConnectBaseUrlInput');
-        if (input && input.offsetParent) {
-          try { input.focus({ preventScroll: true }); }
-          catch (_) { input.focus(); }
-        }
-        return;
-      }
-      try {
-        await ensureConnectPublishGrant(transport.connect, getActiveSiteRepoConfig());
-      } catch (err) {
-        showError(err && err.message ? err.message : t('editor.composer.github.modal.connectAuthorizationFailed'), {
-          connectFallback: true
-        });
-        return;
-      }
-    }
-    if (btnSubmit) {
-      btnSubmit.disabled = true;
-      btnSubmit.setAttribute('aria-busy', 'true');
-    }
-    try {
-      if (transport.type === 'connect') await performConnectGithubCommit(transport.connect, currentSummary);
-      else await performDirectGithubCommit(transport.token, currentSummary);
-    } finally {
-      if (btnSubmit) btnSubmit.removeAttribute('aria-busy');
-      refreshSyncCommitPanel();
-    }
+  return refreshSyncCommitPanelView(options, {
+    documentRef: document,
+    t,
+    getSyncCommitPanelHost,
+    nextRenderId: () => {
+      syncCommitPanelRenderSeq += 1;
+      return syncCommitPanelRenderSeq;
+    },
+    getRenderId: () => syncCommitPanelRenderSeq,
+    computeUnsyncedSummary,
+    gatherCommitPayload,
+    appendPublishTransportStatus,
+    resolvePublishTransport,
+    renderFineGrainedTokenSettings,
+    appendGithubCommitSummary,
+    getVisibleFineGrainedTokenInput,
+    getFineGrainedTokenValue,
+    setCachedFineGrainedToken,
+    ensureConnectPublishGrant,
+    getActiveSiteRepoConfig,
+    showToast,
+    performConnectGithubCommit,
+    performDirectGithubCommit,
+    switchToPatFallbackAndFocusToken,
+    refreshSyncCommitPanel
   });
-
-  if (options.focusToken) {
-    focusFineGrainedTokenInput();
-  }
-  return { panel, input: getVisibleFineGrainedTokenInput(), form };
 }
 
 function scheduleSyncCommitPanelRefresh() {
-  if (currentMode !== 'sync') return;
-  try {
-    if (syncCommitPanelRefreshTimer) window.clearTimeout(syncCommitPanelRefreshTimer);
-    syncCommitPanelRefreshTimer = window.setTimeout(() => {
-      syncCommitPanelRefreshTimer = 0;
-      refreshSyncCommitPanel();
-    }, 120);
-  } catch (_) {
-    refreshSyncCommitPanel();
-  }
+  syncCommitPanelRefreshTimer = scheduleSyncCommitPanelRefreshView({
+    currentMode,
+    windowRef: window,
+    timer: syncCommitPanelRefreshTimer,
+    setTimer: (timer) => {
+      syncCommitPanelRefreshTimer = timer;
+    },
+    refreshSyncCommitPanel
+  });
 }
 
 async function waitForRemotePropagation(files = []) {
@@ -6715,9 +6522,8 @@ function getActiveSiteRepoConfig() {
 
 function applyLocalPostCommitState(files = []) {
   if (!Array.isArray(files) || !files.length) return;
+  stagingRegistry.clearCommittedFiles(files);
   const handledMarkdown = new Set();
-  let clearedSystem = false;
-  let clearedThemeManager = false;
   files.forEach((file) => {
     if (!file || !file.kind) return;
     if (file.kind === 'index') {
@@ -6838,17 +6644,6 @@ function applyLocalPostCommitState(files = []) {
       }
       updateComposerMarkdownDraftIndicators({ path: norm });
     }
-    else if (file.kind === 'system') {
-      if (file.category === 'theme') {
-        if (!clearedThemeManager) {
-          clearThemeManagerState({ keepStatus: false, keepRegistryCache: true, keepSiteThemeFallback: true });
-          clearedThemeManager = true;
-        }
-      } else if (!clearedSystem) {
-        clearSystemUpdateState({ keepStatus: false });
-        clearedSystem = true;
-      }
-    }
     else if (file.kind === 'asset') {
       const norm = normalizeRelPath(file.markdownPath || '');
       if (!norm) return;
@@ -6911,28 +6706,28 @@ async function performPublishCommit(transport, summaryEntries = []) {
 
     const headline = `chore: sync ${files.length === 1 ? 'draft' : 'drafts'} via Press`;
     if (transport && transport.type === 'connect') {
-      setSyncOverlayStatus(t('editor.composer.github.modal.connectAuthorizing'));
       connectFallbackActionAvailable = true;
-      const grant = await ensureConnectPublishGrant(transport.connect, { owner, name, branch });
-      setSyncOverlayStatus(t('editor.composer.github.modal.connectPublishing'));
-      await createConnectPublishCommit({
-        connect: transport.connect,
+      await publishStagedCommit({
+        transport,
         repo: { owner, name, branch },
         headline,
         files,
-        grant,
         contentRoot: getTrackedPublishContentRoot(),
-        translate: t
+        getCachedGrant: getCachedConnectPublishGrant,
+        setCachedGrant: setCachedConnectPublishGrant,
+        windowRef: window,
+        documentRef: document,
+        translate: t,
+        onStatus: setSyncOverlayStatus
       });
       connectFallbackActionAvailable = false;
     } else {
-      const { createFineGrainedTokenCommit } = await import('./publish/transports/github-pat-transport.js?v=press-system-v3.4.18');
-      await createFineGrainedTokenCommit(transport && transport.token, {
-        owner,
-        name,
-        branch,
+      await publishStagedCommit({
+        transport,
+        repo: { owner, name, branch },
         headline,
         files,
+        translate: t,
         onStatus: setSyncOverlayStatus
       });
     }
@@ -6983,7 +6778,7 @@ async function performPublishCommit(transport, summaryEntries = []) {
 }
 
 async function ensureConnectPublishGrant(connect, repo) {
-  return authorizeConnectPublishGrant({
+  return ensurePublishGrant({
     connect,
     repo,
     getCachedGrant: getCachedConnectPublishGrant,
@@ -8707,11 +8502,7 @@ function saveDraftToStorage(kind, opts = {}) {
 }
 
 function clearDraftStorage(kind) {
-  const store = readDraftStore();
-  if (store && Object.prototype.hasOwnProperty.call(store, kind)) {
-    delete store[kind];
-    writeDraftStore(store);
-  }
+  composerDraftStore.removeEntry(kind);
   composerDraftMeta[kind] = null;
 
 }
@@ -10112,12 +9903,7 @@ function scrollEditorContentToTop(behavior = 'smooth') {
 }
 
 function persistSystemTreeExpandedState() {
-  try {
-    window.localStorage.setItem(
-      scopedEditorStorageKey(LS_KEYS.systemTreeExpanded),
-      expandedEditorTreeNodeIds.has('system') ? '1' : '0'
-    );
-  } catch (_) {}
+  editorSessionStateStore.writeLegacySystemTreeExpanded(expandedEditorTreeNodeIds.has('system'));
 }
 
 function normalizeEditorScrollTop(value) {
@@ -10287,99 +10073,21 @@ function setEditorSystemPanelVisible(visible) {
 }
 
 function animateEditorSystemPanelContent() {
-  const panel = document.getElementById('editorSystemPanel');
-  if (!panel) return;
-  try {
-    const previousTimer = panel.__pressSystemAnimationTimer;
-    if (previousTimer) window.clearTimeout(previousTimer);
-  } catch (_) {}
-  panel.classList.remove('is-content-entering');
-  try { panel.getBoundingClientRect(); } catch (_) {}
-  panel.classList.add('is-content-entering');
-  try {
-    panel.__pressSystemAnimationTimer = window.setTimeout(() => {
-      panel.classList.remove('is-content-entering');
-      panel.__pressSystemAnimationTimer = null;
-    }, 260);
-  } catch (_) {}
+  animateSystemPanelContent({ windowRef: window, documentRef: document });
 }
 
 function showEditorSystemPanel(mode) {
-  const nextMode = mode === 'sync' ? 'sync' : (mode === 'updates' ? 'updates' : (mode === 'themes' ? 'themes' : 'composer'));
-  mountEditorSystemPanels();
-  const panel = document.getElementById('editorSystemPanel');
-  const title = document.getElementById('editorSystemTitle');
-  const kicker = document.getElementById('editorSystemKicker');
-  const meta = document.getElementById('editorSystemMeta');
-  const actions = document.getElementById('editorSystemActions');
-  const composerActions = document.getElementById('editorModalComposerActions');
-  const themeActions = document.getElementById('editorModalThemeActions');
-  const updateActions = document.getElementById('editorModalUpdateActions');
-  const syncActions = document.getElementById('editorModalSyncActions');
-  const composerPanel = document.getElementById('mode-composer');
-  const themesPanel = document.getElementById('mode-themes');
-  const updatesPanel = document.getElementById('mode-updates');
-  const syncPanel = document.getElementById('mode-sync');
-  if (!panel) return;
-
-  setEditorSystemPanelVisible(true);
-  if (kicker) kicker.textContent = treeText('system', 'System');
-  if (title) {
-    title.textContent = nextMode === 'sync'
-      ? treeText('sync', 'Publish')
-      : (nextMode === 'updates'
-        ? treeText('pressUpdates', 'Press Updates')
-        : (nextMode === 'themes'
-          ? treeText('themes', 'Themes')
-          : treeText('siteSettings', 'Site Settings')));
-  }
-  if (meta) {
-    meta.textContent = nextMode === 'sync'
-      ? treeText('syncMeta', 'Publish local changes to GitHub.')
-      : (nextMode === 'updates'
-        ? treeText('systemUpdatesMeta', 'Review and apply Press updates.')
-        : (nextMode === 'themes'
-          ? treeText('themesMeta', 'Theme packs.')
-          : treeText('siteSettingsMeta', 'Edit site.yaml settings.')));
-  }
-
-  if (actions) {
-    [
-      ['composer', composerActions],
-      ['themes', themeActions],
-      ['updates', updateActions],
-      ['sync', syncActions]
-    ].forEach(([key, actionSet]) => {
-      if (!actionSet) return;
-      if (actionSet.parentElement !== actions) actions.appendChild(actionSet);
-      const active = key === nextMode;
-      actionSet.hidden = !active;
-      actionSet.setAttribute('aria-hidden', active ? 'false' : 'true');
-    });
-  }
-
-  [
-    ['composer', composerPanel],
-    ['themes', themesPanel],
-    ['updates', updatesPanel],
-    ['sync', syncPanel]
-  ].forEach(([key, modePanel]) => {
-    const active = key === nextMode;
-    if (!modePanel) return;
-    modePanel.hidden = !active;
-    modePanel.setAttribute('aria-hidden', active ? 'false' : 'true');
-    modePanel.style.display = active ? '' : 'none';
+  return showComposerSystemPanel(mode, {
+    documentRef: document,
+    treeText,
+    mountEditorSystemPanels,
+    setEditorSystemPanelVisible,
+    getActiveComposerFile,
+    applyComposerFile,
+    resetSiteSettingsNavOnOpen,
+    refreshSyncCommitPanel,
+    animatePanel: animateEditorSystemPanelContent
   });
-
-  if (nextMode === 'composer') {
-    try {
-      if (getActiveComposerFile() !== 'site') applyComposerFile('site', { force: true, immediate: true });
-    } catch (_) {}
-    resetSiteSettingsNavOnOpen();
-  } else if (nextMode === 'sync') {
-    refreshSyncCommitPanel();
-  }
-  animateEditorSystemPanelContent();
 }
 
 function getEditorOverlayTitle(mode) {
@@ -10564,7 +10272,7 @@ function setEditorRailWidth(value, options = {}) {
     resizer.setAttribute('aria-valuenow', String(Math.round(width)));
   }
   if (options.persist) {
-    try { window.localStorage.setItem(EDITOR_RAIL_WIDTH_KEY, String(Math.round(width))); } catch (_) {}
+    editorSessionStateStore.writeUnscopedNumber(EDITOR_RAIL_WIDTH_KEY, width);
   }
   return width;
 }
@@ -10577,10 +10285,7 @@ function initEditorRailResize() {
   editorRailResizeBound = true;
 
   let stored = EDITOR_RAIL_DEFAULT_WIDTH;
-  try {
-    const value = window.localStorage.getItem(EDITOR_RAIL_WIDTH_KEY);
-    if (value) stored = Number(value);
-  } catch (_) {}
+  stored = editorSessionStateStore.readUnscopedNumber(EDITOR_RAIL_WIDTH_KEY, EDITOR_RAIL_DEFAULT_WIDTH);
   setEditorRailWidth(stored, { persist: false });
 
   const isMobile = () => {
@@ -10705,8 +10410,6 @@ function initMobileEditorRail() {
 function persistDynamicEditorState() {
   if (!allowEditorStatePersist) return;
   try {
-    const store = window.localStorage;
-    if (!store) return;
     captureEditorContentScroll(currentMode);
     const open = Array.from(dynamicEditorTabs.values())
       .map((tab) => {
@@ -10741,23 +10444,12 @@ function persistDynamicEditorState() {
       state.activeLookupKey = active && (active.lookupKey || active.path) ? (active.lookupKey || active.path) : null;
       state.activePath = active && active.path ? active.path : null;
     }
-    store.setItem(scopedEditorStorageKey(LS_KEYS.editorState), JSON.stringify(state));
+    editorSessionStateStore.writeEditorState(state);
   } catch (_) {}
 }
 
 function restoreDynamicEditorState() {
-  let raw = null;
-  try {
-    const store = window.localStorage;
-    if (!store) return false;
-    raw = store.getItem(scopedEditorStorageKey(LS_KEYS.editorState));
-  } catch (_) {
-    return false;
-  }
-  if (!raw) return false;
-  let data;
-  try { data = JSON.parse(raw); }
-  catch (_) { return false; }
+  const data = editorSessionStateStore.readEditorState();
   if (!data || typeof data !== 'object') return false;
 
   const isV3 = data.v === EDITOR_STATE_VERSION;

--- a/assets/js/editor-drafts.js
+++ b/assets/js/editor-drafts.js
@@ -1,0 +1,31 @@
+import { readJsonStore, writeJsonStore } from './editor-storage.js?v=press-system-v3.4.18';
+
+export function createScopedDraftStore({
+  storage,
+  storageKey,
+  scopeKey
+} = {}) {
+  const resolveKey = () => (typeof scopeKey === 'function' ? scopeKey(storageKey) : storageKey);
+
+  function read() {
+    return readJsonStore(storage, resolveKey(), {});
+  }
+
+  function write(store) {
+    writeJsonStore(storage, resolveKey(), store);
+  }
+
+  function removeEntry(key) {
+    const store = read();
+    if (!store || !Object.prototype.hasOwnProperty.call(store, key)) return false;
+    delete store[key];
+    write(store);
+    return true;
+  }
+
+  return {
+    read,
+    write,
+    removeEntry
+  };
+}

--- a/assets/js/editor-session-state.js
+++ b/assets/js/editor-session-state.js
@@ -1,0 +1,55 @@
+export function createEditorSessionStateStore({
+  storage,
+  scopeKey,
+  keys = {}
+} = {}) {
+  const scoped = (key) => (typeof scopeKey === 'function' ? scopeKey(key) : key);
+
+  function getItem(key) {
+    try { return storage && storage.getItem ? storage.getItem(scoped(key)) : ''; }
+    catch (_) { return ''; }
+  }
+
+  function setItem(key, value) {
+    try {
+      if (storage && storage.setItem) storage.setItem(scoped(key), String(value));
+    } catch (_) {}
+  }
+
+  function readJson(key) {
+    try {
+      const raw = getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function writeJson(key, value) {
+    try {
+      if (storage && storage.setItem) storage.setItem(scoped(key), JSON.stringify(value));
+    } catch (_) {}
+  }
+
+  return {
+    readEditorState: () => readJson(keys.editorState),
+    writeEditorState: (state) => writeJson(keys.editorState, state),
+    readLegacySystemTreeExpanded: () => getItem(keys.systemTreeExpanded) === '1',
+    writeLegacySystemTreeExpanded: (expanded) => setItem(keys.systemTreeExpanded, expanded ? '1' : '0'),
+    readUnscopedNumber(key, fallback = 0) {
+      try {
+        const raw = storage && storage.getItem ? storage.getItem(key) : null;
+        if (raw == null || raw === '') return fallback;
+        const value = Number(raw);
+        return Number.isFinite(value) ? value : fallback;
+      } catch (_) {
+        return fallback;
+      }
+    },
+    writeUnscopedNumber(key, value) {
+      try {
+        if (storage && storage.setItem) storage.setItem(key, String(Math.round(Number(value) || 0)));
+      } catch (_) {}
+    }
+  };
+}

--- a/assets/js/editor-storage.js
+++ b/assets/js/editor-storage.js
@@ -1,0 +1,73 @@
+function normalizeStorageScopePart(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  return raw.replace(/[^a-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'root';
+}
+
+export function resolveEditorStorageScope(locationLike) {
+  let protocol = '';
+  let host = '';
+  let pathname = '';
+  try {
+    if (typeof locationLike === 'string') {
+      const url = new URL(locationLike);
+      protocol = url.protocol;
+      host = url.host;
+      pathname = url.pathname;
+    } else if (locationLike && typeof locationLike === 'object') {
+      if (locationLike.href) {
+        const url = new URL(String(locationLike.href));
+        protocol = url.protocol;
+        host = url.host;
+        pathname = url.pathname;
+      } else {
+        protocol = String(locationLike.protocol || '');
+        host = String(locationLike.host || locationLike.hostname || '');
+        pathname = String(locationLike.pathname || '');
+      }
+    }
+  } catch (_) {
+    return 'unknown';
+  }
+  const path = String(pathname || '');
+  const segments = path.split('/').filter(Boolean);
+  const firstSegment = segments[0] || '';
+  const isRootIndexFile = segments.length === 1
+    && (firstSegment === 'index.html' || firstSegment === 'index_editor.html')
+    && !path.endsWith('/');
+  const sitePath = firstSegment && !isRootIndexFile ? firstSegment : 'root';
+  const protocolPart = protocol ? protocol.replace(/:$/, '') : 'site';
+  return [
+    'v2',
+    normalizeStorageScopePart(protocolPart),
+    normalizeStorageScopePart(host || 'local'),
+    normalizeStorageScopePart(sitePath)
+  ].join(':');
+}
+
+export function createScopedStorageKey(scope, key) {
+  return `${key}:${scope || 'unknown'}`;
+}
+
+export function readJsonStore(storage, key, fallback = {}) {
+  try {
+    const raw = storage && storage.getItem ? storage.getItem(key) : '';
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+export function writeJsonStore(storage, key, store) {
+  try {
+    if (!storage) return;
+    if (!store || !Object.keys(store).length) {
+      storage.removeItem(key);
+      return;
+    }
+    storage.setItem(key, JSON.stringify(store));
+  } catch (_) {
+    /* ignore unavailable storage */
+  }
+}

--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -1,0 +1,78 @@
+import {
+  createConnectPublishCommit,
+  ensureConnectPublishGrant as authorizeConnectPublishGrant
+} from './transports/connect-transport.js?v=press-system-v3.4.18';
+
+export async function ensurePublishGrant({
+  connect,
+  repo,
+  getCachedGrant,
+  setCachedGrant,
+  windowRef = window,
+  documentRef = document,
+  translate = (key) => key
+} = {}) {
+  return authorizeConnectPublishGrant({
+    connect,
+    repo,
+    getCachedGrant,
+    setCachedGrant,
+    windowRef,
+    documentRef,
+    translate
+  });
+}
+
+export async function publishCommit({
+  transport,
+  repo,
+  headline,
+  files,
+  contentRoot,
+  getCachedGrant,
+  setCachedGrant,
+  windowRef = window,
+  documentRef = document,
+  translate = (key) => key,
+  onStatus
+} = {}) {
+  const owner = repo && repo.owner ? String(repo.owner) : '';
+  const name = repo && repo.name ? String(repo.name) : '';
+  const branch = repo && repo.branch ? String(repo.branch) : 'main';
+  if (!owner || !name) {
+    throw new Error('GitHub repository information is missing in site.yaml.');
+  }
+
+  if (transport && transport.type === 'connect') {
+    if (typeof onStatus === 'function') onStatus(translate('editor.composer.github.modal.connectAuthorizing'));
+    const grant = await ensurePublishGrant({
+      connect: transport.connect,
+      repo: { owner, name, branch },
+      getCachedGrant,
+      setCachedGrant,
+      windowRef,
+      documentRef,
+      translate
+    });
+    if (typeof onStatus === 'function') onStatus(translate('editor.composer.github.modal.connectPublishing'));
+    return createConnectPublishCommit({
+      connect: transport.connect,
+      repo: { owner, name, branch },
+      headline,
+      files,
+      grant,
+      contentRoot,
+      translate
+    });
+  }
+
+  const { createFineGrainedTokenCommit } = await import('./transports/github-pat-transport.js?v=press-system-v3.4.18');
+  return createFineGrainedTokenCommit(transport && transport.token, {
+    owner,
+    name,
+    branch,
+    headline,
+    files,
+    onStatus
+  });
+}

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3,9 +3,14 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { createPublishSettingsStore } from '../assets/js/publish/settings-store.js';
+import { createEditorSessionStateStore } from '../assets/js/editor-session-state.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const composerPath = resolve(here, '../assets/js/composer.js');
+const composerSyncPanelPath = resolve(here, '../assets/js/composer-sync-panel.js');
+const composerSystemPanelPath = resolve(here, '../assets/js/composer-system-panel.js');
+const editorStoragePath = resolve(here, '../assets/js/editor-storage.js');
+const publishCommitServicePath = resolve(here, '../assets/js/publish/commit-service.js');
 const publishSettingsPath = resolve(here, '../assets/js/publish/settings-store.js');
 const connectTransportPath = resolve(here, '../assets/js/publish/transports/connect-transport.js');
 const patTransportPath = resolve(here, '../assets/js/publish/transports/github-pat-transport.js');
@@ -26,6 +31,10 @@ const jaI18nPath = resolve(here, '../assets/i18n/ja.js');
 const languagesManifestPath = resolve(here, '../assets/i18n/languages.json');
 const i18nPath = resolve(here, '../assets/js/i18n.js');
 const source = readFileSync(composerPath, 'utf8');
+const composerSyncPanelSource = readFileSync(composerSyncPanelPath, 'utf8');
+const composerSystemPanelSource = readFileSync(composerSystemPanelPath, 'utf8');
+const editorStorageSource = readFileSync(editorStoragePath, 'utf8');
+const publishCommitServiceSource = readFileSync(publishCommitServicePath, 'utf8');
 const publishSettingsSource = readFileSync(publishSettingsPath, 'utf8');
 const connectTransportSource = readFileSync(connectTransportPath, 'utf8');
 const patTransportSource = readFileSync(patTransportPath, 'utf8');
@@ -82,8 +91,8 @@ function extractFunctionDeclaration(text, name) {
 
 function loadRepoInferenceHelpers() {
   const helpers = [
-    extractFunctionDeclaration(source, 'normalizeStorageScopePart'),
-    extractFunctionDeclaration(source, 'resolveEditorStorageScope'),
+    extractFunctionDeclaration(editorStorageSource, 'normalizeStorageScopePart'),
+    extractFunctionDeclaration(editorStorageSource, 'resolveEditorStorageScope').replace('export ', ''),
     extractFunctionDeclaration(source, 'inferRepoConfigFromGitHubPagesUrl'),
     extractFunctionDeclaration(source, 'isPlaceholderRepoConfig'),
     extractFunctionDeclaration(source, 'isSameRepoConfig'),
@@ -242,23 +251,19 @@ assert.notEqual(
 
 assert.match(
   source,
-  /const EDITOR_STORAGE_SCOPE = [\s\S]*resolveEditorStorageScope\(window\.location\)[\s\S]*function scopedEditorStorageKey\(key\) \{[\s\S]*return `\$\{key\}:\$\{EDITOR_STORAGE_SCOPE\}`;/,
+  /const EDITOR_STORAGE_SCOPE = [\s\S]*resolveEditorStorageScope\(window\.location\)[\s\S]*function scopedEditorStorageKey\(key\) \{[\s\S]*return createScopedStorageKey\(EDITOR_STORAGE_SCOPE, key\);/,
   'composer should derive a site-scoped local storage key suffix from window.location'
 );
 
-[
-  'LS_KEYS.editorState',
-  'LS_KEYS.systemTreeExpanded',
-  'LS_KEYS.cfile',
-  'DRAFT_STORAGE_KEY',
-  'MARKDOWN_DRAFT_STORAGE_KEY'
-].forEach((keyName) => {
-  assert.match(
-    source,
-    new RegExp(`scopedEditorStorageKey\\(${keyName.replace('.', '\\.')}\\)`),
-    `${keyName} should use site-scoped browser storage`
-  );
-});
+assert.match(
+  editorStorageSource,
+  /export function createScopedStorageKey\(scope, key\) \{[\s\S]*return `\$\{key\}:\$\{scope \|\| 'unknown'\}`;/,
+  'editor storage helper should build scoped local storage keys'
+);
+
+assert.match(source, /createEditorSessionStateStore\(\{[\s\S]*scopeKey: scopedEditorStorageKey,[\s\S]*keys: LS_KEYS/, 'editor session state should use site-scoped browser storage');
+assert.match(source, /createScopedDraftStore\(\{[\s\S]*storageKey: DRAFT_STORAGE_KEY,[\s\S]*scopeKey: scopedEditorStorageKey[\s\S]*createScopedDraftStore\(\{[\s\S]*storageKey: MARKDOWN_DRAFT_STORAGE_KEY,[\s\S]*scopeKey: scopedEditorStorageKey/, 'composer and markdown draft stores should use site-scoped browser storage');
+assert.match(source, /scopedEditorStorageKey\(LS_KEYS\.cfile\)/, 'active composer file storage should remain site-scoped');
 
 assert.match(
   publishSettingsSource,
@@ -274,6 +279,23 @@ function createMemoryStorage(seed = {}) {
     removeItem: (key) => { data.delete(key); },
     dump: () => Object.fromEntries(data.entries())
   };
+}
+
+{
+  const localStorage = createMemoryStorage();
+  const store = createEditorSessionStateStore({
+    storage: localStorage,
+    scopeKey: (key) => `${key}:scope`,
+    keys: {
+      editorState: 'press_composer_editor_state',
+      systemTreeExpanded: 'press_editor_system_tree_expanded'
+    }
+  });
+  assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'missing rail width should preserve the default width');
+  localStorage.setItem('press_editor_rail_width', '420');
+  assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 420, 'stored rail width should be restored');
+  localStorage.setItem('press_editor_rail_width', 'invalid');
+  assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'invalid rail width should fall back to the default width');
 }
 
 {
@@ -1932,8 +1954,8 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /async function refreshSyncCommitPanel\(options = \{\}\) \{[\s\S]*const headerSubmit = document\.getElementById\('btnSyncSubmit'\)[\s\S]*gatherCommitPayload\(\{ cleanupUnusedAssets: false, showSeoStatus: false \}\)[\s\S]*form\.id = 'syncCommitForm';[\s\S]*const btnSubmit = headerSubmit;[\s\S]*appendPublishTransportStatus\(form\);[\s\S]*appendGithubCommitSummary\(summaryBlock, commitFiles, seoFiles, summaryEntries\)[\s\S]*const transport = resolvePublishTransport\(\);[\s\S]*ensureConnectPublishGrant\(transport\.connect, getActiveSiteRepoConfig\(\)\)[\s\S]*performConnectGithubCommit\(transport\.connect, currentSummary\)[\s\S]*performDirectGithubCommit\(transport\.token, currentSummary\);/,
+  composerSyncPanelSource,
+  /export async function refreshSyncCommitPanelView\(options = \{\}, deps = \{\}\) \{[\s\S]*const headerSubmit = documentRef\.getElementById\('btnSyncSubmit'\)[\s\S]*gatherCommitPayload\(\{ cleanupUnusedAssets: false, showSeoStatus: false \}\)[\s\S]*form\.id = 'syncCommitForm';[\s\S]*const btnSubmit = headerSubmit;[\s\S]*appendPublishTransportStatus\(form\);[\s\S]*appendGithubCommitSummary\(summaryBlock, commitFiles, seoFiles, summaryEntries\)[\s\S]*const transport = resolvePublishTransport\(\);[\s\S]*ensureConnectPublishGrant\(transport\.connect, getActiveSiteRepoConfig\(\)\)[\s\S]*performConnectGithubCommit\(transport\.connect, currentSummary\)[\s\S]*performDirectGithubCommit\(transport\.token, currentSummary\);/,
   'inline Sync page commit form should reuse existing payload and route through the selected publish transport'
 );
 
@@ -1961,10 +1983,16 @@ assert.doesNotMatch(
   'composer should not directly own Connect or GitHub commit transport implementations'
 );
 
+assert.doesNotMatch(
+  publishCommitServiceSource,
+  /import \{ createFineGrainedTokenCommit \} from '\.\/transports\/github-pat-transport\.js\?v=[\w.-]+'/,
+  'publish commit service should not eagerly import the PAT transport on composer startup'
+);
+
 assert.match(
-  source,
-  /import\('\.\/publish\/transports\/github-pat-transport\.js\?v=[\w.-]+'\)/,
-  'PAT fallback transport should be loaded only when the user explicitly selects the PAT path'
+  publishCommitServiceSource,
+  /await import\('\.\/transports\/github-pat-transport\.js\?v=[\w.-]+'\)[\s\S]*createFineGrainedTokenCommit\(transport && transport\.token/,
+  'publish commit service should lazy-load the PAT transport only for PAT publishing'
 );
 
 assert.match(
@@ -2022,7 +2050,7 @@ assert.match(
 );
 
 assert.doesNotMatch(
-  source.slice(source.indexOf('async function refreshSyncCommitPanel(options = {}) {'), source.indexOf('function scheduleSyncCommitPanelRefresh()')),
+  composerSyncPanelSource,
   /editor\.composer\.github\.modal\.tokenLabel|sync-token-help|className = 'sync-token-field'/,
   'Sync page should no longer render the fine-grained token settings inline'
 );
@@ -2764,15 +2792,12 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /function showEditorSystemPanel\(mode\) \{[\s\S]*mode === 'sync' \? 'sync'[\s\S]*editorSystemActions[\s\S]*editorModalThemeActions[\s\S]*editorModalSyncActions[\s\S]*mode-composer[\s\S]*mode-themes[\s\S]*mode-updates[\s\S]*mode-sync[\s\S]*\['themes', themeActions\][\s\S]*\['sync', syncActions\]/,
+  composerSystemPanelSource,
+  /export function showEditorSystemPanel\(mode, deps = \{\}\) \{[\s\S]*mode === 'sync' \? 'sync'[\s\S]*editorSystemActions[\s\S]*editorModalThemeActions[\s\S]*editorModalSyncActions[\s\S]*mode-composer[\s\S]*mode-themes[\s\S]*mode-updates[\s\S]*mode-sync[\s\S]*\['themes', themeActions\][\s\S]*\['sync', syncActions\]/,
   'Site Settings, Themes, Press Updates, and Sync should render through the inline system panel'
 );
 
-const showEditorSystemPanelBody = source.slice(
-  source.indexOf('function showEditorSystemPanel(mode) {'),
-  source.indexOf('function getEditorOverlayTitle(mode)')
-);
+const showEditorSystemPanelBody = composerSystemPanelSource;
 
 assert.doesNotMatch(
   showEditorSystemPanelBody,
@@ -3362,8 +3387,8 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /const showError = \(message, options = \{\}\) => \{[\s\S]*sync-commit-error-hint[\s\S]*connectFallbackHint[\s\S]*sync-connect-fallback-action[\s\S]*switchToPatFallbackAndFocusToken\(\);/,
+  composerSyncPanelSource,
+  /const showError = \(message, errorOptions = \{\}\) => \{[\s\S]*sync-commit-error-hint[\s\S]*connectFallbackHint[\s\S]*sync-connect-fallback-action[\s\S]*switchToPatFallbackAndFocusToken\(\);/,
   'inline Connect authorization errors should render an explicit PAT fallback action'
 );
 
@@ -3375,7 +3400,7 @@ assert.match(
 
 assert.match(
   source,
-  /let connectFallbackActionAvailable = false;[\s\S]*const \{ files \} = await gatherCommitPayload\(\{ showSeoStatus: true \}\);[\s\S]*connectFallbackActionAvailable = true;[\s\S]*await ensureConnectPublishGrant\(transport\.connect[\s\S]*await createConnectPublishCommit\([\s\S]*connectFallbackActionAvailable = false;[\s\S]*if \(transport && transport\.type === 'connect' && connectFallbackActionAvailable\) \{[\s\S]*toastOptions\.action = \{[\s\S]*connectFallback[\s\S]*switchToPatFallbackAndFocusToken\(\);[\s\S]*showToast\('error', message, toastOptions\);/,
+  /let connectFallbackActionAvailable = false;[\s\S]*const \{ files \} = await gatherCommitPayload\(\{ showSeoStatus: true \}\);[\s\S]*connectFallbackActionAvailable = true;[\s\S]*await publishStagedCommit\(\{[\s\S]*transport,[\s\S]*getCachedGrant: getCachedConnectPublishGrant[\s\S]*connectFallbackActionAvailable = false;[\s\S]*if \(transport && transport\.type === 'connect' && connectFallbackActionAvailable\) \{[\s\S]*toastOptions\.action = \{[\s\S]*connectFallback[\s\S]*switchToPatFallbackAndFocusToken\(\);[\s\S]*showToast\('error', message, toastOptions\);/,
   'Only Connect authorization and publish failures should expose a toast action that switches to PAT fallback'
 );
 

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -12,6 +12,7 @@ const indexHtml = read('index.html');
 const indexEditorHtml = read('index_editor.html');
 const indexEditorPreviewHtml = read('index_editor_preview.html');
 const composer = read('assets/js/composer.js');
+const composerStaging = read('assets/js/composer-staging.js');
 const editorMain = read('assets/js/editor-main.js');
 const editorPreviewRuntime = read('assets/js/editor-preview-runtime.js');
 const search = read('assets/js/search.js');
@@ -151,7 +152,7 @@ assert.match(composer, /async function gatherLocalChangesForCommit[\s\S]*await P
 assert.match(composer, /function getLockedEncryptedMarkdownDraft[\s\S]*!draft\.encrypted \|\| draft\.decrypted[\s\S]*const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft\(tab\)[\s\S]*alreadyEncrypted = true/, 'publish should reuse locked encrypted draft ciphertext instead of treating empty editor content as plaintext');
 assert.match(composer, /function bumpMarkdownDraftSaveGeneration[\s\S]*async function saveMarkdownDraftForTab[\s\S]*const saveGeneration = getMarkdownDraftSaveGeneration\(tab\)[\s\S]*if \(saveGeneration !== getMarkdownDraftSaveGeneration\(tab\)\) return null;[\s\S]*function clearMarkdownDraftForTab[\s\S]*bumpMarkdownDraftSaveGeneration\(tab\)/, 'discard and close should cancel in-flight encrypted draft saves before they can rewrite localStorage');
 assert.match(composer, /function createDiscardedMarkdownProtectionState\(protection\)[\s\S]*password: ''[\s\S]*remoteSignature: current\.remoteSignature[\s\S]*setMarkdownProtectionState\(active, createDiscardedMarkdownProtectionState\(protection\)\)/, 'discarding a protected markdown edit should clear discarded password changes instead of reusing them on the next save');
-assert.match(composer, /Object\.defineProperty\(next, 'plaintextContent'[\s\S]*enumerable: false/, 'protected markdown commit plaintext baselines should stay non-enumerable in memory');
+assert.match(composerStaging, /Object\.defineProperty\(next, 'plaintextContent'[\s\S]*enumerable: false/, 'protected markdown commit plaintext baselines should stay non-enumerable in memory');
 assert.match(composer, /async function openMarkdownPushOnGitHub[\s\S]*const plaintextContent = normalizeMarkdownContent[\s\S]*prepareMarkdownForProtectedStorage\(tab, plaintextContent[\s\S]*nsCopyToClipboard\(preparedContent\)[\s\S]*computeTextSignature\(preparedContent\)/, 'manual GitHub edit flow should copy encrypted markdown and watch the encrypted remote signature');
 assert.match(composer, /configureMarkdownPasswordInput[\s\S]*data-1p-ignore[\s\S]*data-lpignore/, 'editor protection password fields should not opt into browser password-manager storage');
 assert.match(themeLayout, /NATIVE_MODULE_CACHE_KEY = '[\w.-]+'/, 'theme layout should cache-bust native modules when shared i18n boundaries change');


### PR DESCRIPTION
## Summary
- Split composer publish orchestration into `publish/commit-service.js` while preserving existing Connect and PAT transport modules.
- Added staging/provider, storage, draft, session-state, sync-panel, and system-panel modules so `composer.js` keeps app wiring and editor-specific state transitions.
- Updated regression tests to assert the new module boundaries, scoped storage behavior, lazy PAT transport loading, and protected markdown plaintext handling.

## Validation
- `node --check assets/js/composer.js` and new extracted JS modules
- `node --experimental-default-type=module scripts/test-composer-identity-grid.js`
- `node scripts/test-ui-components.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node scripts/test-content-model.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- Local preview `bash scripts/preview-local.sh`, then browser check of `index_editor.html` system panel switching and default editor rail width

## Impact
- Editor runtime code changes only; no schema, theme contract, or Connect API contract changes.
- System release package boundary remains covered by existing package/workflow checks.
- Pre-PR internal review found two regressions; both were fixed before opening this PR: default rail width fallback and lazy PAT transport loading.
