### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify Pages workflow contract
         run: |
@@ -65,13 +65,13 @@ jobs:
           node scripts/sync-runtime-cache-keys.mjs --materialize-root "${site_dir}" --tag "${tag}"
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/pages
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/product-state.yml
+++ b/.github/workflows/product-state.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate product-state ledger
         id: generate

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -20,18 +20,28 @@ if ! grep -F 'pages: write' "${workflow}" >/dev/null || ! grep -F 'id-token: wri
   exit 1
 fi
 
-if ! grep -F 'actions/configure-pages@v5' "${workflow}" >/dev/null; then
+if ! grep -F 'actions/checkout@v6' "${workflow}" >/dev/null; then
+  echo "Pages workflow must use a Node 24-compatible checkout action" >&2
+  exit 1
+fi
+
+if ! grep -F 'actions/configure-pages@v6' "${workflow}" >/dev/null; then
   echo "Pages workflow must configure GitHub Pages before artifact upload" >&2
   exit 1
 fi
 
-if ! grep -F 'actions/upload-pages-artifact@v3' "${workflow}" >/dev/null; then
+if ! grep -F 'actions/upload-pages-artifact@v5' "${workflow}" >/dev/null; then
   echo "Pages workflow must upload a GitHub Pages artifact" >&2
   exit 1
 fi
 
-if ! grep -F 'actions/deploy-pages@v4' "${workflow}" >/dev/null; then
+if ! grep -F 'actions/deploy-pages@v5' "${workflow}" >/dev/null; then
   echo "Pages workflow must deploy through the official Pages action" >&2
+  exit 1
+fi
+
+if grep -E 'actions/(checkout@v4|configure-pages@v5|deploy-pages@v4|upload-artifact@v4|upload-pages-artifact@v3)' .github/workflows/*.yml >/dev/null; then
+  echo "Press workflows must not pin known Node 20-backed GitHub actions" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Summary:
- Upgrade Press GitHub Actions pins to Node 24-compatible official action majors.
- Extend the Pages workflow guard to reject known Node 20-backed action pins.

Tests:
- bash scripts/test-pages-workflow.sh
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-product-state-workflow.sh
- node scripts/sync-runtime-cache-keys.mjs --check
- git diff --check

Impact:
- Workflow-only maintenance; no Press runtime/package surface change expected.
- Local subagent pre-PR review skipped because the available subagent tool requires explicit user authorization in this run.