### PR TITLE
Allow Pages deploys for workflow-only changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,12 @@ jobs:
             exit 0
           fi
 
+          changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+          if [[ -z "${changed_system_files}" ]]; then
+            echo "No unreleased Press system surface changes; Pages can reuse ${latest_tag}."
+            exit 0
+          fi
+
           source_tag="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) { throw new Error('assets/press-system.json must declare matching version and tag'); } process.stdout.write(tag);")"
           export LATEST_TAG="${latest_tag}"
           export NEXT_TAG="${source_tag}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: dist/pages
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,9 @@ jobs:
             exit 0
           fi
 
-          changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+          git fetch --no-tags --force --depth=1 origin "refs/tags/${latest_tag}:refs/tags/${latest_tag}"
+
+          changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native scripts/sync-runtime-cache-keys.mjs)"
           if [[ -z "${changed_system_files}" ]]; then
             echo "No unreleased Press system surface changes; Pages can reuse ${latest_tag}."
             exit 0

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -85,6 +85,11 @@ if ! grep -F 'path: dist/pages' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if ! grep -F 'include-hidden-files: true' "${workflow}" >/dev/null; then
+  echo "Pages workflow must include dotfiles such as .nojekyll in the Pages artifact" >&2
+  exit 1
+fi
+
 if grep -Eq '^[[:space:]]+NODE$' "${workflow}"; then
   echo "Pages workflow must not use indented heredoc terminators inside shell blocks" >&2
   exit 1

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -55,6 +55,16 @@ if ! grep -F 'gh release view --json tagName' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if ! grep -F 'changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"' "${workflow}" >/dev/null; then
+  echo "Pages workflow must compare the Press system surface with the latest release before enforcing cache-key advancement" >&2
+  exit 1
+fi
+
+if ! grep -F 'No unreleased Press system surface changes; Pages can reuse ${latest_tag}.' "${workflow}" >/dev/null; then
+  echo "Pages workflow must allow workflow-only or non-system deploys to reuse the current release cache key" >&2
+  exit 1
+fi
+
 if ! grep -F 'Pages deploy cache key' "${workflow}" >/dev/null; then
   echo "Pages workflow must reject deployments that reuse the latest release cache key" >&2
   exit 1

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -55,7 +55,12 @@ if ! grep -F 'gh release view --json tagName' "${workflow}" >/dev/null; then
   exit 1
 fi
 
-if ! grep -F 'changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"' "${workflow}" >/dev/null; then
+if ! grep -F 'git fetch --no-tags --force --depth=1 origin "refs/tags/${latest_tag}:refs/tags/${latest_tag}"' "${workflow}" >/dev/null; then
+  echo "Pages workflow must fetch the latest release tag before diffing against it" >&2
+  exit 1
+fi
+
+if ! grep -F 'changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native scripts/sync-runtime-cache-keys.mjs)"' "${workflow}" >/dev/null; then
   echo "Pages workflow must compare the Press system surface with the latest release before enforcing cache-key advancement" >&2
   exit 1
 fi


### PR DESCRIPTION
Summary:
- Let the Press Pages workflow reuse the current release cache key when no Press system surface changed since the latest release.
- Keep the stricter cache-key advancement check for unreleased runtime/system changes.
- Extend the Pages workflow guard to cover this distinction.

Tests:
- bash scripts/test-pages-workflow.sh
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-product-state-workflow.sh
- node scripts/sync-runtime-cache-keys.mjs --check
- ruby YAML parse for .github/workflows/*.yml
- git diff --check

Impact:
- Fixes the Pages failure from workflow-only PR #438 while preserving the release cache-key gate for system-surface changes.
- Local subagent pre-PR review skipped because the available subagent tool requires explicit user authorization in this run.