### PR TITLE
[codex] Avoid stale product state sources

### DIFF
--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -4,6 +4,19 @@ const path = require('node:path');
 
 const DEFAULT_PRESS_REPOSITORY = 'EkilyHQ/Press';
 const DEFAULT_RAW_ROOT = 'https://raw.githubusercontent.com';
+const RAW_GITHUB_CONTENTS_REFS = new Set(['main', 'demo', 'release-artifacts']);
+const SIGNED_URL_QUERY_KEYS = [
+  'awsaccesskeyid',
+  'expires',
+  'sig',
+  'signature',
+  'x-amz-algorithm',
+  'x-amz-credential',
+  'x-amz-signature',
+  'x-goog-algorithm',
+  'x-goog-credential',
+  'x-goog-signature'
+];
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,
   downstream: [
@@ -70,12 +83,104 @@ function readJsonFile(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+function hasSignedUrlQuery(url) {
+  const keys = new Set(Array.from(url.searchParams.keys()).map((key) => key.toLowerCase()));
+  return SIGNED_URL_QUERY_KEYS.some((key) => keys.has(key));
+}
+
+function cacheBustJsonUrl(value, options = {}) {
+  if (options.cacheBust === false) return value;
+  const url = new URL(value);
+  if (hasSignedUrlQuery(url)) return value;
+  const token = options.cacheBustToken || `${Date.now()}`;
+  url.searchParams.set('press_state_cache', token);
+  return url.toString();
+}
+
+function decodeUrlPathParts(pathname) {
+  try {
+    return pathname.split('/').filter(Boolean).map((part) => decodeURIComponent(part));
+  } catch {
+    return null;
+  }
+}
+
+function shouldUseGithubContentsApi(ref) {
+  return RAW_GITHUB_CONTENTS_REFS.has(ref) || /^v\d+\.\d+\.\d+$/i.test(ref);
+}
+
+function rawGithubUrlToContentsApi(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return '';
+  }
+  if (url.hostname !== 'raw.githubusercontent.com') return '';
+  const parts = decodeUrlPathParts(url.pathname);
+  if (!parts || parts.length < 4) return '';
+  const [owner, repo, ref, ...fileParts] = parts;
+  if (!shouldUseGithubContentsApi(ref)) return '';
+  const encodedPath = fileParts.map(encodeURIComponent).join('/');
+  const apiUrl = new URL(
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodedPath}`
+  );
+  apiUrl.searchParams.set('ref', ref);
+  return apiUrl.toString();
+}
+
+function buildJsonFetchInit({ accept, githubContentsUrl, options }) {
+  const headers = {
+    Accept: accept,
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache'
+  };
+  const githubToken = options.githubToken || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
+  if (githubContentsUrl && githubToken) {
+    headers.Authorization = `Bearer ${githubToken}`;
+    headers['X-GitHub-Api-Version'] = '2022-11-28';
+  }
+  return {
+    cache: 'no-store',
+    headers
+  };
+}
+
+function shouldFallbackToRawGithub(response) {
+  if (!response) return true;
+  return response.status === 401
+    || response.status === 403
+    || response.status === 429
+    || response.status >= 500;
+}
+
 async function loadJsonSource(source, options = {}) {
   const value = String(source || '').trim();
   if (!value) throw new Error('missing JSON source');
   if (isUrl(value)) {
     const fetchImpl = options.fetchImpl || fetch;
-    const response = await fetchImpl(value, { headers: { Accept: 'application/json' } });
+    const githubContentsUrl = options.githubRawContentsApi === false
+      ? ''
+      : rawGithubUrlToContentsApi(value);
+    const requestUrl = githubContentsUrl || cacheBustJsonUrl(value, options);
+    let response;
+    try {
+      response = await fetchImpl(requestUrl, buildJsonFetchInit({
+        accept: githubContentsUrl ? 'application/vnd.github.raw+json' : 'application/json',
+        githubContentsUrl,
+        options
+      }));
+    } catch (error) {
+      if (!githubContentsUrl) throw error;
+      response = null;
+    }
+    if (githubContentsUrl && (!response || !response.ok) && shouldFallbackToRawGithub(response)) {
+      response = await fetchImpl(cacheBustJsonUrl(value, options), buildJsonFetchInit({
+        accept: 'application/json',
+        githubContentsUrl: '',
+        options
+      }));
+    }
     if (!response || !response.ok) {
       const status = response && response.status ? response.status : 'network';
       throw new Error(`unable to fetch ${value}: ${status}`);
@@ -622,6 +727,8 @@ module.exports = {
   DEFAULT_SOURCES,
   aggregateStatus,
   buildProductState,
+  cacheBustJsonUrl,
+  loadJsonSource,
   normalizeSemver,
   satisfiesSemverRange,
   shouldFailCheck,

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const {
   DEFAULT_SOURCES,
   buildProductState,
+  loadJsonSource,
   satisfiesSemverRange,
   shouldFailCheck
 } = require('./product-state-ledger.js');
@@ -140,6 +141,247 @@ function loader(fixtures) {
 test('semver range helper accepts Press engine compatibility ranges', () => {
   assert.equal(satisfiesSemverRange('3.4.51', '>=3.4.0 <4.0.0'), true);
   assert.equal(satisfiesSemverRange('4.0.0', '>=3.4.0 <4.0.0'), false);
+});
+
+test('loadJsonSource cache-busts HTTP JSON reads without changing the canonical source', async () => {
+  const calls = [];
+  const payload = await loadJsonSource('https://example.test/state.json?existing=1', {
+    cacheBustToken: 'test-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => ({ ok: true })
+      };
+    }
+  });
+
+  assert.deepEqual(payload, { ok: true });
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.origin, 'https://example.test');
+  assert.equal(calledUrl.pathname, '/state.json');
+  assert.equal(calledUrl.searchParams.get('existing'), '1');
+  assert.equal(calledUrl.searchParams.get('press_state_cache'), 'test-token');
+  assert.equal(calls[0].init.cache, 'no-store');
+  assert.equal(calls[0].init.headers['Cache-Control'], 'no-cache');
+  assert.equal(calls[0].init.headers.Pragma, 'no-cache');
+});
+
+test('loadJsonSource preserves signed HTTP source URLs while using no-cache headers', async () => {
+  const calls = [];
+  await loadJsonSource('https://example.test/state.json?x-amz-signature=abc123&existing=1', {
+    cacheBustToken: 'ignored-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => ({ ok: true })
+      };
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.searchParams.get('x-amz-signature'), 'abc123');
+  assert.equal(calledUrl.searchParams.get('existing'), '1');
+  assert.equal(calledUrl.searchParams.has('press_state_cache'), false);
+  assert.equal(calls[0].init.headers['Cache-Control'], 'no-cache');
+});
+
+test('loadJsonSource preserves Azure SAS source URLs while using no-cache headers', async () => {
+  const calls = [];
+  await loadJsonSource('https://example.test/state.json?sv=2026-01-01&sig=sas-signature', {
+    cacheBustToken: 'ignored-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => ({ ok: true })
+      };
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.searchParams.get('sig'), 'sas-signature');
+  assert.equal(calledUrl.searchParams.has('press_state_cache'), false);
+  assert.equal(calls[0].init.headers['Cache-Control'], 'no-cache');
+});
+
+test('loadJsonSource reads raw GitHub JSON through the Contents API raw media type', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json', {
+    githubToken: 'test-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.origin, 'https://api.github.com');
+  assert.equal(calledUrl.pathname, '/repos/EkilyHQ/YAP/contents/assets/press-system.json');
+  assert.equal(calledUrl.searchParams.get('ref'), 'main');
+  assert.equal(calledUrl.searchParams.has('press_state_cache'), false);
+  assert.equal(calls[0].init.headers.Accept, 'application/vnd.github.raw+json');
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer test-token');
+  assert.equal(calls[0].init.headers['X-GitHub-Api-Version'], '2022-11-28');
+});
+
+test('loadJsonSource falls back to raw GitHub URLs when the Contents API is unavailable', async () => {
+  const calls = [];
+  const payload = await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json', {
+    cacheBustToken: 'fallback-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      if (calls.length === 1) {
+        return { ok: false, status: 403 };
+      }
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(payload.version, '3.4.51');
+  assert.equal(calls.length, 2);
+  assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
+  const fallbackUrl = new URL(calls[1].url);
+  assert.equal(fallbackUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(fallbackUrl.searchParams.get('press_state_cache'), 'fallback-token');
+  assert.equal(calls[1].init.headers.Accept, 'application/json');
+});
+
+test('loadJsonSource falls back to raw GitHub URLs when Contents API auth is rejected', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json', {
+    cacheBustToken: 'auth-fallback-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      if (calls.length === 1) {
+        return { ok: false, status: 401 };
+      }
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
+  const fallbackUrl = new URL(calls[1].url);
+  assert.equal(fallbackUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(fallbackUrl.searchParams.get('press_state_cache'), 'auth-fallback-token');
+});
+
+test('loadJsonSource falls back to raw GitHub URLs when the Contents API fetch throws', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json', {
+    cacheBustToken: 'throw-fallback-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      if (calls.length === 1) {
+        throw new Error('api unavailable');
+      }
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
+  const fallbackUrl = new URL(calls[1].url);
+  assert.equal(fallbackUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(fallbackUrl.searchParams.get('press_state_cache'), 'throw-fallback-token');
+});
+
+test('loadJsonSource falls back to raw GitHub URLs when the Contents API has a server error', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json', {
+    cacheBustToken: 'server-fallback-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      if (calls.length === 1) {
+        return { ok: false, status: 503 };
+      }
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 2);
+  assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
+  const fallbackUrl = new URL(calls[1].url);
+  assert.equal(fallbackUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(fallbackUrl.searchParams.get('press_state_cache'), 'server-fallback-token');
+});
+
+test('loadJsonSource does not fall back to stale raw GitHub URLs on Contents API 404', async () => {
+  const calls = [];
+  await assert.rejects(
+    loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/missing.json', {
+      cacheBustToken: 'not-used',
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: false, status: 404 };
+      }
+    }),
+    /unable to fetch .*: 404/
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
+});
+
+test('loadJsonSource leaves ambiguous raw GitHub refs on the raw URL path', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/release/3.4/assets/press-system.json', {
+    cacheBustToken: 'raw-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(calledUrl.pathname, '/EkilyHQ/YAP/release/3.4/assets/press-system.json');
+  assert.equal(calledUrl.searchParams.get('press_state_cache'), 'raw-token');
+});
+
+test('loadJsonSource does not throw locally for malformed raw GitHub escapes', async () => {
+  const calls = [];
+  await loadJsonSource('https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/%ZZ.json', {
+    cacheBustToken: 'bad-escape-token',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => pressManifest()
+      };
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  const calledUrl = new URL(calls[0].url);
+  assert.equal(calledUrl.origin, 'https://raw.githubusercontent.com');
+  assert.equal(calledUrl.pathname, '/EkilyHQ/YAP/main/assets/%ZZ.json');
+  assert.equal(calledUrl.searchParams.get('press_state_cache'), 'bad-escape-token');
 });
 
 test('buildProductState reports ok when all declared and observed facts agree', async () => {


### PR DESCRIPTION
## Summary
- read raw GitHub JSON sources through the GitHub Contents API raw media type when generating product-state ledgers
- keep canonical source URLs unchanged in the ledger while avoiding stale raw CDN reads
- add regression coverage for cache-busted HTTP reads and raw GitHub source translation

## Verification
- `node scripts/test-product-state-ledger.js`
- `node --check scripts/product-state-ledger.js`
- `git diff --check`
- `node scripts/product-state-ledger.js --out /tmp/ekily-product-state-cache-bust.json`
- `node scripts/product-state-ledger.js --state /tmp/ekily-product-state-cache-bust.json --check --quiet`

## Release impact
- No Press system package surface changes; this only affects product-state generation freshness.