### PR TITLE
Split composer staging boundaries

### DIFF
--- a/assets/i18n/cht-hk.js
+++ b/assets/i18n/cht-hk.js
@@ -1,4 +1,4 @@
-import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.20';
+import chtTwTranslations from './cht-tw.js?v=press-system-v3.4.21';
 
 export const languageMeta = { label: '繁體中文（香港）' };
 

--- a/assets/i18n/languages.json
+++ b/assets/i18n/languages.json
@@ -1,7 +1,7 @@
 [
-  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.20" },
-  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.20" },
-  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.20" },
-  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.20" },
-  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.20" }
+  { "value": "en", "label": "English", "module": "./en.js?v=press-system-v3.4.21" },
+  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=press-system-v3.4.21" },
+  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=press-system-v3.4.21" },
+  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=press-system-v3.4.21" },
+  { "value": "ja", "label": "日本語", "module": "./ja.js?v=press-system-v3.4.21" }
 ]

--- a/assets/js/composer-content-staging.js
+++ b/assets/js/composer-content-staging.js
@@ -1,0 +1,350 @@
+import { createCommitFileCollector } from './composer-staging.js?v=press-system-v3.4.21';
+import {
+  listLocalMarkdownAssetReferences,
+  planManagedContentDeletions
+} from './repository-deletions.js?v=press-system-v3.4.21';
+
+export function createContentCommitStagingProvider({
+  getDynamicEditorTabs = () => new Map(),
+  flushMarkdownDraft = async () => null,
+  getStateSlice = () => null,
+  getContentRootSafe = () => 'wwwroot',
+  getRemoteBaseline = () => ({}),
+  getComposerDiffCache = () => ({}),
+  setComposerDiff = () => {},
+  collectCurrentRepositoryMarkdownAssetReferences = async () => ({ refs: new Set(), failures: [] }),
+  collectUnsyncedMarkdownEntries = () => [],
+  getPrimaryEditorApi = () => null,
+  getActiveDynamicTab = () => null,
+  getCurrentMode = () => '',
+  readMarkdownDraftStore = () => ({}),
+  normalizeRelPath = (value) => String(value || '').replace(/\\+/g, '/').replace(/^\/+/, ''),
+  findDynamicTabByPath = () => null,
+  getLockedEncryptedMarkdownDraft = () => '',
+  normalizeMarkdownContent = (value) => String(value == null ? '' : value).replace(/\r\n?/g, '\n'),
+  isEncryptedMarkdownDraftEntry = () => false,
+  prepareMarkdownForProtectedStorage = async (tab, text) => ({ content: text, encrypted: false }),
+  listMarkdownAssets = () => [],
+  isAssetReferencedInContent = () => true,
+  removeMarkdownAsset = () => {},
+  enrichIndexStateForPublish = async (state) => state,
+  toIndexYaml = () => '',
+  toTabsYaml = () => '',
+  toSiteYaml = () => '',
+  setStateSlice = () => {},
+  computeIndexDiff = () => null,
+  recomputeDiff = () => null,
+  listMarkdownAssetDeletions = () => [],
+  safeString = (value) => String(value == null ? '' : value),
+  draftHasAssetDeletions = () => false,
+  textWithFallback = (key, fallback) => fallback,
+  fetchImpl = fetch
+} = {}) {
+  function collectDirtyMarkdownPathsForDeletion() {
+    const paths = new Set();
+    const dynamicEditorTabs = getDynamicEditorTabs();
+    if (dynamicEditorTabs && typeof dynamicEditorTabs.forEach === 'function') {
+      dynamicEditorTabs.forEach((tab) => {
+        if (!tab || !tab.path) return;
+        if (tab.isDirty || (tab.localDraft && (normalizeMarkdownContent(tab.localDraft.content || '') || normalizeMarkdownContent(tab.localDraft.encryptedContent || '') || draftHasAssetDeletions(tab.localDraft)))) {
+          paths.add(tab.path);
+        }
+      });
+    }
+    try {
+      const store = readMarkdownDraftStore();
+      if (store && typeof store === 'object') {
+        Object.keys(store).forEach((key) => {
+          const entry = store[key];
+          if (!entry || typeof entry !== 'object') return;
+          const hasContent = entry.content != null && normalizeMarkdownContent(entry.content);
+          const hasAssets = Array.isArray(entry.assets) && entry.assets.length;
+          const hasDeletedAssets = draftHasAssetDeletions(entry);
+          if (hasContent || hasAssets || hasDeletedAssets) paths.add(key);
+        });
+      }
+    } catch (_) {}
+    return Array.from(paths);
+  }
+
+  function formatRepositoryDeletionBlockers(blocked = []) {
+    const paths = (Array.isArray(blocked) ? blocked : [])
+      .map(item => item && item.path ? String(item.path) : '')
+      .filter(Boolean);
+    if (!paths.length) {
+      return textWithFallback(
+        'editor.toasts.repositoryDeletionDraftsPending',
+        'Unable to delete files while local drafts are still pending.'
+      );
+    }
+    const sample = paths.slice(0, 5).join(', ');
+    const remaining = paths.length > 5 ? paths.length - 5 : 0;
+    const fallbackSuffix = remaining ? `, +${remaining} more` : '';
+    return textWithFallback(
+      'editor.toasts.repositoryDeletionDraftsBlocked',
+      `Publish blocked because deleted files still have local drafts: ${sample}${fallbackSuffix}. Restore, publish, or discard those drafts before deleting the files.`,
+      { sample, remaining }
+    );
+  }
+
+  async function fetchMarkdownForRepositoryDeletion(file) {
+    const path = file && file.path ? String(file.path).replace(/\\+/g, '/').replace(/^\/+/, '') : '';
+    if (!path) return '';
+    try {
+      const resp = await fetchImpl(`${path}?ts=${Date.now()}`, { cache: 'no-store' });
+      if (!resp.ok) return '';
+      return normalizeMarkdownContent(await resp.text());
+    } catch (_) {
+      return '';
+    }
+  }
+
+  async function collectDeletedMarkdownAssetFiles(markdownDeletionFiles = [], options = {}) {
+    const contentRoot = options.contentRoot || 'wwwroot';
+    const referencedAssets = options.referencedAssets instanceof Set ? options.referencedAssets : new Set();
+    const out = [];
+    const seen = new Set();
+    for (const file of Array.isArray(markdownDeletionFiles) ? markdownDeletionFiles : []) {
+      if (!file || !file.deleted || !file.markdownPath) continue;
+      const markdown = await fetchMarkdownForRepositoryDeletion(file);
+      if (!markdown) continue;
+      listLocalMarkdownAssetReferences(markdown, file.markdownPath, contentRoot).forEach((resolved) => {
+        if (!resolved || !resolved.contentPath || !resolved.commitPath) return;
+        if (referencedAssets.has(resolved.contentPath)) return;
+        if (seen.has(resolved.commitPath)) return;
+        seen.add(resolved.commitPath);
+        out.push({
+          kind: 'asset',
+          category: 'content-asset',
+          label: resolved.relativePath || resolved.contentPath,
+          path: resolved.commitPath,
+          markdownPath: resolved.markdownPath,
+          assetPath: resolved.contentPath,
+          assetRelativePath: resolved.relativePath || '',
+          state: 'deleted',
+          deleted: true
+        });
+      });
+    }
+    return out;
+  }
+
+  async function getCommitFiles(options = {}) {
+    const { cleanupUnusedAssets = true } = options;
+    const collector = createCommitFileCollector();
+    const { addFile } = collector;
+    const dynamicEditorTabs = getDynamicEditorTabs();
+
+    try {
+      const tabValues = dynamicEditorTabs && typeof dynamicEditorTabs.values === 'function'
+        ? Array.from(dynamicEditorTabs.values())
+        : [];
+      const flushes = tabValues.map((tab) => (
+        flushMarkdownDraft(tab).catch((err) => {
+          console.warn('Failed to flush markdown draft before commit', err);
+          return null;
+        })
+      ));
+      await Promise.all(flushes);
+    } catch (_) { /* ignore */ }
+
+    const remoteBaseline = getRemoteBaseline() || {};
+    const composerDiffCache = getComposerDiffCache() || {};
+    const siteState = getStateSlice('site');
+    let root;
+    if (siteState && Object.prototype.hasOwnProperty.call(siteState, 'contentRoot')) {
+      root = safeString(siteState.contentRoot);
+    }
+    if (!root) {
+      root = getContentRootSafe();
+    }
+    const normalizedRoot = String(root || '')
+      .replace(/\\+/g, '/').replace(/\/?$/, '');
+    const rootPrefix = normalizedRoot ? `${normalizedRoot}/` : '';
+    const baselineRoot = (() => {
+      const baselineSite = remoteBaseline && remoteBaseline.site && typeof remoteBaseline.site === 'object'
+        ? remoteBaseline.site
+        : {};
+      const raw = Object.prototype.hasOwnProperty.call(baselineSite, 'contentRoot')
+        ? safeString(baselineSite.contentRoot)
+        : '';
+      return String(raw || 'wwwroot').replace(/\\+/g, '/').replace(/\/?$/, '');
+    })();
+    const pendingMarkdownByPath = new Map();
+
+    if (composerDiffCache.tabs && composerDiffCache.tabs.hasChanges) {
+      const state = getStateSlice('tabs') || { __order: [] };
+      const yaml = toTabsYaml(state);
+      addFile({ kind: 'tabs', label: 'tabs.yaml', path: `${rootPrefix}tabs.yaml`, content: yaml });
+    }
+    if (composerDiffCache.site && composerDiffCache.site.hasChanges) {
+      const state = getStateSlice('site') || {};
+      const yaml = toSiteYaml(state);
+      addFile({ kind: 'site', label: 'site.yaml', path: 'site.yaml', content: yaml });
+    }
+
+    const contentDeletionPlan = planManagedContentDeletions({
+      index: getStateSlice('index') || { __order: [] },
+      tabs: getStateSlice('tabs') || { __order: [] },
+      indexBaseline: remoteBaseline.index || { __order: [] },
+      tabsBaseline: remoteBaseline.tabs || { __order: [] },
+      indexDiff: composerDiffCache.index,
+      tabsDiff: composerDiffCache.tabs,
+      contentRoot: normalizedRoot || 'wwwroot',
+      currentContentRoot: normalizedRoot || 'wwwroot',
+      baselineContentRoot: baselineRoot || 'wwwroot',
+      dirtyMarkdownPaths: collectDirtyMarkdownPathsForDeletion()
+    });
+    if (contentDeletionPlan.blocked.length) {
+      throw new Error(formatRepositoryDeletionBlockers(contentDeletionPlan.blocked));
+    }
+    contentDeletionPlan.files.forEach(addFile);
+    const assetReferenceScan = await collectCurrentRepositoryMarkdownAssetReferences({
+      excludeMarkdownPaths: contentDeletionPlan.files.map(file => file && file.markdownPath).filter(Boolean),
+      currentContentRoot: normalizedRoot || 'wwwroot',
+      baselineContentRoot: baselineRoot || 'wwwroot'
+    });
+    const referencedAssetPaths = assetReferenceScan.refs;
+    const assetReferenceScanComplete = !(assetReferenceScan.failures && assetReferenceScan.failures.length);
+    if (assetReferenceScanComplete) {
+      const deletedMarkdownAssetFiles = await collectDeletedMarkdownAssetFiles(contentDeletionPlan.files, {
+        contentRoot: baselineRoot || 'wwwroot',
+        referencedAssets: referencedAssetPaths
+      });
+      deletedMarkdownAssetFiles.forEach(addFile);
+    } else {
+      console.warn('Skipping repository asset deletions because some current markdown files could not be checked.', assetReferenceScan.failures);
+    }
+
+    const markdownEntries = collectUnsyncedMarkdownEntries();
+    if (markdownEntries && markdownEntries.length) {
+      const editorApi = getPrimaryEditorApi();
+      const activeTab = getActiveDynamicTab();
+      let activeValue = null;
+      if (editorApi && typeof editorApi.getValue === 'function' && activeTab && activeTab.mode === getCurrentMode()) {
+        try { activeValue = String(editorApi.getValue() || ''); }
+        catch (_) { activeValue = null; }
+      }
+      const draftStore = readMarkdownDraftStore();
+      for (const entry of markdownEntries) {
+        const rel = normalizeRelPath(entry.path);
+        if (!rel) continue;
+        const repoPath = `${rootPrefix}${rel}`;
+        const tab = findDynamicTabByPath(rel);
+        let text = '';
+        let alreadyEncrypted = false;
+        if (tab) {
+          const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft(tab);
+          if (lockedEncryptedDraft) {
+            text = lockedEncryptedDraft;
+            alreadyEncrypted = true;
+          } else if (tab === activeTab && activeValue != null) {
+            tab.content = activeValue;
+            text = normalizeMarkdownContent(tab.content);
+          } else if (tab.content != null && tab.content !== undefined) {
+            text = normalizeMarkdownContent(tab.content);
+          } else if (tab.localDraft && tab.localDraft.content != null) {
+            text = normalizeMarkdownContent(tab.localDraft.content);
+          }
+        } else if (draftStore && draftStore[rel] && typeof draftStore[rel] === 'object') {
+          const draft = draftStore[rel];
+          if (draft.content != null) text = normalizeMarkdownContent(draft.content);
+          alreadyEncrypted = isEncryptedMarkdownDraftEntry(draft);
+        }
+        const prepared = alreadyEncrypted
+          ? { content: text, encrypted: true }
+          : await prepareMarkdownForProtectedStorage(tab, text, { reason: 'commit' });
+        pendingMarkdownByPath.set(rel, {
+          content: prepared.content,
+          plaintextContent: prepared.encrypted && !alreadyEncrypted ? text : '',
+          protected: !!prepared.encrypted
+        });
+        addFile({
+          kind: 'markdown',
+          label: rel,
+          path: repoPath,
+          content: prepared.content,
+          plaintextContent: prepared.encrypted && !alreadyEncrypted ? text : '',
+          markdownPath: rel,
+          state: entry.state || '',
+          protected: !!prepared.encrypted
+        });
+
+        const assets = listMarkdownAssets(rel);
+        if (assets.length) {
+          const normalizedText = normalizeMarkdownContent(text);
+          const unusedAssets = [];
+          assets.forEach((asset) => {
+            if (!asset || !asset.path || !asset.base64) return;
+            const commitPath = `${rootPrefix}${asset.path}`.replace(/\\+/g, '/');
+            if (!alreadyEncrypted && !isAssetReferencedInContent(normalizedText, asset)) {
+              unusedAssets.push(asset.path);
+              return;
+            }
+            addFile({
+              kind: 'asset',
+              label: asset.relativePath || asset.path,
+              path: commitPath,
+              base64: asset.base64,
+              binary: true,
+              mime: asset.mime || 'application/octet-stream',
+              size: Number.isFinite(asset.size) ? asset.size : 0,
+              markdownPath: rel,
+              assetPath: asset.path,
+              assetRelativePath: asset.relativePath || ''
+            });
+          });
+          if (cleanupUnusedAssets && unusedAssets.length) {
+            unusedAssets.forEach((assetPath) => {
+              removeMarkdownAsset(rel, assetPath);
+            });
+          }
+        }
+      }
+    }
+
+    const originalIndexDiff = composerDiffCache.index || recomputeDiff('index');
+    const indexState = getStateSlice('index') || { __order: [] };
+    let indexYaml = toIndexYaml(indexState);
+    let indexMetadataChanged = false;
+    if ((originalIndexDiff && originalIndexDiff.hasChanges) || pendingMarkdownByPath.size > 0) {
+      const enrichedIndexState = await enrichIndexStateForPublish(indexState, {
+        contentRoot: normalizedRoot || 'wwwroot',
+        pendingMarkdownByPath
+      });
+      const enrichedIndexYaml = toIndexYaml(enrichedIndexState);
+      indexMetadataChanged = enrichedIndexYaml !== indexYaml;
+      if (indexMetadataChanged) {
+        setStateSlice('index', enrichedIndexState);
+        const nextIndexDiff = computeIndexDiff(enrichedIndexState, remoteBaseline.index);
+        setComposerDiff('index', nextIndexDiff);
+        indexYaml = enrichedIndexYaml;
+      }
+    }
+    if ((originalIndexDiff && originalIndexDiff.hasChanges) || indexMetadataChanged) {
+      addFile({ kind: 'index', label: 'index.yaml', path: `${rootPrefix}index.yaml`, content: indexYaml });
+    }
+
+    const assetDeletionRefs = referencedAssetPaths;
+    if (assetReferenceScanComplete) {
+      listMarkdownAssetDeletions().forEach((asset) => {
+        if (!asset || !asset.assetPath || !asset.deleted) return;
+        if (assetDeletionRefs.has(asset.assetPath)) return;
+        const commitPath = `${rootPrefix}${asset.assetPath}`.replace(/\\+/g, '/');
+        addFile({
+          ...asset,
+          label: asset.assetRelativePath || asset.label || asset.assetPath,
+          path: commitPath,
+          deleted: true,
+          state: 'deleted'
+        });
+      });
+    }
+
+    return collector.getFiles();
+  }
+
+  return {
+    getCommitFiles
+  };
+}

--- a/assets/js/composer-index-publish-metadata.js
+++ b/assets/js/composer-index-publish-metadata.js
@@ -1,0 +1,287 @@
+import { computeReadTime, extractExcerpt, parseFrontMatter } from './content.js?v=press-system-v3.4.21';
+import { parseEncryptedMarkdownEnvelope } from './encrypted-content.js?v=press-system-v3.4.21';
+
+const INDEX_PUBLISH_METADATA_KEYS = new Set([
+  'location',
+  'path',
+  'title',
+  'date',
+  'tag',
+  'tags',
+  'image',
+  'thumb',
+  'cover',
+  'excerpt',
+  'readTime',
+  'readMinutes',
+  'minutes',
+  'protected',
+  'encryption',
+  'version',
+  'versionLabel',
+  'ai',
+  'aiGenerated',
+  'llm',
+  'draft',
+  'wip',
+  'unfinished',
+  'inprogress'
+]);
+
+function interpretIndexTruthyFlag(value) {
+  if (value === true) return true;
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'y' || normalized === 'on' || normalized === 'enabled';
+}
+
+function getIndexField(source, keys, isIndexMetadataObject) {
+  const input = isIndexMetadataObject(source) ? source : {};
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(input, key)) {
+      return { found: true, key, value: input[key] };
+    }
+  }
+  return { found: false, key: '', value: undefined };
+}
+
+export function createIndexPublishMetadataEnricher({
+  safeString = (value) => String(value == null ? '' : value),
+  normalizeRelPath = (value) => String(value || '').replace(/\\+/g, '/').replace(/^\/+/, ''),
+  normalizeMarkdownContent = (value) => String(value == null ? '' : value).replace(/\r\n?/g, '\n'),
+  isIndexMetadataObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value),
+  cloneIndexMetadataValue = (value) => value,
+  getIndexVariantLocation = (value) => typeof value === 'string' ? value : safeString(value && (value.location || value.path)),
+  normalizeIndexVariantList = (value) => Array.isArray(value) ? value : [value],
+  prepareIndexState = (state) => state || { __order: [] },
+  deepClone = (value) => JSON.parse(JSON.stringify(value)),
+  sortLangKeys = (entry) => Object.keys(entry || {}).filter(key => key !== '__order').sort(),
+  extractVersionFromPath = () => '',
+  findDynamicTabByPath = () => null,
+  getLockedEncryptedMarkdownDraft = () => '',
+  getMarkdownProtectionState = () => ({}),
+  getContentRootSafe = () => 'wwwroot',
+  fetchImpl = fetch
+} = {}) {
+  function isIndexVariantPublishComplete(value) {
+    if (!isIndexMetadataObject(value)) return false;
+    if (!getIndexVariantLocation(value)) return false;
+    if (!safeString(value.title).trim()) return false;
+    if (value.protected == null && value.encryption == null) return false;
+    const protectedPost = interpretIndexTruthyFlag(value.protected) || !!value.encryption;
+    if (protectedPost) return !!safeString(value.excerpt).trim() || value.readTime != null;
+    return value.readTime != null && safeString(value.excerpt).trim();
+  }
+
+  function normalizeIndexPublishTags(value) {
+    if (Array.isArray(value)) {
+      const tags = value.map(item => safeString(item).trim()).filter(Boolean);
+      return tags.length ? tags : undefined;
+    }
+    const tag = safeString(value).trim();
+    return tag || undefined;
+  }
+
+  function resolveIndexPublishImage(image, location) {
+    const raw = safeString(image).trim();
+    if (!raw) return undefined;
+    if (/^(https?:|data:)/i.test(raw) || raw.startsWith('/')) return raw;
+    const lastSlash = safeString(location).lastIndexOf('/');
+    const baseDir = lastSlash >= 0 ? safeString(location).slice(0, lastSlash + 1) : '';
+    return normalizeRelPath(`${baseDir}${raw}`) || raw;
+  }
+
+  function getIndexGeneratedMetadata(existing = {}) {
+    const out = {};
+    if (!isIndexMetadataObject(existing)) return out;
+    Object.keys(existing).forEach((key) => {
+      if (INDEX_PUBLISH_METADATA_KEYS.has(key)) return;
+      const cloned = cloneIndexMetadataValue(existing[key]);
+      if (cloned !== undefined && cloned !== null && cloned !== '') out[key] = cloned;
+    });
+    return out;
+  }
+
+  function copyExistingIndexFields(out, existing, keys) {
+    if (!out || !isIndexMetadataObject(existing)) return false;
+    let copied = false;
+    keys.forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(existing, key)) return;
+      const cloned = cloneIndexMetadataValue(existing[key]);
+      if (cloned === undefined || cloned === null || cloned === '') return;
+      out[key] = cloned;
+      copied = true;
+    });
+    return copied;
+  }
+
+  function buildIndexMetadataFromMarkdown(markdown, location, fallbackTitle, existing = {}, options = {}) {
+    const source = normalizeMarkdownContent(markdown || '');
+    const plaintext = normalizeMarkdownContent(options.plaintextContent || '');
+    const envelope = parseEncryptedMarkdownEnvelope(source);
+    const { frontMatter } = parseFrontMatter(source);
+    const fm = frontMatter || {};
+    const protectedField = getIndexField(fm, ['protected', 'encryption'], isIndexMetadataObject);
+    const explicitUnprotected = options.protectionExplicit === true && options.protected === false;
+    const existingProtected = interpretIndexTruthyFlag(existing.protected) || !!existing.encryption;
+    const protectedPost = !!options.protected
+      || envelope.encrypted
+      || (protectedField.found ? interpretIndexTruthyFlag(protectedField.value) : (!explicitUnprotected && existingProtected));
+    const out = {
+      ...getIndexGeneratedMetadata(existing),
+      location
+    };
+    const title = safeString(fm.title || existing.title || fallbackTitle).trim();
+    if (title) out.title = title;
+    const dateField = getIndexField(fm, ['date'], isIndexMetadataObject);
+    if (dateField.found) {
+      if (safeString(dateField.value).trim()) out.date = dateField.value;
+    } else {
+      copyExistingIndexFields(out, existing, ['date']);
+    }
+    const tagsField = getIndexField(fm, ['tags', 'tag'], isIndexMetadataObject);
+    if (tagsField.found) {
+      const tags = normalizeIndexPublishTags(tagsField.value);
+      if (tags !== undefined) out.tags = tags;
+    } else {
+      copyExistingIndexFields(out, existing, ['tags', 'tag']);
+    }
+    const imageField = getIndexField(fm, ['image', 'cover', 'thumb'], isIndexMetadataObject);
+    if (imageField.found) {
+      const image = resolveIndexPublishImage(imageField.value, location);
+      if (image) out.image = image;
+    } else {
+      copyExistingIndexFields(out, existing, ['image', 'cover', 'thumb']);
+    }
+    const excerptField = getIndexField(fm, ['excerpt'], isIndexMetadataObject);
+    const excerpt = protectedPost
+      ? safeString(excerptField.found ? excerptField.value : existing.excerpt).trim()
+      : safeString(excerptField.found ? excerptField.value : extractExcerpt(source, 50)).trim();
+    if (excerpt) out.excerpt = excerpt;
+    const readSource = plaintext || (!protectedPost ? source : '');
+    if (readSource) out.readTime = computeReadTime(readSource, 200);
+    else {
+      const readTimeField = getIndexField(existing, ['readTime', 'readMinutes', 'minutes'], isIndexMetadataObject);
+      if (readTimeField.found && readTimeField.value !== '') out.readTime = cloneIndexMetadataValue(readTimeField.value);
+    }
+    out.protected = !!protectedPost;
+    const versionField = getIndexField(fm, ['version', 'versionLabel'], isIndexMetadataObject);
+    if (versionField.found) {
+      const versionLabel = safeString(versionField.value).trim();
+      if (versionLabel) out.versionLabel = versionLabel;
+    } else if (!copyExistingIndexFields(out, existing, ['versionLabel', 'version'])) {
+      const versionLabel = safeString(extractVersionFromPath(location)).trim();
+      if (versionLabel) out.versionLabel = versionLabel;
+    }
+    const aiField = getIndexField(fm, ['ai', 'aiGenerated', 'llm'], isIndexMetadataObject);
+    if (aiField.found) {
+      if (interpretIndexTruthyFlag(aiField.value)) out.ai = true;
+    } else {
+      copyExistingIndexFields(out, existing, ['ai', 'aiGenerated', 'llm']);
+    }
+    const draftField = getIndexField(fm, ['draft', 'wip', 'unfinished', 'inprogress'], isIndexMetadataObject);
+    if (draftField.found) {
+      if (interpretIndexTruthyFlag(draftField.value)) out.draft = true;
+    } else {
+      copyExistingIndexFields(out, existing, ['draft', 'wip', 'unfinished', 'inprogress']);
+    }
+    return out;
+  }
+
+  async function readMarkdownForIndexMetadata(location, pendingMarkdownByPath, contentRoot) {
+    const normalized = normalizeRelPath(location);
+    if (!normalized) return null;
+    if (pendingMarkdownByPath && pendingMarkdownByPath.has(normalized)) {
+      const pending = pendingMarkdownByPath.get(normalized);
+      return pending && typeof pending === 'object'
+        ? { ...pending, protectionExplicit: true }
+        : { content: normalizeMarkdownContent(pending || ''), plaintextContent: '', protected: false, protectionExplicit: true };
+    }
+    const tab = findDynamicTabByPath(normalized);
+    if (tab) {
+      const locked = getLockedEncryptedMarkdownDraft(tab);
+      if (locked) return { content: locked, plaintextContent: '', protected: true, protectionExplicit: true };
+      if (tab.content != null) {
+        const protection = getMarkdownProtectionState(tab);
+        return {
+          content: normalizeMarkdownContent(tab.content),
+          plaintextContent: normalizeMarkdownContent(tab.content),
+          protected: !!(protection && protection.enabled),
+          protectionExplicit: true
+        };
+      }
+      if (tab.remoteContent != null) {
+        const protection = getMarkdownProtectionState(tab);
+        return {
+          content: normalizeMarkdownContent(tab.remoteContent),
+          plaintextContent: normalizeMarkdownContent(tab.remoteContent),
+          protected: !!(protection && protection.enabled),
+          protectionExplicit: true
+        };
+      }
+    }
+    const root = safeString(contentRoot || getContentRootSafe() || 'wwwroot').replace(/\\+/g, '/').replace(/\/?$/, '');
+    const url = `${root || 'wwwroot'}/${normalized}`;
+    try {
+      const response = await fetchImpl(url, { cache: 'no-store' });
+      if (!response || !response.ok) return null;
+      return { content: normalizeMarkdownContent(await response.text()), plaintextContent: '', protected: false };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function enrichIndexStateForPublish(state, options = {}) {
+    const source = prepareIndexState(state || { __order: [] });
+    const next = deepClone(source);
+    const pendingMarkdownByPath = options.pendingMarkdownByPath instanceof Map ? options.pendingMarkdownByPath : new Map();
+    const contentRoot = options.contentRoot || 'wwwroot';
+    const keys = Array.isArray(next.__order) ? next.__order.slice() : Object.keys(next).filter(key => key !== '__order');
+    for (const key of keys) {
+      const entry = next[key];
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+      for (const lang of sortLangKeys(entry)) {
+        const originalValue = entry[lang];
+        const originalWasArray = Array.isArray(originalValue);
+        const variants = normalizeIndexVariantList(originalValue);
+        const enriched = [];
+        for (const variant of variants) {
+          const location = getIndexVariantLocation(variant);
+          if (!location) continue;
+          if (isIndexVariantPublishComplete(variant) && !pendingMarkdownByPath.has(location)) {
+            enriched.push(variant);
+            continue;
+          }
+          const markdownEntry = await readMarkdownForIndexMetadata(location, pendingMarkdownByPath, contentRoot);
+          if (!markdownEntry || !markdownEntry.content) {
+            enriched.push(variant);
+            continue;
+          }
+          enriched.push(buildIndexMetadataFromMarkdown(
+            markdownEntry.content,
+            location,
+            key,
+            isIndexMetadataObject(variant) ? variant : {},
+            {
+              plaintextContent: markdownEntry.plaintextContent,
+              protected: markdownEntry.protected,
+              protectionExplicit: markdownEntry.protectionExplicit
+            }
+          ));
+        }
+        if (!enriched.length) {
+          delete entry[lang];
+        } else if (originalWasArray || enriched.length > 1) {
+          entry[lang] = enriched;
+        } else {
+          entry[lang] = enriched[0];
+        }
+      }
+    }
+    return next;
+  }
+
+  return {
+    buildIndexMetadataFromMarkdown,
+    enrichIndexStateForPublish
+  };
+}

--- a/assets/js/composer-post-commit-state.js
+++ b/assets/js/composer-post-commit-state.js
@@ -1,0 +1,191 @@
+import { parseEncryptedMarkdownEnvelope } from './encrypted-content.js?v=press-system-v3.4.21';
+
+export function createPostCommitStateApplier({
+  stagingRegistry,
+  getStateSlice = () => null,
+  getRemoteBaseline = () => ({}),
+  setRemoteBaselineSlice = () => {},
+  deepClone = (value) => JSON.parse(JSON.stringify(value)),
+  prepareIndexState = (state) => state || { __order: [] },
+  prepareTabsState = (state) => state || { __order: [] },
+  prepareSiteState = (state) => state || {},
+  cloneSiteState = (state) => ({ ...(state || {}) }),
+  notifyComposerChange = () => {},
+  clearDraftStorage = () => {},
+  getContentRootSafe = () => 'wwwroot',
+  applyComposerEffectiveSiteConfig = (state) => state,
+  safeString = (value) => String(value == null ? '' : value),
+  updateComposerMarkdownDraftIndicators = () => {},
+  updateMarkdownPushButton = () => {},
+  updateMarkdownDiscardButton = () => {},
+  updateMarkdownSaveButton = () => {},
+  updateMarkdownProtectionButton = () => {},
+  getActiveDynamicTab = () => null,
+  normalizeRelPath = (value) => String(value || '').replace(/\\+/g, '/').replace(/^\/+/, ''),
+  clearMarkdownDraftEntry = () => {},
+  clearMarkdownAssetsForPath = () => {},
+  findDynamicTabByPath = () => null,
+  computeTextSignature = (value) => String(value || ''),
+  setMarkdownProtectionState = () => {},
+  createMarkdownProtectionState = () => ({}),
+  setDynamicTabStatus = () => {},
+  normalizeMarkdownContent = (value) => String(value == null ? '' : value).replace(/\r\n?/g, '\n'),
+  getMarkdownProtectionState = () => ({}),
+  scheduleMarkdownDraftSave = () => {},
+  updateDynamicTabDirtyState = () => {},
+  removeMarkdownAsset = () => {},
+  removeMarkdownAssetDeletion = () => {},
+  updateUnsyncedSummary = () => {}
+} = {}) {
+  function apply(files = []) {
+    if (!Array.isArray(files) || !files.length) return;
+    if (stagingRegistry && typeof stagingRegistry.clearCommittedFiles === 'function') {
+      stagingRegistry.clearCommittedFiles(files);
+    }
+    const handledMarkdown = new Set();
+    files.forEach((file) => {
+      if (!file || !file.kind) return;
+      if (file.kind === 'index') {
+        const state = getStateSlice('index') || { __order: [] };
+        setRemoteBaselineSlice('index', deepClone(prepareIndexState(state)));
+        notifyComposerChange('index', { skipAutoSave: true });
+        clearDraftStorage('index');
+      } else if (file.kind === 'tabs') {
+        const state = getStateSlice('tabs') || { __order: [] };
+        setRemoteBaselineSlice('tabs', deepClone(prepareTabsState(state)));
+        notifyComposerChange('tabs', { skipAutoSave: true });
+        clearDraftStorage('tabs');
+      } else if (file.kind === 'site') {
+        const state = getStateSlice('site');
+        const snapshot = state ? cloneSiteState(state) : cloneSiteState(prepareSiteState({}));
+        setRemoteBaselineSlice('site', snapshot);
+
+        const previousRoot = getContentRootSafe();
+        const effectiveSnapshot = applyComposerEffectiveSiteConfig(snapshot);
+        const rawNextRoot = effectiveSnapshot && typeof effectiveSnapshot === 'object' && Object.prototype.hasOwnProperty.call(effectiveSnapshot, 'contentRoot')
+          ? safeString(effectiveSnapshot.contentRoot)
+          : '';
+        const normalizedNextRoot = (rawNextRoot ? rawNextRoot : 'wwwroot').trim().replace(/[\\]/g, '/').replace(/\/?$/, '');
+        const rootChanged = normalizedNextRoot !== previousRoot;
+
+        notifyComposerChange('site', { skipAutoSave: true });
+        clearDraftStorage('site');
+
+        if (rootChanged) {
+          updateComposerMarkdownDraftIndicators();
+          updateMarkdownPushButton(getActiveDynamicTab());
+          updateMarkdownDiscardButton(getActiveDynamicTab());
+          updateMarkdownSaveButton(getActiveDynamicTab());
+          updateMarkdownProtectionButton(getActiveDynamicTab());
+        }
+      } else if (file.kind === 'markdown') {
+        const norm = normalizeRelPath(file.markdownPath || file.label || '');
+        if (!norm) return;
+        handledMarkdown.add(norm);
+        if (file.deleted) {
+          clearMarkdownDraftEntry(norm);
+          clearMarkdownAssetsForPath(norm);
+          const tab = findDynamicTabByPath(norm);
+          if (tab) {
+            tab.remoteContent = '';
+            tab.remoteSignature = computeTextSignature('');
+            tab.content = '';
+            tab.loaded = true;
+            tab.localDraft = null;
+            tab.draftConflict = false;
+            tab.isDirty = false;
+            setMarkdownProtectionState(tab, createMarkdownProtectionState());
+            setDynamicTabStatus(tab, {
+              state: 'missing',
+              checkedAt: Date.now(),
+              code: 404,
+              message: 'Deleted via Press'
+            });
+          }
+          updateComposerMarkdownDraftIndicators({ path: norm });
+          return;
+        }
+        const committedText = normalizeMarkdownContent(file.content || '');
+        const tab = findDynamicTabByPath(norm);
+        const commitSignature = computeTextSignature(committedText);
+        const committedEnvelope = parseEncryptedMarkdownEnvelope(committedText);
+        const committedProtected = !!file.protected || committedEnvelope.encrypted;
+        const checkedAt = Date.now();
+        if (tab) {
+          const baselineText = committedProtected
+            ? normalizeMarkdownContent(file.plaintextContent || tab.content || '')
+            : committedText;
+          const currentText = normalizeMarkdownContent(tab.content || '');
+          const hasNewerLocalContent = currentText !== baselineText;
+          tab.remoteContent = baselineText;
+          tab.remoteSignature = commitSignature;
+          tab.loaded = true;
+          if (committedProtected) {
+            setMarkdownProtectionState(tab, {
+              ...getMarkdownProtectionState(tab),
+              enabled: true,
+              encryptedRemote: true,
+              passwordChanged: false,
+              remoteSignature: commitSignature,
+              remoteCiphertext: committedEnvelope.ciphertext || ''
+            });
+          } else {
+            setMarkdownProtectionState(tab, createMarkdownProtectionState());
+          }
+          if (hasNewerLocalContent) {
+            if (tab.localDraft) {
+              tab.localDraft = { ...tab.localDraft, remoteSignature: tab.remoteSignature };
+            }
+            scheduleMarkdownDraftSave(tab);
+            updateDynamicTabDirtyState(tab, { autoSave: false });
+            setDynamicTabStatus(tab, {
+              state: 'existing',
+              checkedAt,
+              message: 'Local edits pending sync'
+            });
+          } else {
+            clearMarkdownDraftEntry(norm);
+            clearMarkdownAssetsForPath(norm);
+            tab.content = baselineText;
+            tab.localDraft = null;
+            tab.draftConflict = false;
+            tab.isDirty = false;
+            updateDynamicTabDirtyState(tab, { autoSave: false });
+            setDynamicTabStatus(tab, {
+              state: 'existing',
+              checkedAt,
+              message: 'Synchronized via Press'
+            });
+          }
+        } else {
+          clearMarkdownDraftEntry(norm);
+          clearMarkdownAssetsForPath(norm);
+        }
+        updateComposerMarkdownDraftIndicators({ path: norm });
+      }
+      else if (file.kind === 'asset') {
+        const norm = normalizeRelPath(file.markdownPath || '');
+        if (!norm) return;
+        const assetPath = normalizeRelPath(file.assetPath || '');
+        if (assetPath) {
+          removeMarkdownAsset(norm, assetPath);
+          removeMarkdownAssetDeletion(norm, assetPath);
+        }
+        else if (file.path) {
+          const withoutRoot = file.path.replace(/^\/?(?:wwwroot\/)?/, '');
+          removeMarkdownAsset(norm, normalizeRelPath(withoutRoot));
+          removeMarkdownAssetDeletion(norm, normalizeRelPath(withoutRoot));
+        }
+      }
+    });
+    updateUnsyncedSummary();
+    updateMarkdownPushButton(getActiveDynamicTab());
+    updateMarkdownDiscardButton(getActiveDynamicTab());
+    updateMarkdownSaveButton(getActiveDynamicTab());
+    updateMarkdownProtectionButton(getActiveDynamicTab());
+  }
+
+  return {
+    apply
+  };
+}

--- a/assets/js/composer-publish-flow.js
+++ b/assets/js/composer-publish-flow.js
@@ -1,5 +1,5 @@
-import { ensurePublishGrant, publishCommit as publishStagedCommit } from './publish/commit-service.js?v=press-system-v3.4.20';
-import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.20';
+import { ensurePublishGrant, publishCommit as publishStagedCommit } from './publish/commit-service.js?v=press-system-v3.4.21';
+import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js?v=press-system-v3.4.21';
 
 export function createComposerPublishFlow({
   windowRef = window,

--- a/assets/js/composer-publish-settings-ui.js
+++ b/assets/js/composer-publish-settings-ui.js
@@ -2,7 +2,7 @@ import {
   CONNECT_PUBLISH_PRESETS,
   getDefaultConnectPublishBaseUrl,
   normalizeConnectPublishBaseUrl
-} from './publish/settings-store.js?v=press-system-v3.4.20';
+} from './publish/settings-store.js?v=press-system-v3.4.21';
 
 export function createPublishTransportSettingsUi({
   documentRef = document,

--- a/assets/js/composer-seo-staging.js
+++ b/assets/js/composer-seo-staging.js
@@ -1,0 +1,422 @@
+import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.21';
+
+function escapeSeoXml(str) {
+  return String(str || '').replace(/[<>&'\"]/g, (char) => {
+    switch (char) {
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '&': return '&amp;';
+      case "'": return '&apos;';
+      case '"': return '&quot;';
+      default: return char;
+    }
+  });
+}
+
+function escapeSeoHtml(str) {
+  return String(str || '').replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return char;
+    }
+  });
+}
+
+function formatSeoXml(xml) {
+  try {
+    const formatted = [];
+    let pad = 0;
+    xml
+      .replace(/>(\s*)</g, '>$1\n<')
+      .split('\n')
+      .forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        if (/^<\//.test(trimmed)) pad = Math.max(pad - 1, 0);
+        formatted.push(`${'  '.repeat(pad)}${trimmed}`);
+        if (/^<[^!?][^>]*[^/]>/i.test(trimmed) && !/<.*<\/.*>/.test(trimmed)) pad += 1;
+      });
+    return formatted.join('\n');
+  } catch (_) {
+    return xml;
+  }
+}
+
+function generateSeoSitemapXml(urls) {
+  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+  xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n';
+  urls.forEach((url) => {
+    if (!url || !url.loc) return;
+    xml += '  <url>\n';
+    xml += `    <loc>${escapeSeoXml(url.loc)}</loc>\n`;
+    if (Array.isArray(url.alternates)) {
+      url.alternates.forEach((alt) => {
+        if (!alt || !alt.href || !alt.hreflang) return;
+        xml += `    <xhtml:link rel="alternate" hreflang="${escapeSeoXml(alt.hreflang)}" href="${escapeSeoXml(alt.href)}"/>\n`;
+      });
+      if (url.xdefault) {
+        xml += `    <xhtml:link rel="alternate" hreflang="x-default" href="${escapeSeoXml(url.xdefault)}"/>\n`;
+      }
+    }
+    if (url.lastmod) xml += `    <lastmod>${escapeSeoXml(url.lastmod)}</lastmod>\n`;
+    if (url.changefreq) xml += `    <changefreq>${escapeSeoXml(url.changefreq)}</changefreq>\n`;
+    if (url.priority) xml += `    <priority>${escapeSeoXml(url.priority)}</priority>\n`;
+    xml += '  </url>\n';
+  });
+  xml += '</urlset>';
+  return formatSeoXml(xml);
+}
+
+function computeSeoContentRoot(siteConfig) {
+  const raw = siteConfig && siteConfig.contentRoot ? String(siteConfig.contentRoot) : 'wwwroot';
+  const trimmed = raw.trim().replace(/^\/+|\/+$/g, '');
+  return trimmed || 'wwwroot';
+}
+
+function generateSeoRobotsTxt(siteConfig) {
+  const baseUrl = resolveSiteBaseUrl(siteConfig);
+  const contentRoot = computeSeoContentRoot(siteConfig);
+  const deriveBasePath = () => {
+    if (!baseUrl) return '/';
+    const ensureLeadingAndTrailingSlash = (value) => {
+      if (!value) return '/';
+      let normalized = value;
+      if (!normalized.startsWith('/')) normalized = `/${normalized}`;
+      normalized = normalized.replace(/\/+/g, '/');
+      if (normalized !== '/' && !normalized.endsWith('/')) normalized = `${normalized}/`;
+      return normalized === '//' ? '/' : normalized;
+    };
+    const resolvePathname = (raw) => {
+      if (!raw) return '/';
+      try {
+        const parsed = new URL(raw);
+        return parsed.pathname || '/';
+      } catch (_) {
+        try {
+          if (typeof window !== 'undefined' && window.location && window.location.origin) {
+            const parsed = new URL(raw, window.location.origin);
+            return parsed.pathname || '/';
+          }
+        } catch (_) {
+          /* noop */
+        }
+      }
+      if (typeof raw === 'string') {
+        const trimmed = raw.trim();
+        if (trimmed.startsWith('/')) return trimmed;
+      }
+      return '/';
+    };
+    const pathname = resolvePathname(baseUrl);
+    if (!pathname || pathname === '/') return '/';
+    return ensureLeadingAndTrailingSlash(pathname);
+  };
+  const basePath = deriveBasePath();
+  const withBasePath = (path) => {
+    const input = String(path == null ? '' : path).trim();
+    if (!input || input === '/') return basePath;
+    const hasTrailingSlash = input.endsWith('/');
+    const stripped = input.replace(/^\/+/, '');
+    const prefix = basePath === '/' ? '/' : basePath;
+    let combined = prefix === '/' ? `/${stripped}` : `${prefix}${stripped}`;
+    if (hasTrailingSlash && !combined.endsWith('/')) combined += '/';
+    if (!combined.startsWith('/')) combined = `/${combined}`;
+    return combined === '//' ? '/' : combined;
+  };
+  let robots = 'User-agent: *\n';
+  robots += `Allow: ${withBasePath('/')}\n\n`;
+  robots += '# Sitemap\n';
+  robots += `Sitemap: ${baseUrl}sitemap.xml\n\n`;
+  robots += '# Allow crawling of main content\n';
+  robots += `Allow: ${withBasePath(`${contentRoot}/`)}\n`;
+  robots += `Allow: ${withBasePath('assets/')}\n\n`;
+  robots += '# Disallow admin or internal directories\n';
+  robots += `Disallow: ${withBasePath('admin/')}\n`;
+  robots += `Disallow: ${withBasePath('.git/')}\n`;
+  robots += `Disallow: ${withBasePath('node_modules/')}\n`;
+  robots += `Disallow: ${withBasePath('.env')}\n`;
+  robots += `Disallow: ${withBasePath('package.json')}\n`;
+  robots += `Disallow: ${withBasePath('package-lock.json')}\n\n`;
+  robots += '# SEO tools (allow but not priority)\n';
+  robots += `Allow: ${withBasePath('sitemap-generator.html')}\n\n`;
+  robots += '# Crawl delay (be nice to servers)\n';
+  robots += 'Crawl-delay: 1\n\n';
+  robots += '# Generated by Press\n';
+  robots += `# ${new Date().toISOString()}\n`;
+  return robots;
+}
+
+function generateSeoMetaTags(siteConfig) {
+  const baseUrl = resolveSiteBaseUrl(siteConfig);
+  const getLocalizedValue = (val, fallback = '') => {
+    if (!val) return fallback;
+    if (typeof val === 'string') return val;
+    if (val.default) return val.default;
+    const langs = Object.keys(val);
+    if (langs.length) return val[langs[0]];
+    return fallback;
+  };
+  const siteTitle = getLocalizedValue(siteConfig.siteTitle, 'Press');
+  const siteDescription = getLocalizedValue(siteConfig.siteDescription, 'Where knowledge becomes pages.');
+  const siteKeywords = getLocalizedValue(siteConfig.siteKeywords, 'blog, static site, markdown');
+  const avatar = siteConfig.avatar || 'assets/avatar.png';
+  const fullAvatarUrl = avatar.startsWith('http') ? avatar : baseUrl + avatar.replace(/^\/+/, '');
+  let html = '';
+  html += `  <!-- Primary SEO Meta Tags -->\n`;
+  html += `  <title>${escapeSeoHtml(siteTitle)}</title>\n`;
+  html += `  <meta name="title" content="${escapeSeoHtml(siteTitle)}">\n`;
+  html += `  <meta name="description" content="${escapeSeoHtml(siteDescription)}">\n`;
+  html += `  <meta name="keywords" content="${escapeSeoHtml(siteKeywords)}">\n`;
+  html += `  <meta name="author" content="${escapeSeoHtml(siteTitle)}">\n`;
+  html += '  <meta name="robots" content="index, follow">\n';
+  html += `  <link rel="canonical" href="${baseUrl}">\n`;
+  html += '  \n';
+  html += '  <!-- Open Graph / Facebook -->\n';
+  html += '  <meta property="og:type" content="website">\n';
+  html += `  <meta property="og:url" content="${baseUrl}">\n`;
+  html += `  <meta property="og:title" content="${escapeSeoHtml(siteTitle)}">\n`;
+  html += `  <meta property="og:description" content="${escapeSeoHtml(siteDescription)}">\n`;
+  html += `  <meta property="og:image" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
+  html += `  <meta property="og:logo" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
+  html += '  \n';
+  html += '  <!-- Twitter -->\n';
+  html += '  <meta property="twitter:card" content="summary_large_image">\n';
+  html += `  <meta property="twitter:url" content="${baseUrl}">\n`;
+  html += `  <meta property="twitter:title" content="${escapeSeoHtml(siteTitle)}">\n`;
+  html += `  <meta property="twitter:description" content="${escapeSeoHtml(siteDescription)}">\n`;
+  html += `  <meta property="twitter:image" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
+  html += '  \n';
+  html += '  <!-- Initial meta tags - will be updated by dynamic SEO system -->\n';
+  html += '  <meta name="theme-color" content="#1a1a1a">\n';
+  html += '  <meta name="msapplication-TileColor" content="#1a1a1a">\n';
+  html += `  <link rel="icon" type="image/png" href="${escapeSeoHtml(avatar)}">`;
+  return html;
+}
+
+function normalizeSeoLangCode(value) {
+  const raw = String(value == null ? '' : value).trim();
+  if (!raw) return '';
+  const sanitized = raw.replace(/[^0-9A-Za-z-]/g, '');
+  return sanitized || '';
+}
+
+function computeSeoHtmlLang(siteConfig) {
+  const fromConfig = siteConfig && siteConfig.defaultLanguage;
+  const normalized = normalizeSeoLangCode(fromConfig);
+  if (normalized) return normalized;
+  try {
+    if (typeof document !== 'undefined' && document.documentElement) {
+      const docLang = normalizeSeoLangCode(document.documentElement.lang);
+      if (docLang) return docLang;
+    }
+  } catch (_) { /* ignore */ }
+  return 'en';
+}
+
+function applySeoHtmlLang(html, lang) {
+  const normalized = normalizeSeoLangCode(lang);
+  if (!normalized) return html;
+  const langAttrRegex = /(<html\b[^>]*\blang\s*=\s*)(["'])([^"']*)(\2)/i;
+  if (langAttrRegex.test(html)) {
+    return html.replace(langAttrRegex, `$1$2${normalized}$4`);
+  }
+  return html.replace(/<html\b([^>]*)>/i, `<html$1 lang="${normalized}">`);
+}
+
+function injectSeoMetaIntoIndexHtml(baseHtml, metaBlock) {
+  if (!baseHtml) return '';
+  const META_START = '  <!-- Primary SEO Meta Tags -->';
+  const META_NOTE = '  <!-- Note: Structured data is dynamically generated by the SEO system -->';
+  const startIndex = baseHtml.indexOf(META_START);
+  const noteIndex = baseHtml.indexOf(META_NOTE);
+  if (startIndex === -1 || noteIndex === -1 || noteIndex < startIndex) return '';
+  const before = baseHtml.slice(0, startIndex);
+  const after = baseHtml.slice(noteIndex + META_NOTE.length);
+  const trimmedMeta = metaBlock.trimEnd();
+  const replacement = `${trimmedMeta}\n\n${META_NOTE}`;
+  return `${before}${replacement}${after}`;
+}
+
+function buildDefaultIndexHtml(metaBlock, lang) {
+  const langAttr = normalizeSeoLangCode(lang) || 'en';
+  const trimmedMeta = metaBlock.trimEnd();
+  const metaSection = trimmedMeta ? `${trimmedMeta}\n\n` : '';
+  let html = '<!DOCTYPE html>\n';
+  html += `<html lang="${escapeSeoHtml(langAttr)}">\n\n`;
+  html += '<head>\n';
+  html += '  <meta charset="UTF-8">\n';
+  html += '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n\n';
+  html += metaSection;
+  html += '  <!-- Note: Structured data is dynamically generated by the SEO system -->\n\n';
+  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.21"></script>\n';
+  html += '  <link rel="stylesheet" id="theme-pack">\n';
+  html += '</head>\n\n';
+  html += '<body>\n';
+  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.21"></script>\n';
+  html += '</body>\n\n';
+  html += '</html>\n';
+  return html;
+}
+
+function generateSeoIndexHtml(siteConfig, baseHtml) {
+  const metaBlock = ensureTrailingNewline(generateSeoMetaTags(siteConfig)).trimEnd();
+  const lang = computeSeoHtmlLang(siteConfig);
+  let html = '';
+  if (baseHtml) {
+    html = injectSeoMetaIntoIndexHtml(baseHtml, metaBlock);
+  }
+  if (!html) {
+    html = buildDefaultIndexHtml(metaBlock, lang);
+  }
+  html = applySeoHtmlLang(html, lang);
+  return ensureTrailingNewline(html);
+}
+
+function ensureTrailingNewline(text) {
+  const str = String(text == null ? '' : text);
+  return str.endsWith('\n') ? str : `${str}\n`;
+}
+
+function normalizeSeoContent(text) {
+  return String(text == null ? '' : text)
+    .replace(/\r\n?/g, '\n')
+    .trim();
+}
+
+export function createSeoStagingProvider({
+  getStateSlice = () => ({}),
+  getContentRootSafe = () => 'wwwroot',
+  getRemoteBaselineSite = () => ({}),
+  cloneSiteState = (state) => ({ ...(state || {}) }),
+  isIndexMetadataObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value),
+  getIndexVariantLocation = (value) => typeof value === 'string' ? value : String(value && (value.location || value.path) || ''),
+  fetchImpl = fetch
+} = {}) {
+  function exportIndexDataForSeo(state) {
+    const output = {};
+    if (!state || typeof state !== 'object') return output;
+    const keys = Array.isArray(state.__order)
+      ? state.__order.filter((key) => key && key !== '__order')
+      : Object.keys(state);
+    keys.forEach((key) => {
+      if (key === '__order') return;
+      const entry = state[key];
+      if (!entry || typeof entry !== 'object') return;
+      const langs = {};
+      Object.keys(entry).forEach((lang) => {
+        if (lang === '__order') return;
+        const value = entry[lang];
+        if (Array.isArray(value)) {
+          const normalized = value
+            .map((item) => getIndexVariantLocation(item))
+            .filter((item) => item);
+          if (!normalized.length) return;
+          if (normalized.length === 1) langs[lang] = normalized[0];
+          else langs[lang] = normalized;
+        } else if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (trimmed) langs[lang] = trimmed;
+        } else if (isIndexMetadataObject(value)) {
+          const location = getIndexVariantLocation(value);
+          if (location) langs[lang] = location;
+        }
+      });
+      if (Object.keys(langs).length) output[key] = langs;
+    });
+    return output;
+  }
+
+  function exportTabsDataForSeo(state) {
+    const output = {};
+    if (!state || typeof state !== 'object') return output;
+    const keys = Array.isArray(state.__order)
+      ? state.__order.filter((key) => key && key !== '__order')
+      : Object.keys(state);
+    keys.forEach((key) => {
+      if (key === '__order') return;
+      const entry = state[key];
+      if (!entry || typeof entry !== 'object') return;
+      const langs = {};
+      Object.keys(entry).forEach((lang) => {
+        if (lang === '__order') return;
+        const value = entry[lang];
+        if (!value || typeof value !== 'object') return;
+        const title = value.title != null ? String(value.title) : '';
+        const location = value.location != null ? String(value.location) : '';
+        if (!title && !location) return;
+        langs[lang] = { title, location };
+      });
+      if (Object.keys(langs).length) output[key] = langs;
+    });
+    return output;
+  }
+
+  function exportSiteConfigForSeo(state) {
+    const base = cloneSiteState(state || {});
+    if (!base.contentRoot) base.contentRoot = getContentRootSafe() || 'wwwroot';
+    if (!base.defaultLanguage) {
+      try {
+        const baseline = getRemoteBaselineSite();
+        if (baseline && baseline.defaultLanguage) base.defaultLanguage = baseline.defaultLanguage;
+      } catch (_) { /* ignore */ }
+    }
+    return base;
+  }
+
+  async function fetchExistingSeoFile(path) {
+    try {
+      const response = await fetchImpl(path, { cache: 'no-store' });
+      if (!response.ok) return '';
+      return await response.text();
+    } catch (_) {
+      return '';
+    }
+  }
+
+  async function getCommitFiles() {
+    try {
+      const siteState = exportSiteConfigForSeo(getStateSlice('site'));
+      const indexState = exportIndexDataForSeo(getStateSlice('index'));
+      const tabsState = exportTabsDataForSeo(getStateSlice('tabs'));
+      const urls = generateSitemapData(indexState, tabsState, siteState) || [];
+      const sitemapXml = ensureTrailingNewline(generateSeoSitemapXml(urls));
+      const robotsTxt = ensureTrailingNewline(generateSeoRobotsTxt(siteState));
+      const remoteIndexHtml = await fetchExistingSeoFile('index.html');
+      const indexHtml = generateSeoIndexHtml(siteState, remoteIndexHtml);
+
+      const candidates = [
+        { seoType: 'sitemap', path: 'sitemap.xml', label: 'sitemap.xml', content: sitemapXml },
+        { seoType: 'robots', path: 'robots.txt', label: 'robots.txt', content: robotsTxt },
+        { seoType: 'index', path: 'index.html', label: 'index.html', content: indexHtml, remote: remoteIndexHtml }
+      ];
+
+      const files = [];
+      for (const candidate of candidates) {
+        const remote = Object.prototype.hasOwnProperty.call(candidate, 'remote')
+          ? candidate.remote
+          : await fetchExistingSeoFile(candidate.path);
+        if (normalizeSeoContent(remote) === normalizeSeoContent(candidate.content)) continue;
+        files.push({
+          kind: 'seo',
+          seoType: candidate.seoType,
+          label: candidate.label,
+          path: candidate.path,
+          content: candidate.content,
+          isSeo: true
+        });
+      }
+      return files;
+    } catch (err) {
+      console.error('Failed to prepare SEO files for commit', err);
+      return [];
+    }
+  }
+
+  return {
+    getCommitFiles
+  };
+}

--- a/assets/js/composer-staging.js
+++ b/assets/js/composer-staging.js
@@ -28,10 +28,21 @@ export function createCommitFileCollector() {
 function normalizeProviderEntries(entries, provider) {
   return (Array.isArray(entries) ? entries : [])
     .filter(entry => entry && typeof entry === 'object')
-    .map(entry => ({
-      ...entry,
-      providerId: entry.providerId || provider.id
-    }));
+    .map(entry => {
+      const next = {
+        ...entry,
+        providerId: entry.providerId || provider.id
+      };
+      if (Object.prototype.hasOwnProperty.call(entry, 'plaintextContent')) {
+        Object.defineProperty(next, 'plaintextContent', {
+          value: String(entry.plaintextContent || ''),
+          enumerable: false,
+          configurable: true,
+          writable: true
+        });
+      }
+      return next;
+    });
 }
 
 export function createStagingRegistry() {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8,47 +8,48 @@ import {
   resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.20';
-import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=press-system-v3.4.20';
-import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.20';
-import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.20';
-import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.20';
-import { computeReadTime, extractExcerpt, parseFrontMatter } from './content.js';
+import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=press-system-v3.4.21';
+import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=press-system-v3.4.21';
+import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=press-system-v3.4.21';
+import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=press-system-v3.4.21';
 import {
   decryptMarkdownDocument,
   encryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope
-} from './encrypted-content.js?v=press-system-v3.4.20';
+} from './encrypted-content.js?v=press-system-v3.4.21';
 import {
   collectLocalMarkdownAssetReferences,
   collectManagedMarkdownReferences,
   listLocalMarkdownAssetReferences,
-  planManagedContentDeletions,
   resolveLocalMarkdownAssetReference
-} from './repository-deletions.js?v=press-system-v3.4.20';
-import { createCommitFileCollector, createStagingRegistry } from './composer-staging.js?v=press-system-v3.4.20';
+} from './repository-deletions.js?v=press-system-v3.4.21';
+import { createStagingRegistry } from './composer-staging.js?v=press-system-v3.4.21';
+import { createIndexPublishMetadataEnricher } from './composer-index-publish-metadata.js?v=press-system-v3.4.21';
+import { createContentCommitStagingProvider } from './composer-content-staging.js?v=press-system-v3.4.21';
+import { createSeoStagingProvider } from './composer-seo-staging.js?v=press-system-v3.4.21';
+import { createPostCommitStateApplier } from './composer-post-commit-state.js?v=press-system-v3.4.21';
 import {
   createScopedStorageKey,
   resolveEditorStorageScope
-} from './editor-storage.js?v=press-system-v3.4.20';
-import { createScopedDraftStore } from './editor-drafts.js?v=press-system-v3.4.20';
-import { createEditorSessionStateStore } from './editor-session-state.js?v=press-system-v3.4.20';
+} from './editor-storage.js?v=press-system-v3.4.21';
+import { createScopedDraftStore } from './editor-drafts.js?v=press-system-v3.4.21';
+import { createEditorSessionStateStore } from './editor-session-state.js?v=press-system-v3.4.21';
 import {
   refreshSyncCommitPanelView,
   scheduleSyncCommitPanelRefreshView
-} from './composer-sync-panel.js?v=press-system-v3.4.20';
-import { createSyncOverlayController } from './composer-sync-overlay.js?v=press-system-v3.4.20';
+} from './composer-sync-panel.js?v=press-system-v3.4.21';
+import { createSyncOverlayController } from './composer-sync-overlay.js?v=press-system-v3.4.21';
 import {
   animateEditorSystemPanelContent as animateSystemPanelContent,
   showEditorSystemPanel as showComposerSystemPanel
-} from './composer-system-panel.js?v=press-system-v3.4.20';
-import { createPublishTransportSettingsUi } from './composer-publish-settings-ui.js?v=press-system-v3.4.20';
-import { createPublishSummaryRenderer } from './composer-publish-summary.js?v=press-system-v3.4.20';
-import { createComposerPublishFlow } from './composer-publish-flow.js?v=press-system-v3.4.20';
+} from './composer-system-panel.js?v=press-system-v3.4.21';
+import { createPublishTransportSettingsUi } from './composer-publish-settings-ui.js?v=press-system-v3.4.21';
+import { createPublishSummaryRenderer } from './composer-publish-summary.js?v=press-system-v3.4.21';
+import { createComposerPublishFlow } from './composer-publish-flow.js?v=press-system-v3.4.21';
 import {
   CONNECT_PUBLISH_PRESETS,
   createPublishSettingsStore
-} from './publish/settings-store.js?v=press-system-v3.4.20';
+} from './publish/settings-store.js?v=press-system-v3.4.21';
 
 // Utility helpers
 const $ = (s, r = document) => r.querySelector(s);
@@ -182,7 +183,7 @@ const publishFlow = createComposerPublishFlow({
   getActiveSiteRepoConfig: () => getActiveSiteRepoConfig(),
   getTrackedPublishContentRoot: () => getTrackedPublishContentRoot(),
   gatherCommitPayload: (options) => gatherCommitPayload(options),
-  applyLocalPostCommitState: (files) => applyLocalPostCommitState(files),
+  applyLocalPostCommitState: (files) => postCommitStateApplier.apply(files),
   getCachedConnectPublishGrant,
   setCachedConnectPublishGrant,
   clearCachedConnectPublishGrant,
@@ -205,6 +206,112 @@ const {
   ensureConnectPublishGrant
 } = publishFlow;
 const stagingRegistry = createStagingRegistry();
+const indexPublishMetadata = createIndexPublishMetadataEnricher({
+  safeString,
+  normalizeRelPath,
+  normalizeMarkdownContent,
+  isIndexMetadataObject,
+  cloneIndexMetadataValue,
+  getIndexVariantLocation,
+  normalizeIndexVariantList,
+  prepareIndexState,
+  deepClone,
+  sortLangKeys,
+  extractVersionFromPath,
+  findDynamicTabByPath,
+  getLockedEncryptedMarkdownDraft,
+  getMarkdownProtectionState,
+  getContentRootSafe
+});
+const contentCommitStagingProvider = createContentCommitStagingProvider({
+  getDynamicEditorTabs: () => dynamicEditorTabs,
+  flushMarkdownDraft,
+  getStateSlice,
+  getContentRootSafe,
+  getRemoteBaseline: () => remoteBaseline,
+  getComposerDiffCache: () => composerDiffCache,
+  setComposerDiff: (kind, diff) => {
+    composerDiffCache[kind] = diff;
+  },
+  collectCurrentRepositoryMarkdownAssetReferences,
+  collectUnsyncedMarkdownEntries,
+  getPrimaryEditorApi,
+  getActiveDynamicTab,
+  getCurrentMode: () => currentMode,
+  readMarkdownDraftStore,
+  normalizeRelPath,
+  findDynamicTabByPath,
+  getLockedEncryptedMarkdownDraft,
+  normalizeMarkdownContent,
+  isEncryptedMarkdownDraftEntry,
+  prepareMarkdownForProtectedStorage,
+  listMarkdownAssets,
+  isAssetReferencedInContent,
+  removeMarkdownAsset,
+  enrichIndexStateForPublish: indexPublishMetadata.enrichIndexStateForPublish,
+  toIndexYaml,
+  toTabsYaml,
+  toSiteYaml,
+  setStateSlice,
+  computeIndexDiff,
+  recomputeDiff,
+  listMarkdownAssetDeletions,
+  safeString,
+  draftHasAssetDeletions,
+  textWithFallback
+});
+const seoStagingProvider = createSeoStagingProvider({
+  getStateSlice,
+  getContentRootSafe,
+  getRemoteBaselineSite: () => remoteBaseline.site,
+  cloneSiteState,
+  isIndexMetadataObject,
+  getIndexVariantLocation
+});
+const postCommitStateApplier = createPostCommitStateApplier({
+  stagingRegistry,
+  getStateSlice,
+  getRemoteBaseline: () => remoteBaseline,
+  setRemoteBaselineSlice: (kind, value) => {
+    remoteBaseline[kind] = value;
+  },
+  deepClone,
+  prepareIndexState,
+  prepareTabsState,
+  prepareSiteState,
+  cloneSiteState,
+  notifyComposerChange,
+  clearDraftStorage,
+  getContentRootSafe,
+  applyComposerEffectiveSiteConfig,
+  safeString,
+  updateComposerMarkdownDraftIndicators,
+  updateMarkdownPushButton,
+  updateMarkdownDiscardButton,
+  updateMarkdownSaveButton,
+  updateMarkdownProtectionButton,
+  getActiveDynamicTab,
+  normalizeRelPath,
+  clearMarkdownDraftEntry,
+  clearMarkdownAssetsForPath,
+  findDynamicTabByPath,
+  computeTextSignature,
+  setMarkdownProtectionState,
+  createMarkdownProtectionState,
+  setDynamicTabStatus,
+  normalizeMarkdownContent,
+  getMarkdownProtectionState,
+  scheduleMarkdownDraftSave,
+  updateDynamicTabDirtyState,
+  removeMarkdownAsset,
+  removeMarkdownAssetDeletion,
+  updateUnsyncedSummary
+});
+stagingRegistry.registerStagingProvider({
+  id: 'content',
+  required: true,
+  getCommitFiles: (context = {}) => contentCommitStagingProvider.getCommitFiles(context)
+});
 stagingRegistry.registerStagingProvider({
   id: 'system-updates',
   getSummaryEntries: () => getSystemUpdateSummaryEntries().map(entry => ({ ...entry, kind: 'system' })),
@@ -225,7 +332,7 @@ stagingRegistry.registerStagingProvider({
         if (typeof context.setStatus === 'function') context.setStatus('Generating SEO files…');
       } catch (_) { /* ignore */ }
     }
-    return generateSeoCommitFiles();
+    return seoStagingProvider.getCommitFiles(context);
   }
 });
 const editorSessionStateStore = createEditorSessionStateStore({
@@ -4670,1012 +4777,16 @@ function findDynamicTabByPath(path) {
   return null;
 }
 
-function encodeContentToBase64(text) {
-  const input = String(text == null ? '' : text);
-  if (typeof window !== 'undefined' && typeof window.TextEncoder === 'function') {
-    try {
-      const encoder = new TextEncoder();
-      const bytes = encoder.encode(input);
-      const chunkSize = 0x8000;
-      let binary = '';
-      for (let i = 0; i < bytes.length; i += chunkSize) {
-        const slice = bytes.subarray(i, i + chunkSize);
-        binary += String.fromCharCode.apply(null, slice);
-      }
-      return btoa(binary);
-    } catch (_) {
-      /* fall through to fallback */
-    }
-  }
-  try {
-    return btoa(unescape(encodeURIComponent(input)));
-  } catch (_) {
-    let binary = '';
-    for (let i = 0; i < input.length; i += 1) {
-      const code = input.charCodeAt(i);
-      if (code > 0xFF) {
-        binary += String.fromCharCode(code >> 8, code & 0xFF);
-      } else {
-        binary += String.fromCharCode(code);
-      }
-    }
-    return btoa(binary);
-  }
-}
-
-function exportIndexDataForSeo(state) {
-  const output = {};
-  if (!state || typeof state !== 'object') return output;
-  const keys = Array.isArray(state.__order)
-    ? state.__order.filter((key) => key && key !== '__order')
-    : Object.keys(state);
-  keys.forEach((key) => {
-    if (key === '__order') return;
-    const entry = state[key];
-    if (!entry || typeof entry !== 'object') return;
-    const langs = {};
-    Object.keys(entry).forEach((lang) => {
-      if (lang === '__order') return;
-      const value = entry[lang];
-      if (Array.isArray(value)) {
-        const normalized = value
-          .map((item) => getIndexVariantLocation(item))
-          .filter((item) => item);
-        if (!normalized.length) return;
-        if (normalized.length === 1) langs[lang] = normalized[0];
-        else langs[lang] = normalized;
-      } else if (typeof value === 'string') {
-        const trimmed = value.trim();
-        if (trimmed) langs[lang] = trimmed;
-      } else if (isIndexMetadataObject(value)) {
-        const location = getIndexVariantLocation(value);
-        if (location) langs[lang] = location;
-      }
-    });
-    if (Object.keys(langs).length) output[key] = langs;
-  });
-  return output;
-}
-
-const INDEX_PUBLISH_METADATA_KEYS = new Set([
-  'location',
-  'path',
-  'title',
-  'date',
-  'tag',
-  'tags',
-  'image',
-  'thumb',
-  'cover',
-  'excerpt',
-  'readTime',
-  'readMinutes',
-  'minutes',
-  'protected',
-  'encryption',
-  'version',
-  'versionLabel',
-  'ai',
-  'aiGenerated',
-  'llm',
-  'draft',
-  'wip',
-  'unfinished',
-  'inprogress'
-]);
-
-function interpretIndexTruthyFlag(value) {
-  if (value === true) return true;
-  const normalized = String(value ?? '').trim().toLowerCase();
-  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'y' || normalized === 'on' || normalized === 'enabled';
-}
-
-function isIndexVariantPublishComplete(value) {
-  if (!isIndexMetadataObject(value)) return false;
-  if (!getIndexVariantLocation(value)) return false;
-  if (!safeString(value.title).trim()) return false;
-  if (value.protected == null && value.encryption == null) return false;
-  const protectedPost = interpretIndexTruthyFlag(value.protected) || !!value.encryption;
-  if (protectedPost) return !!safeString(value.excerpt).trim() || value.readTime != null;
-  return value.readTime != null && safeString(value.excerpt).trim();
-}
-
-function normalizeIndexPublishTags(value) {
-  if (Array.isArray(value)) {
-    const tags = value.map(item => safeString(item).trim()).filter(Boolean);
-    return tags.length ? tags : undefined;
-  }
-  const tag = safeString(value).trim();
-  return tag || undefined;
-}
-
-function resolveIndexPublishImage(image, location) {
-  const raw = safeString(image).trim();
-  if (!raw) return undefined;
-  if (/^(https?:|data:)/i.test(raw) || raw.startsWith('/')) return raw;
-  const lastSlash = safeString(location).lastIndexOf('/');
-  const baseDir = lastSlash >= 0 ? safeString(location).slice(0, lastSlash + 1) : '';
-  return normalizeRelPath(`${baseDir}${raw}`) || raw;
-}
-
-function getIndexGeneratedMetadata(existing = {}) {
-  const out = {};
-  if (!isIndexMetadataObject(existing)) return out;
-  Object.keys(existing).forEach((key) => {
-    if (INDEX_PUBLISH_METADATA_KEYS.has(key)) return;
-    const cloned = cloneIndexMetadataValue(existing[key]);
-    if (cloned !== undefined && cloned !== null && cloned !== '') out[key] = cloned;
-  });
-  return out;
-}
-
-function getIndexField(source, keys) {
-  const input = isIndexMetadataObject(source) ? source : {};
-  for (const key of keys) {
-    if (Object.prototype.hasOwnProperty.call(input, key)) {
-      return { found: true, key, value: input[key] };
-    }
-  }
-  return { found: false, key: '', value: undefined };
-}
-
-function copyExistingIndexFields(out, existing, keys) {
-  if (!out || !isIndexMetadataObject(existing)) return false;
-  let copied = false;
-  keys.forEach((key) => {
-    if (!Object.prototype.hasOwnProperty.call(existing, key)) return;
-    const cloned = cloneIndexMetadataValue(existing[key]);
-    if (cloned === undefined || cloned === null || cloned === '') return;
-    out[key] = cloned;
-    copied = true;
-  });
-  return copied;
-}
-
-function buildIndexMetadataFromMarkdown(markdown, location, fallbackTitle, existing = {}, options = {}) {
-  const source = normalizeMarkdownContent(markdown || '');
-  const plaintext = normalizeMarkdownContent(options.plaintextContent || '');
-  const envelope = parseEncryptedMarkdownEnvelope(source);
-  const { frontMatter } = parseFrontMatter(source);
-  const fm = frontMatter || {};
-  const protectedField = getIndexField(fm, ['protected', 'encryption']);
-  const explicitUnprotected = options.protectionExplicit === true && options.protected === false;
-  const existingProtected = interpretIndexTruthyFlag(existing.protected) || !!existing.encryption;
-  const protectedPost = !!options.protected
-    || envelope.encrypted
-    || (protectedField.found ? interpretIndexTruthyFlag(protectedField.value) : (!explicitUnprotected && existingProtected));
-  const out = {
-    ...getIndexGeneratedMetadata(existing),
-    location
-  };
-  const title = safeString(fm.title || existing.title || fallbackTitle).trim();
-  if (title) out.title = title;
-  const dateField = getIndexField(fm, ['date']);
-  if (dateField.found) {
-    if (safeString(dateField.value).trim()) out.date = dateField.value;
-  } else {
-    copyExistingIndexFields(out, existing, ['date']);
-  }
-  const tagsField = getIndexField(fm, ['tags', 'tag']);
-  if (tagsField.found) {
-    const tags = normalizeIndexPublishTags(tagsField.value);
-    if (tags !== undefined) out.tags = tags;
-  } else {
-    copyExistingIndexFields(out, existing, ['tags', 'tag']);
-  }
-  const imageField = getIndexField(fm, ['image', 'cover', 'thumb']);
-  if (imageField.found) {
-    const image = resolveIndexPublishImage(imageField.value, location);
-    if (image) out.image = image;
-  } else {
-    copyExistingIndexFields(out, existing, ['image', 'cover', 'thumb']);
-  }
-  const excerptField = getIndexField(fm, ['excerpt']);
-  const excerpt = protectedPost
-    ? safeString(excerptField.found ? excerptField.value : existing.excerpt).trim()
-    : safeString(excerptField.found ? excerptField.value : extractExcerpt(source, 50)).trim();
-  if (excerpt) out.excerpt = excerpt;
-  const readSource = plaintext || (!protectedPost ? source : '');
-  if (readSource) out.readTime = computeReadTime(readSource, 200);
-  else {
-    const readTimeField = getIndexField(existing, ['readTime', 'readMinutes', 'minutes']);
-    if (readTimeField.found && readTimeField.value !== '') out.readTime = cloneIndexMetadataValue(readTimeField.value);
-  }
-  out.protected = !!protectedPost;
-  const versionField = getIndexField(fm, ['version', 'versionLabel']);
-  if (versionField.found) {
-    const versionLabel = safeString(versionField.value).trim();
-    if (versionLabel) out.versionLabel = versionLabel;
-  } else if (!copyExistingIndexFields(out, existing, ['versionLabel', 'version'])) {
-    const versionLabel = safeString(extractVersionFromPath(location)).trim();
-    if (versionLabel) out.versionLabel = versionLabel;
-  }
-  const aiField = getIndexField(fm, ['ai', 'aiGenerated', 'llm']);
-  if (aiField.found) {
-    if (interpretIndexTruthyFlag(aiField.value)) out.ai = true;
-  } else {
-    copyExistingIndexFields(out, existing, ['ai', 'aiGenerated', 'llm']);
-  }
-  const draftField = getIndexField(fm, ['draft', 'wip', 'unfinished', 'inprogress']);
-  if (draftField.found) {
-    if (interpretIndexTruthyFlag(draftField.value)) out.draft = true;
-  } else {
-    copyExistingIndexFields(out, existing, ['draft', 'wip', 'unfinished', 'inprogress']);
-  }
-  return out;
-}
-
-async function readMarkdownForIndexMetadata(location, pendingMarkdownByPath, contentRoot) {
-  const normalized = normalizeRelPath(location);
-  if (!normalized) return null;
-  if (pendingMarkdownByPath && pendingMarkdownByPath.has(normalized)) {
-    const pending = pendingMarkdownByPath.get(normalized);
-    return pending && typeof pending === 'object'
-      ? { ...pending, protectionExplicit: true }
-      : { content: normalizeMarkdownContent(pending || ''), plaintextContent: '', protected: false, protectionExplicit: true };
-  }
-  const tab = findDynamicTabByPath(normalized);
-  if (tab) {
-    const locked = getLockedEncryptedMarkdownDraft(tab);
-    if (locked) return { content: locked, plaintextContent: '', protected: true, protectionExplicit: true };
-    if (tab.content != null) {
-      const protection = getMarkdownProtectionState(tab);
-      return {
-        content: normalizeMarkdownContent(tab.content),
-        plaintextContent: normalizeMarkdownContent(tab.content),
-        protected: !!(protection && protection.enabled),
-        protectionExplicit: true
-      };
-    }
-    if (tab.remoteContent != null) {
-      const protection = getMarkdownProtectionState(tab);
-      return {
-        content: normalizeMarkdownContent(tab.remoteContent),
-        plaintextContent: normalizeMarkdownContent(tab.remoteContent),
-        protected: !!(protection && protection.enabled),
-        protectionExplicit: true
-      };
-    }
-  }
-  const root = safeString(contentRoot || getContentRootSafe() || 'wwwroot').replace(/\\+/g, '/').replace(/\/?$/, '');
-  const url = `${root || 'wwwroot'}/${normalized}`;
-  try {
-    const response = await fetch(url, { cache: 'no-store' });
-    if (!response || !response.ok) return null;
-    return { content: normalizeMarkdownContent(await response.text()), plaintextContent: '', protected: false };
-  } catch (_) {
-    return null;
-  }
-}
-
-async function enrichIndexStateForPublish(state, options = {}) {
-  const source = prepareIndexState(state || { __order: [] });
-  const next = deepClone(source);
-  const pendingMarkdownByPath = options.pendingMarkdownByPath instanceof Map ? options.pendingMarkdownByPath : new Map();
-  const contentRoot = options.contentRoot || 'wwwroot';
-  const keys = Array.isArray(next.__order) ? next.__order.slice() : Object.keys(next).filter(key => key !== '__order');
-  for (const key of keys) {
-    const entry = next[key];
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-    for (const lang of sortLangKeys(entry)) {
-      const originalValue = entry[lang];
-      const originalWasArray = Array.isArray(originalValue);
-      const variants = normalizeIndexVariantList(originalValue);
-      const enriched = [];
-      for (const variant of variants) {
-        const location = getIndexVariantLocation(variant);
-        if (!location) continue;
-        if (isIndexVariantPublishComplete(variant) && !pendingMarkdownByPath.has(location)) {
-          enriched.push(variant);
-          continue;
-        }
-        const markdownEntry = await readMarkdownForIndexMetadata(location, pendingMarkdownByPath, contentRoot);
-        if (!markdownEntry || !markdownEntry.content) {
-          enriched.push(variant);
-          continue;
-        }
-        enriched.push(buildIndexMetadataFromMarkdown(
-          markdownEntry.content,
-          location,
-          key,
-          isIndexMetadataObject(variant) ? variant : {},
-          {
-            plaintextContent: markdownEntry.plaintextContent,
-            protected: markdownEntry.protected,
-            protectionExplicit: markdownEntry.protectionExplicit
-          }
-        ));
-      }
-      if (!enriched.length) {
-        delete entry[lang];
-      } else if (originalWasArray || enriched.length > 1) {
-        entry[lang] = enriched;
-      } else {
-        entry[lang] = enriched[0];
-      }
-    }
-  }
-  return next;
-}
-
-function exportTabsDataForSeo(state) {
-  const output = {};
-  if (!state || typeof state !== 'object') return output;
-  const keys = Array.isArray(state.__order)
-    ? state.__order.filter((key) => key && key !== '__order')
-    : Object.keys(state);
-  keys.forEach((key) => {
-    if (key === '__order') return;
-    const entry = state[key];
-    if (!entry || typeof entry !== 'object') return;
-    const langs = {};
-    Object.keys(entry).forEach((lang) => {
-      if (lang === '__order') return;
-      const value = entry[lang];
-      if (!value || typeof value !== 'object') return;
-      const title = value.title != null ? String(value.title) : '';
-      const location = value.location != null ? String(value.location) : '';
-      if (!title && !location) return;
-      langs[lang] = { title, location };
-    });
-    if (Object.keys(langs).length) output[key] = langs;
-  });
-  return output;
-}
-
-function exportSiteConfigForSeo(state) {
-  const base = cloneSiteState(state || {});
-  if (!base.contentRoot) base.contentRoot = getContentRootSafe() || 'wwwroot';
-  if (!base.defaultLanguage) {
-    try {
-      const baseline = remoteBaseline && remoteBaseline.site;
-      if (baseline && baseline.defaultLanguage) base.defaultLanguage = baseline.defaultLanguage;
-    } catch (_) { /* ignore */ }
-  }
-  return base;
-}
-
-function escapeSeoXml(str) {
-  return String(str || '').replace(/[<>&'\"]/g, (char) => {
-    switch (char) {
-      case '<': return '&lt;';
-      case '>': return '&gt;';
-      case '&': return '&amp;';
-      case "'": return '&apos;';
-      case '"': return '&quot;';
-      default: return char;
-    }
-  });
-}
-
-function escapeSeoHtml(str) {
-  return String(str || '').replace(/[&<>"']/g, (char) => {
-    switch (char) {
-      case '&': return '&amp;';
-      case '<': return '&lt;';
-      case '>': return '&gt;';
-      case '"': return '&quot;';
-      case "'": return '&#39;';
-      default: return char;
-    }
-  });
-}
-
-function formatSeoXml(xml) {
-  try {
-    const formatted = [];
-    let pad = 0;
-    xml
-      .replace(/>(\s*)</g, '>$1\n<')
-      .split('\n')
-      .forEach((line) => {
-        const trimmed = line.trim();
-        if (!trimmed) return;
-        if (/^<\//.test(trimmed)) pad = Math.max(pad - 1, 0);
-        formatted.push(`${'  '.repeat(pad)}${trimmed}`);
-        if (/^<[^!?][^>]*[^/]>/i.test(trimmed) && !/<.*<\/.*>/.test(trimmed)) pad += 1;
-      });
-    return formatted.join('\n');
-  } catch (_) {
-    return xml;
-  }
-}
-
-function generateSeoSitemapXml(urls) {
-  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
-  xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n';
-  urls.forEach((url) => {
-    if (!url || !url.loc) return;
-    xml += '  <url>\n';
-    xml += `    <loc>${escapeSeoXml(url.loc)}</loc>\n`;
-    if (Array.isArray(url.alternates)) {
-      url.alternates.forEach((alt) => {
-        if (!alt || !alt.href || !alt.hreflang) return;
-        xml += `    <xhtml:link rel="alternate" hreflang="${escapeSeoXml(alt.hreflang)}" href="${escapeSeoXml(alt.href)}"/>\n`;
-      });
-      if (url.xdefault) {
-        xml += `    <xhtml:link rel="alternate" hreflang="x-default" href="${escapeSeoXml(url.xdefault)}"/>\n`;
-      }
-    }
-    if (url.lastmod) xml += `    <lastmod>${escapeSeoXml(url.lastmod)}</lastmod>\n`;
-    if (url.changefreq) xml += `    <changefreq>${escapeSeoXml(url.changefreq)}</changefreq>\n`;
-    if (url.priority) xml += `    <priority>${escapeSeoXml(url.priority)}</priority>\n`;
-    xml += '  </url>\n';
-  });
-  xml += '</urlset>';
-  return formatSeoXml(xml);
-}
-
-function computeSeoContentRoot(siteConfig) {
-  const raw = siteConfig && siteConfig.contentRoot ? String(siteConfig.contentRoot) : 'wwwroot';
-  const trimmed = raw.trim().replace(/^\/+|\/+$/g, '');
-  return trimmed || 'wwwroot';
-}
-
-function generateSeoRobotsTxt(siteConfig) {
-  const baseUrl = resolveSiteBaseUrl(siteConfig);
-  const contentRoot = computeSeoContentRoot(siteConfig);
-  const deriveBasePath = () => {
-    if (!baseUrl) return '/';
-    const ensureLeadingAndTrailingSlash = (value) => {
-      if (!value) return '/';
-      let normalized = value;
-      if (!normalized.startsWith('/')) normalized = `/${normalized}`;
-      normalized = normalized.replace(/\/+/g, '/');
-      if (normalized !== '/' && !normalized.endsWith('/')) normalized = `${normalized}/`;
-      return normalized === '//' ? '/' : normalized;
-    };
-    const resolvePathname = (raw) => {
-      if (!raw) return '/';
-      try {
-        const parsed = new URL(raw);
-        return parsed.pathname || '/';
-      } catch (_) {
-        try {
-          if (typeof window !== 'undefined' && window.location && window.location.origin) {
-            const parsed = new URL(raw, window.location.origin);
-            return parsed.pathname || '/';
-          }
-        } catch (_) {
-          /* noop */
-        }
-      }
-      if (typeof raw === 'string') {
-        const trimmed = raw.trim();
-        if (trimmed.startsWith('/')) return trimmed;
-      }
-      return '/';
-    };
-    const pathname = resolvePathname(baseUrl);
-    if (!pathname || pathname === '/') return '/';
-    return ensureLeadingAndTrailingSlash(pathname);
-  };
-  const basePath = deriveBasePath();
-  const withBasePath = (path) => {
-    const input = String(path == null ? '' : path).trim();
-    if (!input || input === '/') return basePath;
-    const hasTrailingSlash = input.endsWith('/');
-    const stripped = input.replace(/^\/+/, '');
-    const prefix = basePath === '/' ? '/' : basePath;
-    let combined = prefix === '/' ? `/${stripped}` : `${prefix}${stripped}`;
-    if (hasTrailingSlash && !combined.endsWith('/')) combined += '/';
-    if (!combined.startsWith('/')) combined = `/${combined}`;
-    return combined === '//' ? '/' : combined;
-  };
-  let robots = 'User-agent: *\n';
-  robots += `Allow: ${withBasePath('/')}\n\n`;
-  robots += '# Sitemap\n';
-  robots += `Sitemap: ${baseUrl}sitemap.xml\n\n`;
-  robots += '# Allow crawling of main content\n';
-  robots += `Allow: ${withBasePath(`${contentRoot}/`)}\n`;
-  robots += `Allow: ${withBasePath('assets/')}\n\n`;
-  robots += '# Disallow admin or internal directories\n';
-  robots += `Disallow: ${withBasePath('admin/')}\n`;
-  robots += `Disallow: ${withBasePath('.git/')}\n`;
-  robots += `Disallow: ${withBasePath('node_modules/')}\n`;
-  robots += `Disallow: ${withBasePath('.env')}\n`;
-  robots += `Disallow: ${withBasePath('package.json')}\n`;
-  robots += `Disallow: ${withBasePath('package-lock.json')}\n\n`;
-  robots += '# SEO tools (allow but not priority)\n';
-  robots += `Allow: ${withBasePath('sitemap-generator.html')}\n\n`;
-  robots += '# Crawl delay (be nice to servers)\n';
-  robots += 'Crawl-delay: 1\n\n';
-  robots += '# Generated by Press\n';
-  robots += `# ${new Date().toISOString()}\n`;
-  return robots;
-}
-
-function generateSeoMetaTags(siteConfig) {
-  const baseUrl = resolveSiteBaseUrl(siteConfig);
-  const getLocalizedValue = (val, fallback = '') => {
-    if (!val) return fallback;
-    if (typeof val === 'string') return val;
-    if (val.default) return val.default;
-    const langs = Object.keys(val);
-    if (langs.length) return val[langs[0]];
-    return fallback;
-  };
-  const siteTitle = getLocalizedValue(siteConfig.siteTitle, 'Press');
-  const siteDescription = getLocalizedValue(siteConfig.siteDescription, 'Where knowledge becomes pages.');
-  const siteKeywords = getLocalizedValue(siteConfig.siteKeywords, 'blog, static site, markdown');
-  const avatar = siteConfig.avatar || 'assets/avatar.png';
-  const fullAvatarUrl = avatar.startsWith('http') ? avatar : baseUrl + avatar.replace(/^\/+/, '');
-  let html = '';
-  html += `  <!-- Primary SEO Meta Tags -->\n`;
-  html += `  <title>${escapeSeoHtml(siteTitle)}</title>\n`;
-  html += `  <meta name="title" content="${escapeSeoHtml(siteTitle)}">\n`;
-  html += `  <meta name="description" content="${escapeSeoHtml(siteDescription)}">\n`;
-  html += `  <meta name="keywords" content="${escapeSeoHtml(siteKeywords)}">\n`;
-  html += `  <meta name="author" content="${escapeSeoHtml(siteTitle)}">\n`;
-  html += '  <meta name="robots" content="index, follow">\n';
-  html += `  <link rel="canonical" href="${baseUrl}">\n`;
-  html += '  \n';
-  html += '  <!-- Open Graph / Facebook -->\n';
-  html += '  <meta property="og:type" content="website">\n';
-  html += `  <meta property="og:url" content="${baseUrl}">\n`;
-  html += `  <meta property="og:title" content="${escapeSeoHtml(siteTitle)}">\n`;
-  html += `  <meta property="og:description" content="${escapeSeoHtml(siteDescription)}">\n`;
-  html += `  <meta property="og:image" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
-  html += `  <meta property="og:logo" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
-  html += '  \n';
-  html += '  <!-- Twitter -->\n';
-  html += '  <meta property="twitter:card" content="summary_large_image">\n';
-  html += `  <meta property="twitter:url" content="${baseUrl}">\n`;
-  html += `  <meta property="twitter:title" content="${escapeSeoHtml(siteTitle)}">\n`;
-  html += `  <meta property="twitter:description" content="${escapeSeoHtml(siteDescription)}">\n`;
-  html += `  <meta property="twitter:image" content="${escapeSeoHtml(fullAvatarUrl)}">\n`;
-  html += '  \n';
-  html += '  <!-- Initial meta tags - will be updated by dynamic SEO system -->\n';
-  html += '  <meta name="theme-color" content="#1a1a1a">\n';
-  html += '  <meta name="msapplication-TileColor" content="#1a1a1a">\n';
-  html += `  <link rel="icon" type="image/png" href="${escapeSeoHtml(avatar)}">`;
-  return html;
-}
-
-function normalizeSeoLangCode(value) {
-  const raw = safeString(value).trim();
-  if (!raw) return '';
-  const sanitized = raw.replace(/[^0-9A-Za-z-]/g, '');
-  return sanitized || '';
-}
-
-function computeSeoHtmlLang(siteConfig) {
-  const fromConfig = siteConfig && siteConfig.defaultLanguage;
-  const normalized = normalizeSeoLangCode(fromConfig);
-  if (normalized) return normalized;
-  try {
-    if (typeof document !== 'undefined' && document.documentElement) {
-      const docLang = normalizeSeoLangCode(document.documentElement.lang);
-      if (docLang) return docLang;
-    }
-  } catch (_) { /* ignore */ }
-  return 'en';
-}
-
-function applySeoHtmlLang(html, lang) {
-  const normalized = normalizeSeoLangCode(lang);
-  if (!normalized) return html;
-  const langAttrRegex = /(<html\b[^>]*\blang\s*=\s*)(["'])([^"']*)(\2)/i;
-  if (langAttrRegex.test(html)) {
-    return html.replace(langAttrRegex, `$1$2${normalized}$4`);
-  }
-  return html.replace(/<html\b([^>]*)>/i, `<html$1 lang="${normalized}">`);
-}
-
-function injectSeoMetaIntoIndexHtml(baseHtml, metaBlock) {
-  if (!baseHtml) return '';
-  const META_START = '  <!-- Primary SEO Meta Tags -->';
-  const META_NOTE = '  <!-- Note: Structured data is dynamically generated by the SEO system -->';
-  const startIndex = baseHtml.indexOf(META_START);
-  const noteIndex = baseHtml.indexOf(META_NOTE);
-  if (startIndex === -1 || noteIndex === -1 || noteIndex < startIndex) return '';
-  const before = baseHtml.slice(0, startIndex);
-  const after = baseHtml.slice(noteIndex + META_NOTE.length);
-  const trimmedMeta = metaBlock.trimEnd();
-  const replacement = `${trimmedMeta}\n\n${META_NOTE}`;
-  return `${before}${replacement}${after}`;
-}
-
-function buildDefaultIndexHtml(metaBlock, lang) {
-  const langAttr = normalizeSeoLangCode(lang) || 'en';
-  const trimmedMeta = metaBlock.trimEnd();
-  const metaSection = trimmedMeta ? `${trimmedMeta}\n\n` : '';
-  let html = '<!DOCTYPE html>\n';
-  html += `<html lang="${escapeSeoHtml(langAttr)}">\n\n`;
-  html += '<head>\n';
-  html += '  <meta charset="UTF-8">\n';
-  html += '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n\n';
-  html += metaSection;
-  html += '  <!-- Note: Structured data is dynamically generated by the SEO system -->\n\n';
-  html += '  <script src="assets/js/theme-boot.js?v=press-system-v3.4.20"></script>\n';
-  html += '  <link rel="stylesheet" id="theme-pack">\n';
-  html += '</head>\n\n';
-  html += '<body>\n';
-  html += '  <script type="module" src="assets/main.js?v=press-system-v3.4.20"></script>\n';
-  html += '</body>\n\n';
-  html += '</html>\n';
-  return html;
-}
-
-function generateSeoIndexHtml(siteConfig, baseHtml) {
-  const metaBlock = ensureTrailingNewline(generateSeoMetaTags(siteConfig)).trimEnd();
-  const lang = computeSeoHtmlLang(siteConfig);
-  let html = '';
-  if (baseHtml) {
-    html = injectSeoMetaIntoIndexHtml(baseHtml, metaBlock);
-  }
-  if (!html) {
-    html = buildDefaultIndexHtml(metaBlock, lang);
-  }
-  html = applySeoHtmlLang(html, lang);
-  return ensureTrailingNewline(html);
-}
-
-function ensureTrailingNewline(text) {
-  const str = String(text == null ? '' : text);
-  return str.endsWith('\n') ? str : `${str}\n`;
-}
-
-function normalizeSeoContent(text) {
-  return String(text == null ? '' : text)
-    .replace(/\r\n?/g, '\n')
-    .trim();
-}
-
-async function fetchExistingSeoFile(path) {
-  try {
-    const response = await fetch(path, { cache: 'no-store' });
-    if (!response.ok) return '';
-    return await response.text();
-  } catch (_) {
-    return '';
-  }
-}
-
-async function generateSeoCommitFiles() {
-  try {
-    const siteState = exportSiteConfigForSeo(getStateSlice('site'));
-    const indexState = exportIndexDataForSeo(getStateSlice('index'));
-    const tabsState = exportTabsDataForSeo(getStateSlice('tabs'));
-    const urls = generateSitemapData(indexState, tabsState, siteState) || [];
-    const sitemapXml = ensureTrailingNewline(generateSeoSitemapXml(urls));
-    const robotsTxt = ensureTrailingNewline(generateSeoRobotsTxt(siteState));
-    const remoteIndexHtml = await fetchExistingSeoFile('index.html');
-    const indexHtml = generateSeoIndexHtml(siteState, remoteIndexHtml);
-
-    const candidates = [
-      { seoType: 'sitemap', path: 'sitemap.xml', label: 'sitemap.xml', content: sitemapXml },
-      { seoType: 'robots', path: 'robots.txt', label: 'robots.txt', content: robotsTxt },
-      { seoType: 'index', path: 'index.html', label: 'index.html', content: indexHtml, remote: remoteIndexHtml }
-    ];
-
-    const files = [];
-    for (const candidate of candidates) {
-      const remote = Object.prototype.hasOwnProperty.call(candidate, 'remote')
-        ? candidate.remote
-        : await fetchExistingSeoFile(candidate.path);
-      if (normalizeSeoContent(remote) === normalizeSeoContent(candidate.content)) continue;
-      files.push({
-        kind: 'seo',
-        seoType: candidate.seoType,
-        label: candidate.label,
-        path: candidate.path,
-        content: candidate.content,
-        isSeo: true
-      });
-    }
-    return files;
-  } catch (err) {
-    console.error('Failed to prepare SEO files for commit', err);
-    return [];
-  }
-}
-
 async function gatherCommitPayload(options = {}) {
   const { showSeoStatus = false } = options;
-  const base = await gatherLocalChangesForCommit(options);
-  const files = Array.isArray(base.files) ? base.files.slice() : [];
   const providerResult = await stagingRegistry.getCommitFiles({
     ...options,
     showSeoStatus,
     setStatus: setSyncOverlayStatus
   });
-  const providerFiles = Array.isArray(providerResult.files) ? providerResult.files : [];
-  if (providerFiles.length) files.push(...providerFiles);
-  const seoFiles = providerFiles.filter(file => file && file.kind === 'seo');
+  const files = Array.isArray(providerResult.files) ? providerResult.files : [];
+  const seoFiles = files.filter(file => file && file.kind === 'seo');
   return { files, seoFiles, warnings: providerResult.warnings || [] };
-}
-
-function collectDirtyMarkdownPathsForDeletion() {
-  const paths = new Set();
-  dynamicEditorTabs.forEach((tab) => {
-    if (!tab || !tab.path) return;
-    if (tab.isDirty || hasMarkdownDraftContent(tab)) paths.add(tab.path);
-  });
-  try {
-    const store = readMarkdownDraftStore();
-    if (store && typeof store === 'object') {
-      Object.keys(store).forEach((key) => {
-        const entry = store[key];
-        if (!entry || typeof entry !== 'object') return;
-        const hasContent = entry.content != null && normalizeMarkdownContent(entry.content);
-        const hasAssets = Array.isArray(entry.assets) && entry.assets.length;
-        const hasDeletedAssets = draftHasAssetDeletions(entry);
-        if (hasContent || hasAssets || hasDeletedAssets) paths.add(key);
-      });
-    }
-  } catch (_) {}
-  return Array.from(paths);
-}
-
-function formatRepositoryDeletionBlockers(blocked = []) {
-  const paths = (Array.isArray(blocked) ? blocked : [])
-    .map(item => item && item.path ? String(item.path) : '')
-    .filter(Boolean);
-  if (!paths.length) {
-    return textWithFallback(
-      'editor.toasts.repositoryDeletionDraftsPending',
-      'Unable to delete files while local drafts are still pending.'
-    );
-  }
-  const sample = paths.slice(0, 5).join(', ');
-  const remaining = paths.length > 5 ? paths.length - 5 : 0;
-  const fallbackSuffix = remaining ? `, +${remaining} more` : '';
-  return textWithFallback(
-    'editor.toasts.repositoryDeletionDraftsBlocked',
-    `Publish blocked because deleted files still have local drafts: ${sample}${fallbackSuffix}. Restore, publish, or discard those drafts before deleting the files.`,
-    { sample, remaining }
-  );
-}
-
-async function fetchMarkdownForRepositoryDeletion(file) {
-  const path = file && file.path ? String(file.path).replace(/\\+/g, '/').replace(/^\/+/, '') : '';
-  if (!path) return '';
-  try {
-    const resp = await fetch(`${path}?ts=${Date.now()}`, { cache: 'no-store' });
-    if (!resp.ok) return '';
-    return normalizeMarkdownContent(await resp.text());
-  } catch (_) {
-    return '';
-  }
-}
-
-async function collectDeletedMarkdownAssetFiles(markdownDeletionFiles = [], options = {}) {
-  const contentRoot = options.contentRoot || 'wwwroot';
-  const referencedAssets = options.referencedAssets instanceof Set ? options.referencedAssets : new Set();
-  const out = [];
-  const seen = new Set();
-  for (const file of Array.isArray(markdownDeletionFiles) ? markdownDeletionFiles : []) {
-    if (!file || !file.deleted || !file.markdownPath) continue;
-    const markdown = await fetchMarkdownForRepositoryDeletion(file);
-    if (!markdown) continue;
-    listLocalMarkdownAssetReferences(markdown, file.markdownPath, contentRoot).forEach((resolved) => {
-      if (!resolved || !resolved.contentPath || !resolved.commitPath) return;
-      if (referencedAssets.has(resolved.contentPath)) return;
-      if (seen.has(resolved.commitPath)) return;
-      seen.add(resolved.commitPath);
-      out.push({
-        kind: 'asset',
-        category: 'content-asset',
-        label: resolved.relativePath || resolved.contentPath,
-        path: resolved.commitPath,
-        markdownPath: resolved.markdownPath,
-        assetPath: resolved.contentPath,
-        assetRelativePath: resolved.relativePath || '',
-        state: 'deleted',
-        deleted: true
-      });
-    });
-  }
-  return out;
-}
-
-async function gatherLocalChangesForCommit(options = {}) {
-  const { cleanupUnusedAssets = true } = options;
-  const collector = createCommitFileCollector();
-  const { addFile } = collector;
-
-  try {
-    const flushes = Array.from(dynamicEditorTabs.values()).map((tab) => (
-      flushMarkdownDraft(tab).catch((err) => {
-        console.warn('Failed to flush markdown draft before commit', err);
-        return null;
-      })
-    ));
-    await Promise.all(flushes);
-  } catch (_) { /* ignore */ }
-
-  const siteState = getStateSlice('site');
-  let root;
-  if (siteState && Object.prototype.hasOwnProperty.call(siteState, 'contentRoot')) {
-    root = safeString(siteState.contentRoot);
-  }
-  if (!root) {
-    root = getContentRootSafe();
-  }
-  const normalizedRoot = String(root || '')
-    .replace(/\\+/g, '/').replace(/\/?$/, '');
-  const rootPrefix = normalizedRoot ? `${normalizedRoot}/` : '';
-  const baselineRoot = (() => {
-    const baselineSite = remoteBaseline && remoteBaseline.site && typeof remoteBaseline.site === 'object'
-      ? remoteBaseline.site
-      : {};
-    const raw = Object.prototype.hasOwnProperty.call(baselineSite, 'contentRoot')
-      ? safeString(baselineSite.contentRoot)
-      : '';
-    return String(raw || 'wwwroot').replace(/\\+/g, '/').replace(/\/?$/, '');
-  })();
-  const pendingMarkdownByPath = new Map();
-
-  if (composerDiffCache.tabs && composerDiffCache.tabs.hasChanges) {
-    const state = getStateSlice('tabs') || { __order: [] };
-    const yaml = toTabsYaml(state);
-    addFile({ kind: 'tabs', label: 'tabs.yaml', path: `${rootPrefix}tabs.yaml`, content: yaml });
-  }
-  if (composerDiffCache.site && composerDiffCache.site.hasChanges) {
-    const state = getStateSlice('site') || {};
-    const yaml = toSiteYaml(state);
-    addFile({ kind: 'site', label: 'site.yaml', path: 'site.yaml', content: yaml });
-  }
-
-  const contentDeletionPlan = planManagedContentDeletions({
-    index: getStateSlice('index') || { __order: [] },
-    tabs: getStateSlice('tabs') || { __order: [] },
-    indexBaseline: remoteBaseline.index || { __order: [] },
-    tabsBaseline: remoteBaseline.tabs || { __order: [] },
-    indexDiff: composerDiffCache.index,
-    tabsDiff: composerDiffCache.tabs,
-    contentRoot: normalizedRoot || 'wwwroot',
-    currentContentRoot: normalizedRoot || 'wwwroot',
-    baselineContentRoot: baselineRoot || 'wwwroot',
-    dirtyMarkdownPaths: collectDirtyMarkdownPathsForDeletion()
-  });
-  if (contentDeletionPlan.blocked.length) {
-    throw new Error(formatRepositoryDeletionBlockers(contentDeletionPlan.blocked));
-  }
-  contentDeletionPlan.files.forEach(addFile);
-  const assetReferenceScan = await collectCurrentRepositoryMarkdownAssetReferences({
-    excludeMarkdownPaths: contentDeletionPlan.files.map(file => file && file.markdownPath).filter(Boolean),
-    currentContentRoot: normalizedRoot || 'wwwroot',
-    baselineContentRoot: baselineRoot || 'wwwroot'
-  });
-  const referencedAssetPaths = assetReferenceScan.refs;
-  const assetReferenceScanComplete = !(assetReferenceScan.failures && assetReferenceScan.failures.length);
-  if (assetReferenceScanComplete) {
-    const deletedMarkdownAssetFiles = await collectDeletedMarkdownAssetFiles(contentDeletionPlan.files, {
-      contentRoot: baselineRoot || 'wwwroot',
-      referencedAssets: referencedAssetPaths
-    });
-    deletedMarkdownAssetFiles.forEach(addFile);
-  } else {
-    console.warn('Skipping repository asset deletions because some current markdown files could not be checked.', assetReferenceScan.failures);
-  }
-
-  const markdownEntries = collectUnsyncedMarkdownEntries();
-  if (markdownEntries && markdownEntries.length) {
-    const editorApi = getPrimaryEditorApi();
-    const activeTab = getActiveDynamicTab();
-    let activeValue = null;
-    if (editorApi && typeof editorApi.getValue === 'function' && activeTab && activeTab.mode === currentMode) {
-      try { activeValue = String(editorApi.getValue() || ''); }
-      catch (_) { activeValue = null; }
-    }
-    const draftStore = readMarkdownDraftStore();
-    for (const entry of markdownEntries) {
-      const rel = normalizeRelPath(entry.path);
-      if (!rel) continue;
-      const repoPath = `${rootPrefix}${rel}`;
-      const tab = findDynamicTabByPath(rel);
-      let text = '';
-      let alreadyEncrypted = false;
-      if (tab) {
-        const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft(tab);
-        if (lockedEncryptedDraft) {
-          text = lockedEncryptedDraft;
-          alreadyEncrypted = true;
-        } else if (tab === activeTab && activeValue != null) {
-          tab.content = activeValue;
-          text = normalizeMarkdownContent(tab.content);
-        } else if (tab.content != null && tab.content !== undefined) {
-          text = normalizeMarkdownContent(tab.content);
-        } else if (tab.localDraft && tab.localDraft.content != null) {
-          text = normalizeMarkdownContent(tab.localDraft.content);
-        }
-      } else if (draftStore && draftStore[rel] && typeof draftStore[rel] === 'object') {
-        const draft = draftStore[rel];
-        if (draft.content != null) text = normalizeMarkdownContent(draft.content);
-        alreadyEncrypted = isEncryptedMarkdownDraftEntry(draft);
-      }
-      const prepared = alreadyEncrypted
-        ? { content: text, encrypted: true }
-        : await prepareMarkdownForProtectedStorage(tab, text, { reason: 'commit' });
-      pendingMarkdownByPath.set(rel, {
-        content: prepared.content,
-        plaintextContent: prepared.encrypted && !alreadyEncrypted ? text : '',
-        protected: !!prepared.encrypted
-      });
-      addFile({
-        kind: 'markdown',
-        label: rel,
-        path: repoPath,
-        content: prepared.content,
-        plaintextContent: prepared.encrypted && !alreadyEncrypted ? text : '',
-        markdownPath: rel,
-        state: entry.state || '',
-        protected: !!prepared.encrypted
-      });
-
-      const assets = listMarkdownAssets(rel);
-      if (assets.length) {
-        const normalizedText = normalizeMarkdownContent(text);
-        const unusedAssets = [];
-        assets.forEach((asset) => {
-          if (!asset || !asset.path || !asset.base64) return;
-          const commitPath = `${rootPrefix}${asset.path}`.replace(/\\+/g, '/');
-          if (!alreadyEncrypted && !isAssetReferencedInContent(normalizedText, asset)) {
-            unusedAssets.push(asset.path);
-            return;
-          }
-          addFile({
-            kind: 'asset',
-            label: asset.relativePath || asset.path,
-            path: commitPath,
-            base64: asset.base64,
-            binary: true,
-            mime: asset.mime || 'application/octet-stream',
-            size: Number.isFinite(asset.size) ? asset.size : 0,
-            markdownPath: rel,
-            assetPath: asset.path,
-            assetRelativePath: asset.relativePath || ''
-          });
-        });
-        if (cleanupUnusedAssets && unusedAssets.length) {
-          unusedAssets.forEach((assetPath) => {
-            removeMarkdownAsset(rel, assetPath);
-          });
-        }
-      }
-    }
-  }
-
-  const originalIndexDiff = composerDiffCache.index || recomputeDiff('index');
-  const indexState = getStateSlice('index') || { __order: [] };
-  let indexYaml = toIndexYaml(indexState);
-  let indexMetadataChanged = false;
-  if ((originalIndexDiff && originalIndexDiff.hasChanges) || pendingMarkdownByPath.size > 0) {
-    const enrichedIndexState = await enrichIndexStateForPublish(indexState, {
-      contentRoot: normalizedRoot || 'wwwroot',
-      pendingMarkdownByPath
-    });
-    const enrichedIndexYaml = toIndexYaml(enrichedIndexState);
-    indexMetadataChanged = enrichedIndexYaml !== indexYaml;
-    if (indexMetadataChanged) {
-      setStateSlice('index', enrichedIndexState);
-      composerDiffCache.index = computeIndexDiff(enrichedIndexState, remoteBaseline.index);
-      indexYaml = enrichedIndexYaml;
-    }
-  }
-  if ((originalIndexDiff && originalIndexDiff.hasChanges) || indexMetadataChanged) {
-    addFile({ kind: 'index', label: 'index.yaml', path: `${rootPrefix}index.yaml`, content: indexYaml });
-  }
-
-  const assetDeletionRefs = referencedAssetPaths;
-  if (assetReferenceScanComplete) {
-    listMarkdownAssetDeletions().forEach((asset) => {
-      if (!asset || !asset.assetPath || !asset.deleted) return;
-      if (assetDeletionRefs.has(asset.assetPath)) return;
-      const commitPath = `${rootPrefix}${asset.assetPath}`.replace(/\\+/g, '/');
-      addFile({
-        ...asset,
-        label: asset.assetRelativePath || asset.label || asset.assetPath,
-        path: commitPath,
-        deleted: true,
-        state: 'deleted'
-      });
-    });
-  }
-
-  return { files: collector.getFiles() };
 }
 
 let syncCommitPanelRenderSeq = 0;
@@ -5760,152 +4871,6 @@ function getActiveSiteRepoConfig() {
     ? window.__press_site_repo
     : {};
   return resolveSiteRepoConfig(site, composerSiteLocalOverride, fallback);
-}
-
-function applyLocalPostCommitState(files = []) {
-  if (!Array.isArray(files) || !files.length) return;
-  stagingRegistry.clearCommittedFiles(files);
-  const handledMarkdown = new Set();
-  files.forEach((file) => {
-    if (!file || !file.kind) return;
-    if (file.kind === 'index') {
-      const state = getStateSlice('index') || { __order: [] };
-      remoteBaseline.index = deepClone(prepareIndexState(state));
-      notifyComposerChange('index', { skipAutoSave: true });
-      clearDraftStorage('index');
-    } else if (file.kind === 'tabs') {
-      const state = getStateSlice('tabs') || { __order: [] };
-      remoteBaseline.tabs = deepClone(prepareTabsState(state));
-      notifyComposerChange('tabs', { skipAutoSave: true });
-      clearDraftStorage('tabs');
-    } else if (file.kind === 'site') {
-      const state = getStateSlice('site');
-      const snapshot = state ? cloneSiteState(state) : cloneSiteState(prepareSiteState({}));
-      remoteBaseline.site = snapshot;
-
-      const previousRoot = getContentRootSafe();
-      const effectiveSnapshot = applyComposerEffectiveSiteConfig(snapshot);
-      const rawNextRoot = effectiveSnapshot && typeof effectiveSnapshot === 'object' && Object.prototype.hasOwnProperty.call(effectiveSnapshot, 'contentRoot')
-        ? safeString(effectiveSnapshot.contentRoot)
-        : '';
-      const normalizedNextRoot = (rawNextRoot ? rawNextRoot : 'wwwroot').trim().replace(/[\\]/g, '/').replace(/\/?$/, '');
-      const rootChanged = normalizedNextRoot !== previousRoot;
-
-      notifyComposerChange('site', { skipAutoSave: true });
-      clearDraftStorage('site');
-
-      if (rootChanged) {
-        updateComposerMarkdownDraftIndicators();
-        updateMarkdownPushButton(getActiveDynamicTab());
-        updateMarkdownDiscardButton(getActiveDynamicTab());
-        updateMarkdownSaveButton(getActiveDynamicTab());
-        updateMarkdownProtectionButton(getActiveDynamicTab());
-      }
-    } else if (file.kind === 'markdown') {
-      const norm = normalizeRelPath(file.markdownPath || file.label || '');
-      if (!norm) return;
-      handledMarkdown.add(norm);
-      if (file.deleted) {
-        clearMarkdownDraftEntry(norm);
-        clearMarkdownAssetsForPath(norm);
-        const tab = findDynamicTabByPath(norm);
-        if (tab) {
-          tab.remoteContent = '';
-          tab.remoteSignature = computeTextSignature('');
-          tab.content = '';
-          tab.loaded = true;
-          tab.localDraft = null;
-          tab.draftConflict = false;
-          tab.isDirty = false;
-          setMarkdownProtectionState(tab, createMarkdownProtectionState());
-          setDynamicTabStatus(tab, {
-            state: 'missing',
-            checkedAt: Date.now(),
-            code: 404,
-            message: 'Deleted via Press'
-          });
-        }
-        updateComposerMarkdownDraftIndicators({ path: norm });
-        return;
-      }
-      const committedText = normalizeMarkdownContent(file.content || '');
-      const tab = findDynamicTabByPath(norm);
-      const commitSignature = computeTextSignature(committedText);
-      const committedEnvelope = parseEncryptedMarkdownEnvelope(committedText);
-      const committedProtected = !!file.protected || committedEnvelope.encrypted;
-      const checkedAt = Date.now();
-      if (tab) {
-        const baselineText = committedProtected
-          ? normalizeMarkdownContent(file.plaintextContent || tab.content || '')
-          : committedText;
-        const currentText = normalizeMarkdownContent(tab.content || '');
-        const hasNewerLocalContent = currentText !== baselineText;
-        tab.remoteContent = baselineText;
-        tab.remoteSignature = commitSignature;
-        tab.loaded = true;
-        if (committedProtected) {
-          setMarkdownProtectionState(tab, {
-            ...getMarkdownProtectionState(tab),
-            enabled: true,
-            encryptedRemote: true,
-            passwordChanged: false,
-            remoteSignature: commitSignature,
-            remoteCiphertext: committedEnvelope.ciphertext || ''
-          });
-        } else {
-          setMarkdownProtectionState(tab, createMarkdownProtectionState());
-        }
-        if (hasNewerLocalContent) {
-          if (tab.localDraft) {
-            tab.localDraft = { ...tab.localDraft, remoteSignature: tab.remoteSignature };
-          }
-          scheduleMarkdownDraftSave(tab);
-          updateDynamicTabDirtyState(tab, { autoSave: false });
-          setDynamicTabStatus(tab, {
-            state: 'existing',
-            checkedAt,
-            message: 'Local edits pending sync'
-          });
-        } else {
-          clearMarkdownDraftEntry(norm);
-          clearMarkdownAssetsForPath(norm);
-          tab.content = baselineText;
-          tab.localDraft = null;
-          tab.draftConflict = false;
-          tab.isDirty = false;
-          updateDynamicTabDirtyState(tab, { autoSave: false });
-          setDynamicTabStatus(tab, {
-            state: 'existing',
-            checkedAt,
-            message: 'Synchronized via Press'
-          });
-        }
-      } else {
-        clearMarkdownDraftEntry(norm);
-        clearMarkdownAssetsForPath(norm);
-      }
-      updateComposerMarkdownDraftIndicators({ path: norm });
-    }
-    else if (file.kind === 'asset') {
-      const norm = normalizeRelPath(file.markdownPath || '');
-      if (!norm) return;
-      const assetPath = normalizeRelPath(file.assetPath || '');
-      if (assetPath) {
-        removeMarkdownAsset(norm, assetPath);
-        removeMarkdownAssetDeletion(norm, assetPath);
-      }
-      else if (file.path) {
-        const withoutRoot = file.path.replace(/^\/?(?:wwwroot\/)?/, '');
-        removeMarkdownAsset(norm, normalizeRelPath(withoutRoot));
-        removeMarkdownAssetDeletion(norm, normalizeRelPath(withoutRoot));
-      }
-    }
-  });
-  updateUnsyncedSummary();
-  updateMarkdownPushButton(getActiveDynamicTab());
-  updateMarkdownDiscardButton(getActiveDynamicTab());
-  updateMarkdownSaveButton(getActiveDynamicTab());
-  updateMarkdownProtectionButton(getActiveDynamicTab());
 }
 
 function computeOrderDiffDetails(kind) {

--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -1,4 +1,4 @@
-import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.20';
+import { getCanonicalFrontMatterKey, parseMarkdownFrontMatter } from './frontmatter-document.js?v=press-system-v3.4.21';
 
 // Helpers for generating excerpts/snippets from markdown
 export function stripMarkdownToText(md) {

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -1,5 +1,5 @@
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.20';
-import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.20';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.21';
+import { createSafeHighlightFragment, detectLanguage } from './syntax-highlight.js?v=press-system-v3.4.21';
 
 const BLOCK_TYPES = new Set(['paragraph', 'heading', 'image', 'list', 'quote', 'code', 'math', 'card', 'table', 'source', 'blank']);
 const CODE_LANGUAGE_OPTIONS = [

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.20';
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.21';
 
 function applyAttributeTranslation(el, target, value) {
   if (value == null) return;

--- a/assets/js/editor-drafts.js
+++ b/assets/js/editor-drafts.js
@@ -1,4 +1,4 @@
-import { readJsonStore, writeJsonStore } from './editor-storage.js?v=press-system-v3.4.20';
+import { readJsonStore, writeJsonStore } from './editor-storage.js?v=press-system-v3.4.21';
 
 export function createScopedDraftStore({
   storage,

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,6 +1,6 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.20';
-import { createHiEditor } from './hieditor.js?v=press-system-v3.4.20';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=press-system-v3.4.21';
+import { createHiEditor } from './hieditor.js?v=press-system-v3.4.21';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
 import {
   FRONT_MATTER_FIELD_DEFS,
@@ -10,12 +10,12 @@ import {
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings,
   valueIsPresent
-} from './frontmatter-document.js?v=press-system-v3.4.20';
-import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.20';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.20';
+} from './frontmatter-document.js?v=press-system-v3.4.21';
+import { getContentRoot, resolveImageSrc } from './safe-html.js?v=press-system-v3.4.21';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.21';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.20';
-import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.20';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=press-system-v3.4.21';
+import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=press-system-v3.4.21';
 
 const LS_WRAP_KEY = 'press_editor_wrap_enabled';
 const LS_VIEW_KEY = 'press_editor_markdown_view_v2';

--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -1,25 +1,25 @@
 import './components.js';
-import { mdParse } from './markdown.js?v=press-system-v3.4.20';
+import { mdParse } from './markdown.js?v=press-system-v3.4.21';
 import { createContentModel } from './content-model.js';
 import { parseFrontMatter } from './content.js';
-import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.20';
+import { getContentRoot, setSafeHtml } from './safe-html.js?v=press-system-v3.4.21';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from './post-render.js';
-import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.20';
+import { hydrateInternalLinkCards } from './link-cards.js?v=press-system-v3.4.21';
 import { applyLangHints } from './typography.js';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.20';
-import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.20';
-import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.20';
-import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.20';
-import { renderPostNav } from './post-nav.js?v=press-system-v3.4.20';
-import { renderTagSidebar } from './tags.js?v=press-system-v3.4.20';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.21';
+import { initSyntaxHighlighting } from './syntax-highlight.js?v=press-system-v3.4.21';
+import { setupAnchors, setupTOC } from './toc.js?v=press-system-v3.4.21';
+import { initI18n, t, withLangParam } from './i18n.js?v=press-system-v3.4.21';
+import { renderPostNav } from './post-nav.js?v=press-system-v3.4.21';
+import { renderTagSidebar } from './tags.js?v=press-system-v3.4.21';
 import { getArticleTitleFromMain } from './dom-utils.js';
-import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.20';
+import { ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, createThemeI18nContext, getThemeRegion } from './theme-layout.js?v=press-system-v3.4.21';
 
 const RENDER_MESSAGE = 'press-editor-preview-render';
 const READY_MESSAGE = 'press-editor-preview-ready';
 const RENDERED_MESSAGE = 'press-editor-preview-rendered';
 const ERROR_MESSAGE = 'press-editor-preview-error';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.20';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.21';
 
 let activePack = '';
 let latestRenderRequestId = 0;

--- a/assets/js/encrypted-content.js
+++ b/assets/js/encrypted-content.js
@@ -3,7 +3,7 @@ import {
   cloneFrontMatterData,
   parseMarkdownFrontMatter,
   resolveFrontMatterBindings
-} from './frontmatter-document.js?v=press-system-v3.4.20';
+} from './frontmatter-document.js?v=press-system-v3.4.21';
 
 export const ENCRYPTED_MARKDOWN_FORMAT = 'press-encrypted-markdown-v1';
 export const ENCRYPTED_MARKDOWN_FENCE = 'press-encrypted-markdown-v1';

--- a/assets/js/errors.js
+++ b/assets/js/errors.js
@@ -1,5 +1,5 @@
 // errors.js — lightweight global error overlay and reporter
-import { t } from './i18n.js?v=press-system-v3.4.20';
+import { t } from './i18n.js?v=press-system-v3.4.21';
 
 let reporterConfig = {
   reportUrl: null,

--- a/assets/js/hieditor.js
+++ b/assets/js/hieditor.js
@@ -1,4 +1,4 @@
-import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.20';
+import { simpleHighlight } from './syntax-highlight.js?v=press-system-v3.4.21';
 
 function escapeHtmlInline(text) {
   if (!text) return '';

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -10,11 +10,11 @@
 // - Friendly language names come from assets/i18n/languages.json (or the language module's metadata).
 
 import { parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.20';
+import { isEncryptedMarkdown } from './encrypted-content.js?v=press-system-v3.4.21';
 import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 import { getThemeRegion } from './theme-regions.js';
-import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.20';
+import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=press-system-v3.4.21';
 
 // Content fetch cache modes are normalized by cache-control.js.
 

--- a/assets/js/link-cards.js
+++ b/assets/js/link-cards.js
@@ -1,6 +1,6 @@
 import { renderTags, escapeHtml, formatDisplayDate, cardImageSrc, fallbackCover, getContentRoot } from './utils.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './content.js';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.20';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from './encrypted-content.js?v=press-system-v3.4.21';
 import { hydrateCardCovers } from './post-render.js';
 
 const DEFAULT_STRINGS = {

--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,4 +1,4 @@
-import { withLangParam, t } from './i18n.js?v=press-system-v3.4.20';
+import { withLangParam, t } from './i18n.js?v=press-system-v3.4.21';
 import { escapeHtml } from './utils.js';
 
 export function renderPostNav(container, postsIndex, postname) {

--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -1,7 +1,7 @@
 import {
   createConnectPublishCommit,
   ensureConnectPublishGrant as authorizeConnectPublishGrant
-} from './transports/connect-transport.js?v=press-system-v3.4.20';
+} from './transports/connect-transport.js?v=press-system-v3.4.21';
 
 export async function ensurePublishGrant({
   connect,
@@ -66,7 +66,7 @@ export async function publishCommit({
     });
   }
 
-  const { createFineGrainedTokenCommit } = await import('./transports/github-pat-transport.js?v=press-system-v3.4.20');
+  const { createFineGrainedTokenCommit } = await import('./transports/github-pat-transport.js?v=press-system-v3.4.21');
   return createFineGrainedTokenCommit(transport && transport.token, {
     owner,
     name,

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -1,4 +1,4 @@
-import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js?v=press-system-v3.4.20';
+import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js?v=press-system-v3.4.21';
 
 export function serializeConnectPublishFile(file) {
   const out = {

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,8 +1,8 @@
 // seo.js - Dynamic SEO meta tag management for client-side routing
 // This maintains SEO benefits while keeping the "no compilation needed" philosophy
 
-import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.20';
-import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.20';
+import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=press-system-v3.4.21';
+import { getAvailableLangs } from './i18n.js?v=press-system-v3.4.21';
 import { parseFrontMatter } from './content.js';
 
 function ensureTrailingSlash(value) {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,7 +1,7 @@
-import { mdParse } from './markdown.js?v=press-system-v3.4.20';
-import { renderPressMath } from './math-render.js?v=press-system-v3.4.20';
-import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.20';
-import { t } from './i18n.js?v=press-system-v3.4.20';
+import { mdParse } from './markdown.js?v=press-system-v3.4.21';
+import { renderPressMath } from './math-render.js?v=press-system-v3.4.21';
+import { setSafeHtml } from './safe-html.js?v=press-system-v3.4.21';
+import { t } from './i18n.js?v=press-system-v3.4.21';
 import {
   compareSemver,
   isUpgradeAllowed,
@@ -10,7 +10,7 @@ import {
   normalizeSemver,
   normalizeUpgradeFrom,
   semverToTag
-} from './press-version.js?v=press-system-v3.4.20';
+} from './press-version.js?v=press-system-v3.4.21';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([

--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -1,5 +1,5 @@
 // Tag utilities: aggregation, rendering (collapsible), and tooltips for truncated tags
-import { t, withLangParam } from './i18n.js?v=press-system-v3.4.20';
+import { t, withLangParam } from './i18n.js?v=press-system-v3.4.21';
 import { getThemeRegion } from './theme-regions.js';
 import { getQueryVariable, escapeHtml } from './utils.js';
 

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,5 +1,5 @@
 // Template renderers (pure functions returning HTML strings)
-import { t } from './i18n.js?v=press-system-v3.4.20';
+import { t } from './i18n.js?v=press-system-v3.4.21';
 import { computeReadTime } from './content.js';
 import { escapeHtml, renderTags, formatDisplayDate } from './utils.js';
 

--- a/assets/js/theme-boot.js
+++ b/assets/js/theme-boot.js
@@ -18,7 +18,7 @@
     pack = String(pack || '').toLowerCase().trim().replace(/[^a-z0-9_-]/g, '') || 'native';
   } catch (_) { pack = 'native'; }
   if (pack !== 'native') return;
-  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.20';
+  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css?v=press-system-v3.4.21';
   window.__themePackHref = href;
 
   // If the link tag exists already, set it; otherwise try briefly until it does

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -4,7 +4,7 @@ import {
   getRequestedThemePack,
   setThemePackStylesheet,
   suppressThemePack
-} from './theme.js?v=press-system-v3.4.20';
+} from './theme.js?v=press-system-v3.4.21';
 import {
   t,
   withLangParam,
@@ -13,7 +13,7 @@ import {
   ensureLanguageBundle,
   getAvailableLangs,
   getLanguageLabel
-} from './i18n.js?v=press-system-v3.4.20';
+} from './i18n.js?v=press-system-v3.4.21';
 import {
   createThemeRegionRegistry,
   ensureThemeRegionRegistry,
@@ -29,8 +29,8 @@ let layoutMountGeneration = 0;
 
 const DEFAULT_PACK = 'native';
 const CONTRACT_VERSION = 1;
-const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.20';
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.20';
+const NATIVE_MODULE_CACHE_KEY = 'press-system-v3.4.21';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.21';
 
 const EFFECT_VIEW_NAMES = {
   renderPostView: 'post',

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,5 +1,5 @@
-import { t } from './i18n.js?v=press-system-v3.4.20';
-import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.20';
+import { t } from './i18n.js?v=press-system-v3.4.21';
+import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js?v=press-system-v3.4.21';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,10 +1,10 @@
-import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.20';
+import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=press-system-v3.4.21';
 import { getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';
 const THEME_CONTROLS_BOUND = Symbol('pressThemeControlsBound');
 const THEME_CONTROLS_I18N_BOUND = Symbol('pressThemeControlsI18nBound');
-const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.20';
+const NATIVE_STYLE_CACHE_KEY = 'press-system-v3.4.21';
 const THEME_PACK_KEY = 'themePack';
 const THEME_PACK_PENDING_KEY = 'themePackPending';
 const suppressedThemePacks = new Set();

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=press-system-v3.4.20';
+import { t } from './i18n.js?v=press-system-v3.4.21';
 import { getThemeRegion } from './theme-regions.js';
 
 // Anchors and Table of Contents enhancements

--- a/assets/main.js
+++ b/assets/main.js
@@ -5,13 +5,13 @@ import {
   decryptMarkdownDocument,
   parseEncryptedMarkdownEnvelope,
   stripEncryptedBodyForPublicUse
-} from './js/encrypted-content.js?v=press-system-v3.4.20';
-import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.20';
-import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.20';
-import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.20';
+} from './js/encrypted-content.js?v=press-system-v3.4.21';
+import { setupAnchors, setupTOC } from './js/toc.js?v=press-system-v3.4.21';
+import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=press-system-v3.4.21';
+import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=press-system-v3.4.21';
 import { setupSearch } from './js/search.js';
 import { extractExcerpt, computeReadTime, parseFrontMatter } from './js/content.js';
-import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.20';
+import { getContentRoot, setSafeHtml } from './js/safe-html.js?v=press-system-v3.4.21';
 import { getQueryVariable, setDocTitle, setBaseSiteTitle, slugifyTab, isModifiedClick } from './js/utils.js';
 import {
   initI18n,
@@ -23,13 +23,13 @@ import {
   getCurrentLang,
   normalizeLangKey,
   POSTS_METADATA_READY_EVENT
-} from './js/i18n.js?v=press-system-v3.4.20';
-import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.20';
-import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.20';
+} from './js/i18n.js?v=press-system-v3.4.21';
+import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=press-system-v3.4.21';
+import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=press-system-v3.4.21';
 import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
-import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.20';
-import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.20';
+import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=press-system-v3.4.21';
+import { renderPostNav } from './js/post-nav.js?v=press-system-v3.4.21';
 import { getArticleTitleFromMain } from './js/dom-utils.js';
 import { applyLangHints } from './js/typography.js';
 
@@ -80,7 +80,7 @@ function cacheDynamicImport(importer, getCached, setCached) {
 
 function loadMarkdownModule() {
   return cacheDynamicImport(
-    () => import('./js/markdown.js?v=press-system-v3.4.20'),
+    () => import('./js/markdown.js?v=press-system-v3.4.21'),
     () => markdownModulePromise,
     (promise) => { markdownModulePromise = promise; }
   );
@@ -88,7 +88,7 @@ function loadMarkdownModule() {
 
 function loadSyntaxHighlightModule() {
   return cacheDynamicImport(
-    () => import('./js/syntax-highlight.js?v=press-system-v3.4.20'),
+    () => import('./js/syntax-highlight.js?v=press-system-v3.4.21'),
     () => syntaxHighlightModulePromise,
     (promise) => { syntaxHighlightModulePromise = promise; }
   );
@@ -96,7 +96,7 @@ function loadSyntaxHighlightModule() {
 
 function loadMathRenderModule() {
   return cacheDynamicImport(
-    () => import('./js/math-render.js?v=press-system-v3.4.20'),
+    () => import('./js/math-render.js?v=press-system-v3.4.21'),
     () => mathRenderModulePromise,
     (promise) => { mathRenderModulePromise = promise; }
   );
@@ -104,7 +104,7 @@ function loadMathRenderModule() {
 
 function loadAnnotateModule() {
   return cacheDynamicImport(
-    () => import('./js/annotate.js?v=press-system-v3.4.20'),
+    () => import('./js/annotate.js?v=press-system-v3.4.21'),
     () => annotateModulePromise,
     (promise) => { annotateModulePromise = promise; }
   );
@@ -112,7 +112,7 @@ function loadAnnotateModule() {
 
 function loadLinkCardsModule() {
   return cacheDynamicImport(
-    () => import('./js/link-cards.js?v=press-system-v3.4.20'),
+    () => import('./js/link-cards.js?v=press-system-v3.4.21'),
     () => linkCardsModulePromise,
     (promise) => { linkCardsModulePromise = promise; }
   );

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.20",
-  "tag": "v3.4.20",
+  "version": "3.4.21",
+  "tag": "v3.4.21",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.19 <3.4.20"
+      ">=3.4.20 <3.4.21"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.19 first."
+    "message": "Update to v3.4.20 first."
   }
 }

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1,16 +1,16 @@
 import { installLightbox } from '../../../js/lightbox.js';
 import { sanitizeImageUrl, setSafeHtml } from '../../../js/safe-html.js';
 import { slugifyTab, escapeHtml, getQueryVariable, renderTags, cardImageSrc, fallbackCover, formatDisplayDate, formatBytes, renderSkeletonArticle } from '../../../js/utils.js';
-import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.20';
+import { attachHoverTooltip } from '../../../js/tags.js?v=press-system-v3.4.21';
 import { prefersReducedMotion, getArticleTitleFromMain } from '../../../js/dom-utils.js';
-import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.20';
-import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.20';
-import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.20';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=press-system-v3.4.21';
+import { showErrorOverlay } from '../../../js/errors.js?v=press-system-v3.4.21';
+import { renderPostNav } from '../../../js/post-nav.js?v=press-system-v3.4.21';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
 import { applyLangHints } from '../../../js/typography.js';
 import { renderPressPostCardHtml } from '../../../js/post-card-html.js';
-import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.20';
-import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.20';
+import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js?v=press-system-v3.4.21';
+import { isEncryptedMarkdown, stripEncryptedBodyForPublicUse } from '../../../js/encrypted-content.js?v=press-system-v3.4.21';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
@@ -21,7 +21,7 @@ let nativeLinkCardsModulePromise = null;
 
 function loadNativeLinkCardsModule() {
   if (!nativeLinkCardsModulePromise) {
-    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.20').catch((err) => {
+    nativeLinkCardsModulePromise = import('../../../js/link-cards.js?v=press-system-v3.4.21').catch((err) => {
       nativeLinkCardsModulePromise = null;
       throw err;
     });

--- a/assets/themes/native/theme.css
+++ b/assets/themes/native/theme.css
@@ -1,7 +1,7 @@
 /* Native theme pack - 原生 */
 /* Load base layout styles that used to live in assets/styles.css so the native theme
    owns all presentation concerns. */
-@import "./base.css?v=press-system-v3.4.20";
+@import "./base.css?v=press-system-v3.4.21";
 
 :root {
   /* 极简色彩 - 浅色模式 */

--- a/index.html
+++ b/index.html
@@ -69,11 +69,11 @@
       }
     }
   </style>
-  <script src="assets/js/theme-boot.js?v=press-system-v3.4.20"></script>
+  <script src="assets/js/theme-boot.js?v=press-system-v3.4.21"></script>
   <link rel="stylesheet" id="theme-pack">
 </head>
 <body>
   <div id="press-boot-progress" aria-hidden="true"><span></span></div>
-  <script type="module" src="assets/main.js?v=press-system-v3.4.20"></script>
+  <script type="module" src="assets/main.js?v=press-system-v3.4.21"></script>
 </body>
 </html>

--- a/index_editor.html
+++ b/index_editor.html
@@ -18,7 +18,7 @@
       } catch (_) { /* ignore */ }
     })();
   </script>
-  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.20" data-editor-native-theme>
+  <link rel="stylesheet" href="assets/themes/native/theme.css?v=press-system-v3.4.21" data-editor-native-theme>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     html { height: 100%; }
@@ -2605,9 +2605,9 @@
       updateOffset();
     })();
   </script>
-  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.20"></script>
-  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.20"></script>
-  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.20"></script>
+  <script type="module" src="assets/js/editor-boot.js?v=press-system-v3.4.21"></script>
+  <script type="module" src="assets/js/editor-main.js?v=press-system-v3.4.21"></script>
+  <script type="module" src="assets/js/composer.js?v=press-system-v3.4.21"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/index_editor_preview.html
+++ b/index_editor_preview.html
@@ -13,6 +13,6 @@
 </head>
 <body>
   <div class="editor-preview-status" id="editorPreviewStatus">Loading preview...</div>
-  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.20"></script>
+  <script type="module" src="assets/js/editor-preview-runtime.js?v=press-system-v3.4.21"></script>
 </body>
 </html>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { createPublishSettingsStore } from '../assets/js/publish/settings-store.js';
 import { createEditorSessionStateStore } from '../assets/js/editor-session-state.js';
+import { createStagingRegistry } from '../assets/js/composer-staging.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const composerPath = resolve(here, '../assets/js/composer.js');
@@ -12,6 +13,8 @@ const composerSystemPanelPath = resolve(here, '../assets/js/composer-system-pane
 const composerPublishSettingsUiPath = resolve(here, '../assets/js/composer-publish-settings-ui.js');
 const composerPublishSummaryPath = resolve(here, '../assets/js/composer-publish-summary.js');
 const composerPublishFlowPath = resolve(here, '../assets/js/composer-publish-flow.js');
+const composerContentStagingPath = resolve(here, '../assets/js/composer-content-staging.js');
+const composerIndexPublishMetadataPath = resolve(here, '../assets/js/composer-index-publish-metadata.js');
 const editorStoragePath = resolve(here, '../assets/js/editor-storage.js');
 const publishCommitServicePath = resolve(here, '../assets/js/publish/commit-service.js');
 const publishSettingsPath = resolve(here, '../assets/js/publish/settings-store.js');
@@ -39,6 +42,8 @@ const composerSystemPanelSource = readFileSync(composerSystemPanelPath, 'utf8');
 const composerPublishSettingsUiSource = readFileSync(composerPublishSettingsUiPath, 'utf8');
 const composerPublishSummarySource = readFileSync(composerPublishSummaryPath, 'utf8');
 const composerPublishFlowSource = readFileSync(composerPublishFlowPath, 'utf8');
+const composerContentStagingSource = readFileSync(composerContentStagingPath, 'utf8');
+const composerIndexPublishMetadataSource = readFileSync(composerIndexPublishMetadataPath, 'utf8');
 const editorStorageSource = readFileSync(editorStoragePath, 'utf8');
 const publishCommitServiceSource = readFileSync(publishCommitServicePath, 'utf8');
 const publishSettingsSource = readFileSync(publishSettingsPath, 'utf8');
@@ -190,20 +195,20 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /function getIndexField\(source, keys\)[\s\S]*Object\.prototype\.hasOwnProperty\.call\(input, key\)[\s\S]*function copyExistingIndexFields\(out, existing, keys\)/,
+  composerIndexPublishMetadataSource,
+  /function getIndexField\(source, keys,[^)]+\)[\s\S]*Object\.prototype\.hasOwnProperty\.call\(input, key\)[\s\S]*function copyExistingIndexFields\(out, existing, keys\)/,
   'index publish metadata enrichment should distinguish omitted front matter from explicit empty fields'
 );
 
 assert.match(
-  source,
-  /const dateField = getIndexField\(fm, \['date'\]\);[\s\S]*copyExistingIndexFields\(out, existing, \['date'\]\);[\s\S]*const tagsField = getIndexField\(fm, \['tags', 'tag'\]\);[\s\S]*copyExistingIndexFields\(out, existing, \['tags', 'tag'\]\);[\s\S]*const imageField = getIndexField\(fm, \['image', 'cover', 'thumb'\]\);[\s\S]*copyExistingIndexFields\(out, existing, \['image', 'cover', 'thumb'\]\);/,
+  composerIndexPublishMetadataSource,
+  /const dateField = getIndexField\(fm, \['date'\][^)]*\);[\s\S]*copyExistingIndexFields\(out, existing, \['date'\]\);[\s\S]*const tagsField = getIndexField\(fm, \['tags', 'tag'\][^)]*\);[\s\S]*copyExistingIndexFields\(out, existing, \['tags', 'tag'\]\);[\s\S]*const imageField = getIndexField\(fm, \['image', 'cover', 'thumb'\][^)]*\);[\s\S]*copyExistingIndexFields\(out, existing, \['image', 'cover', 'thumb'\]\);/,
   'index publish metadata enrichment should preserve curated date, tags, and image fields when front matter omits them'
 );
 
 assert.match(
-  source,
-  /const aiField = getIndexField\(fm, \['ai', 'aiGenerated', 'llm'\]\);[\s\S]*copyExistingIndexFields\(out, existing, \['ai', 'aiGenerated', 'llm'\]\);[\s\S]*const draftField = getIndexField\(fm, \['draft', 'wip', 'unfinished', 'inprogress'\]\);[\s\S]*copyExistingIndexFields\(out, existing, \['draft', 'wip', 'unfinished', 'inprogress'\]\);/,
+  composerIndexPublishMetadataSource,
+  /const aiField = getIndexField\(fm, \['ai', 'aiGenerated', 'llm'\][^)]*\);[\s\S]*copyExistingIndexFields\(out, existing, \['ai', 'aiGenerated', 'llm'\]\);[\s\S]*const draftField = getIndexField\(fm, \['draft', 'wip', 'unfinished', 'inprogress'\][^)]*\);[\s\S]*copyExistingIndexFields\(out, existing, \['draft', 'wip', 'unfinished', 'inprogress'\]\);/,
   'index publish metadata enrichment should preserve AI and draft flags when front matter omits them'
 );
 
@@ -214,13 +219,37 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /async function gatherLocalChangesForCommit\(options = \{\}\) \{[\s\S]*const prepared = alreadyEncrypted[\s\S]*await prepareMarkdownForProtectedStorage\(tab, text, \{ reason: 'commit' \}\)[\s\S]*content: prepared\.content/,
+  composerContentStagingSource,
+  /async function getCommitFiles\(options = \{\}\) \{[\s\S]*const prepared = alreadyEncrypted[\s\S]*await prepareMarkdownForProtectedStorage\(tab, text, \{ reason: 'commit' \}\)[\s\S]*content: prepared\.content/,
   'composer commit gathering should stage protected article ciphertext'
 );
 
+const protectedPlaintextEntry = {
+  kind: 'markdown',
+  path: 'wwwroot/post/protected.md',
+  content: 'ciphertext'
+};
+Object.defineProperty(protectedPlaintextEntry, 'plaintextContent', {
+  value: 'plain text baseline',
+  enumerable: false,
+  configurable: true,
+  writable: true
+});
+const protectedStagingRegistry = createStagingRegistry();
+protectedStagingRegistry.registerStagingProvider({
+  id: 'content',
+  getCommitFiles: () => [protectedPlaintextEntry]
+});
+const protectedStagedResult = await protectedStagingRegistry.getCommitFiles();
+assert.equal(protectedStagedResult.files[0].plaintextContent, 'plain text baseline', 'staging registry should preserve protected markdown plaintext baselines');
+assert.equal(
+  Object.prototype.propertyIsEnumerable.call(protectedStagedResult.files[0], 'plaintextContent'),
+  false,
+  'staging registry should keep protected plaintext baselines non-enumerable'
+);
+
 assert.match(
-  source,
+  [source, composerContentStagingSource].join('\n'),
   /function getLockedEncryptedMarkdownDraft\(tab\) \{[\s\S]*return normalizeMarkdownContent\(draft\.encryptedContent \|\| ''\);[\s\S]*const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft\(tab\);[\s\S]*alreadyEncrypted = true;/,
   'composer commit gathering should preserve locked encrypted draft ciphertext after reload'
 );
@@ -2014,13 +2043,13 @@ assert.match(
 );
 
 assert.match(
-  source,
+  composerContentStagingSource,
   /from '\.\/repository-deletions\.js\?v=[\w.-]+';[\s\S]*planManagedContentDeletions\(\{[\s\S]*indexBaseline: remoteBaseline\.index[\s\S]*tabsBaseline: remoteBaseline\.tabs[\s\S]*contentDeletionPlan\.files\.forEach\(addFile\);/,
   'composer should stage repository markdown deletions from article/page tombstones'
 );
 
 assert.match(
-  source,
+  composerContentStagingSource,
   /function collectDirtyMarkdownPathsForDeletion\(\) \{[\s\S]*const hasContent = entry\.content != null && normalizeMarkdownContent\(entry\.content\);[\s\S]*const hasAssets = Array\.isArray\(entry\.assets\) && entry\.assets\.length;[\s\S]*const hasDeletedAssets = draftHasAssetDeletions\(entry\);[\s\S]*if \(hasContent \|\| hasAssets \|\| hasDeletedAssets\) paths\.add\(key\);/,
   'repository deletion blockers should treat stored deletion-only asset drafts as pending local draft state'
 );
@@ -2044,13 +2073,13 @@ assert.match(
 );
 
 assert.match(
-  source,
+  [source, composerContentStagingSource].join('\n'),
   /async function fetchMarkdownForAssetScan\(contentPath, contentRoot = 'wwwroot'\) \{[\s\S]*if \(!resp\.ok\) return \{ text: '', failed: true \};[\s\S]*return \{ text: normalizeMarkdownContent\(await resp\.text\(\)\), failed: false \};[\s\S]*async function collectCurrentRepositoryMarkdownAssetReferences\(options = \{\}\) \{[\s\S]*const failures = \[\];[\s\S]*currentManagedMarkdownPathsForAssetScan\(currentRoot\)[\s\S]*fetchMarkdownForAssetScan\(norm, currentRoot\)[\s\S]*if \(result\.failed\) \{[\s\S]*failures\.push\(norm\);[\s\S]*return \{ refs, failures \};[\s\S]*const assetReferenceScan = await collectCurrentRepositoryMarkdownAssetReferences\(\{[\s\S]*const assetReferenceScanComplete = !\(assetReferenceScan\.failures && assetReferenceScan\.failures\.length\);[\s\S]*if \(assetReferenceScanComplete\) \{[\s\S]*listMarkdownAssetDeletions\(\)\.forEach\(\(asset\) => \{/,
   'commit payload should fail closed and include asset deletions only after scanning current published markdown references'
 );
 
 assert.match(
-  source,
+  composerContentStagingSource,
   /async function collectDeletedMarkdownAssetFiles\(markdownDeletionFiles = \[\], options = \{\}\) \{[\s\S]*fetchMarkdownForRepositoryDeletion\(file\)[\s\S]*listLocalMarkdownAssetReferences\(markdown, file\.markdownPath, contentRoot\)[\s\S]*if \(referencedAssets\.has\(resolved\.contentPath\)\) return;[\s\S]*deleted: true[\s\S]*collectDeletedMarkdownAssetFiles\(contentDeletionPlan\.files/,
   'deleting an article or page should also stage same-directory local asset deletions unless known markdown still references them'
 );

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -4,7 +4,7 @@ import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
 import {
   satisfiesSemverRange,
   setPressSystemManifestForTests
-} from '../assets/js/press-version.js?v=press-system-v3.4.20';
+} from '../assets/js/press-version.js?v=press-system-v3.4.21';
 
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 if (!globalThis.btoa) {

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -13,6 +13,8 @@ const indexEditorHtml = read('index_editor.html');
 const indexEditorPreviewHtml = read('index_editor_preview.html');
 const composer = read('assets/js/composer.js');
 const composerStaging = read('assets/js/composer-staging.js');
+const composerContentStaging = read('assets/js/composer-content-staging.js');
+const composerSeoStaging = read('assets/js/composer-seo-staging.js');
 const editorMain = read('assets/js/editor-main.js');
 const editorPreviewRuntime = read('assets/js/editor-preview-runtime.js');
 const search = read('assets/js/search.js');
@@ -128,7 +130,7 @@ assert.match(main, /function cacheDynamicImport\(importer, getCached, setCached\
 assert.match(main, /function getRawIndexVariantLocation\(value\)[\s\S]*value\.location \|\| value\.path[\s\S]*function collectRawIndexVariants\(entry, options = \{\}\)/, 'main should read object variant locations from raw index arrays');
 assert.match(main, /const pickPreferred = \(entry\) => \{[\s\S]*const variants = collectRawIndexVariants\(entry\);[\s\S]*const cand = findBy\(\[curNorm\]\) \|\| findBy\(\[defNorm\]\)/, 'main should preserve homepage order for object version arrays in raw index data');
 assert.match(composer, /from '\.\/i18n\.js\?v=[\w.-]+';/, 'composer should share the repository deletion docs i18n cache key');
-assert.match(composer, /from '\.\/seo\.js\?v=[\w.-]+';/, 'composer should cache-bust SEO helpers after editor i18n dependency changes');
+assert.match(composerSeoStaging, /from '\.\/seo\.js\?v=[\w.-]+';/, 'composer SEO staging should cache-bust SEO helpers after editor i18n dependency changes');
 assert.match(composer, /from '\.\/system-updates\.js\?v=[\w.-]+';/, 'composer should cache-bust system updates after version compatibility changes');
 assert.match(read('assets/js/system-updates.js'), /from '\.\/safe-html\.js\?v=[\w.-]+';/, 'system updates should cache-bust sanitizer when release notes can contain math');
 assert.match(composer, /from '\.\/theme-manager\.js\?v=[\w.-]+';/, 'composer should cache-bust theme manager after Press engine compatibility changes');
@@ -148,8 +150,8 @@ assert.match(main, /const excerpt = String\(publicMetadata\.excerpt \|\| ''\)\.t
 assert.match(main, /const unlockRequestId = __activePostRequestId;[\s\S]*currentPostname !== postname[\s\S]*displayPost\(postname, \{ markdown \}\)/, 'protected post unlock should ignore stale decrypt completions after navigation');
 assert.match(main, /function displayPost\(postname, options = \{\}\)[\s\S]*hasPreloadedMarkdown[\s\S]*Promise\.resolve\(String\(options\.markdown \|\| ''\)\)[\s\S]*getFile\(`\$\{getContentRoot\(\)\}\/\$\{postname\}`\)/, 'protected post unlock should render from the already-loaded encrypted markdown instead of fetching again after successful decrypt');
 assert.match(composer, /async function saveMarkdownDraftForTab[\s\S]*prepareMarkdownForProtectedStorage[\s\S]*saveMarkdownDraftEntry\(tab\.path, prepared\.content[\s\S]*encrypted: prepared\.encrypted/, 'protected markdown drafts should be encrypted before entering localStorage');
-assert.match(composer, /async function gatherLocalChangesForCommit[\s\S]*await Promise\.all\(flushes\)[\s\S]*prepareMarkdownForProtectedStorage\(tab, text, \{ reason: 'commit' \}\)[\s\S]*protected: !!prepared\.encrypted/, 'protected markdown commit payloads should stage ciphertext instead of editor plaintext');
-assert.match(composer, /function getLockedEncryptedMarkdownDraft[\s\S]*!draft\.encrypted \|\| draft\.decrypted[\s\S]*const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft\(tab\)[\s\S]*alreadyEncrypted = true/, 'publish should reuse locked encrypted draft ciphertext instead of treating empty editor content as plaintext');
+assert.match(composerContentStaging, /async function getCommitFiles\(options = \{\}\)[\s\S]*await Promise\.all\(flushes\)[\s\S]*prepareMarkdownForProtectedStorage\(tab, text, \{ reason: 'commit' \}\)[\s\S]*protected: !!prepared\.encrypted/, 'protected markdown commit payloads should stage ciphertext instead of editor plaintext');
+assert.match([composer, composerContentStaging].join('\n'), /function getLockedEncryptedMarkdownDraft[\s\S]*!draft\.encrypted \|\| draft\.decrypted[\s\S]*const lockedEncryptedDraft = getLockedEncryptedMarkdownDraft\(tab\)[\s\S]*alreadyEncrypted = true/, 'publish should reuse locked encrypted draft ciphertext instead of treating empty editor content as plaintext');
 assert.match(composer, /function bumpMarkdownDraftSaveGeneration[\s\S]*async function saveMarkdownDraftForTab[\s\S]*const saveGeneration = getMarkdownDraftSaveGeneration\(tab\)[\s\S]*if \(saveGeneration !== getMarkdownDraftSaveGeneration\(tab\)\) return null;[\s\S]*function clearMarkdownDraftForTab[\s\S]*bumpMarkdownDraftSaveGeneration\(tab\)/, 'discard and close should cancel in-flight encrypted draft saves before they can rewrite localStorage');
 assert.match(composer, /function createDiscardedMarkdownProtectionState\(protection\)[\s\S]*password: ''[\s\S]*remoteSignature: current\.remoteSignature[\s\S]*setMarkdownProtectionState\(active, createDiscardedMarkdownProtectionState\(protection\)\)/, 'discarding a protected markdown edit should clear discarded password changes instead of reusing them on the next save');
 assert.match(composerStaging, /Object\.defineProperty\(next, 'plaintextContent'[\s\S]*enumerable: false/, 'protected markdown commit plaintext baselines should stay non-enumerable in memory');
@@ -172,7 +174,7 @@ assert.match(main, /await ensureThemeLayout\(\);\s*setBootProgress\(0\.6\);/, 'm
 assert.match(main, /Promise\.allSettled\(\[[\s\S]*loadTabsJson\(getContentRoot\(\), 'tabs'\)[\s\S]*\]\);\s*setBootProgress\(0\.82\);/, 'main should advance boot progress after content and tabs finish loading');
 assert.match(main, /restoreLastSiteRouteIfEntry\(\);\s*routeAndRender\(\);\s*setBootProgress\(1\);\s*clearBootProgress\(\);/, 'main should clear the boot progress bar after the first route render takes over');
 assert.match(main, /renderErrorState\([\s\S]*notifyThemeViewChange\('boot'[\s\S]*setBootProgress\(1\);\s*clearBootProgress\(\);/, 'main should clear the boot progress bar after rendering a boot error state');
-assert.match(composer, /src="assets\/main\.js\?v=[\w.-]+"/, 'composer export template should use the same main module URL as index');
+assert.match(composerSeoStaging, /src="assets\/main\.js\?v=[\w.-]+"/, 'composer SEO staging export template should use the same main module URL as index');
 assert.match(themeBoot, /pack !== 'native'[\s\S]*return;/, 'theme boot should not eagerly apply unvalidated external theme CSS');
 assert.doesNotMatch(themeLayout, /loadThemePack\(DEFAULT_PACK\)/, 'theme layout fallback should not persist Native over a failed external pack');
 assert.match(themeLayout, /clearFailedThemeArtifacts\(pack\)/, 'theme layout fallback should clear partial external theme DOM and styles');


### PR DESCRIPTION
## Summary
- split composer publish staging into dedicated content, index metadata, SEO, and post-commit state modules
- register content staging as a first-class staging provider and preserve protected markdown plaintext baselines through provider normalization
- bump Press system/cache keys to v3.4.21 so the new module graph ships cleanly

## Verification
- node --check on changed JS modules
- node scripts/test-ui-components.js
- node --experimental-default-type=module scripts/test-composer-identity-grid.js
- bash scripts/test-main-guard.sh
- bash scripts/test-frontmatter-roundtrip.sh
- node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js
- node --experimental-default-type=module scripts/test-theme-manager.js
- node --experimental-default-type=module scripts/test-theme-contracts.js
- node scripts/test-content-model.js
- node --experimental-default-type=module scripts/test-system-updates.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- node scripts/sync-runtime-cache-keys.mjs --check
- local browser smoke on http://127.0.0.1:8001/index_editor.html: v3.4.21 composer loaded, Publish/Themes/Updates panels present, no console errors
- packaged v3.4.21 ZIP includes composer-content-staging.js, composer-index-publish-metadata.js, composer-post-commit-state.js, and composer-seo-staging.js

## Impact
- Release package: adds four assets/js composer boundary modules and bumps the Press system release to v3.4.21
- Starter sync/theme contract/Connect permissions: no product contract or permission changes

## Review
- Internal pre-PR review found a protected markdown plaintext-baseline regression risk; fixed in composer-staging.js and covered by an executable staging-registry test.
