### PR TITLE
[codex] Centralize Press system surface

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Verify runtime cache keys
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
+          node scripts/test-press-system-surface.mjs
           bash scripts/test-pages-workflow.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,20 @@ jobs:
 
           git fetch --no-tags --force --depth=1 origin "refs/tags/${latest_tag}:refs/tags/${latest_tag}"
 
-          changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native scripts/sync-runtime-cache-keys.mjs)"
+          pages_release_plan_paths_file="$(mktemp)"
+          if ! node scripts/print-press-system-surface.mjs pages-release-plan-paths > "${pages_release_plan_paths_file}"; then
+            echo "Failed to read Press system Pages release-plan paths" >&2
+            exit 1
+          fi
+          pages_release_plan_paths=()
+          while IFS= read -r pages_release_plan_path; do
+            pages_release_plan_paths+=("${pages_release_plan_path}")
+          done < "${pages_release_plan_paths_file}"
+          if [[ "${#pages_release_plan_paths[@]}" -eq 0 ]]; then
+            echo "Press system Pages release-plan path list is empty" >&2
+            exit 1
+          fi
+          changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- "${pages_release_plan_paths[@]}")"
           if [[ -z "${changed_system_files}" ]]; then
             echo "No unreleased Press system surface changes; Pages can reuse ${latest_tag}."
             exit 0

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Verify release package boundary
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
+          node scripts/test-press-system-surface.mjs
           bash scripts/test-system-release-package.sh
           bash scripts/test-system-release-workflow.sh
           bash scripts/test-pages-workflow.sh
@@ -49,10 +50,23 @@ jobs:
           source_version="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) { throw new Error('assets/press-system.json must declare matching version and tag'); } process.stdout.write(version);")"
           next_tag="v${source_version}"
 
+          release_plan_paths_file="$(mktemp)"
+          if ! node scripts/print-press-system-surface.mjs release-plan-paths > "${release_plan_paths_file}"; then
+            echo "Failed to read Press system release-plan paths" >&2
+            exit 1
+          fi
+          release_plan_paths=()
+          while IFS= read -r release_plan_path; do
+            release_plan_paths+=("${release_plan_path}")
+          done < "${release_plan_paths_file}"
+          if [[ "${#release_plan_paths[@]}" -eq 0 ]]; then
+            echo "Press system release-plan path list is empty" >&2
+            exit 1
+          fi
           if [[ -n "${latest_tag}" ]]; then
-            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- "${release_plan_paths[@]}")"
           else
-            changed_files="$(git ls-files -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native)"
+            changed_files="$(git ls-files -- "${release_plan_paths[@]}")"
           fi
 
           if [[ -z "${changed_files}" ]]; then

--- a/assets/js/press-system-surface.mjs
+++ b/assets/js/press-system-surface.mjs
@@ -1,0 +1,83 @@
+const SYSTEM_PACKAGE_PATHS = Object.freeze([
+  'index.html',
+  'index_editor.html',
+  'index_editor_preview.html',
+  'assets/press-system.json',
+  'assets/main.js',
+  'assets/js',
+  'assets/i18n',
+  'assets/schema',
+  'assets/themes/native'
+]);
+
+const SYSTEM_UPDATE_ALLOWED_FILES = Object.freeze([
+  'index.html',
+  'index_editor.html',
+  'index_editor_preview.html',
+  'assets/press-system.json',
+  'assets/press-runtime-manifest.json',
+  'assets/main.js'
+]);
+
+const SYSTEM_UPDATE_ALLOWED_PREFIXES = Object.freeze([
+  'assets/js/',
+  'assets/i18n/',
+  'assets/schema/',
+  'assets/themes/native/'
+]);
+
+const SYSTEM_UPDATE_BLOCKED_PATTERN = /^(?:\.git\/|\.github\/|wwwroot\/|site\.ya?ml$|site\.local\.ya?ml$|CNAME$|robots\.txt$|sitemap\.xml$|README(?:\.md)?$|BRANCHING\.md$|scripts\/|assets\/(?:avatar\.png|avatar\.jpe?g|hero\.jpeg)$)/i;
+
+export const PRESS_SYSTEM_SURFACE = Object.freeze({
+  schemaVersion: 1,
+  type: 'press-system-surface',
+  runtimeManifestPath: 'assets/press-runtime-manifest.json',
+  packagePaths: SYSTEM_PACKAGE_PATHS,
+  systemUpdate: Object.freeze({
+    allowedFiles: SYSTEM_UPDATE_ALLOWED_FILES,
+    allowedPrefixes: SYSTEM_UPDATE_ALLOWED_PREFIXES
+  })
+});
+
+export function normalizePressSystemPath(value) {
+  const clean = String(value || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+  if (!clean || clean.includes('\0')) return '';
+  const parts = clean.split('/');
+  if (parts.some((part) => part === '..' || part === '.')) return '';
+  return clean;
+}
+
+export function getPressSystemPackagePaths() {
+  return [...SYSTEM_PACKAGE_PATHS];
+}
+
+export function getPressSystemRuntimeRoots(options = {}) {
+  const roots = [...SYSTEM_PACKAGE_PATHS];
+  if (options.includeRuntimeManifest) {
+    roots.push(PRESS_SYSTEM_SURFACE.runtimeManifestPath);
+  }
+  return roots;
+}
+
+export function getPressSystemReleasePlanPaths(options = {}) {
+  const paths = new Set(SYSTEM_PACKAGE_PATHS);
+  if (options.includePagesMaterializer) {
+    paths.add('scripts/sync-runtime-cache-keys.mjs');
+  }
+  return [...paths];
+}
+
+export function isPressSystemManagedRuntimePath(value) {
+  const clean = normalizePressSystemPath(value);
+  return clean === 'assets/main.js'
+    || clean.startsWith('assets/js/')
+    || clean.startsWith('assets/i18n/')
+    || clean.startsWith('assets/themes/native/');
+}
+
+export function isPressSystemUpdatePath(value) {
+  const clean = normalizePressSystemPath(value);
+  if (!clean || SYSTEM_UPDATE_BLOCKED_PATTERN.test(clean)) return false;
+  if (SYSTEM_UPDATE_ALLOWED_FILES.includes(clean)) return true;
+  return SYSTEM_UPDATE_ALLOWED_PREFIXES.some((prefix) => clean.startsWith(prefix));
+}

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -11,6 +11,7 @@ import {
   normalizeUpgradeFrom,
   semverToTag
 } from './press-version.js';
+import { isPressSystemUpdatePath } from './press-system-surface.mjs';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([
@@ -23,8 +24,6 @@ export const SYSTEM_UPDATE_ASSET_NAME_PATTERN = /^press-system-v\d+\.\d+\.\d+\.z
 
 const RELEASE_API_URL = 'https://api.github.com/repos/EkilyHQ/Press/releases/latest';
 const RELEASE_MANIFEST_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json';
-const SYSTEM_UPDATE_ALLOWED_PATH_PATTERN = /^(?:index\.html|index_editor\.html|index_editor_preview\.html|assets\/(?:press-system\.json|press-runtime-manifest\.json|main\.js|js\/.+|i18n\/.+|schema\/.+|themes\/native\/.+))$/;
-const SYSTEM_UPDATE_BLOCKED_PATH_PATTERN = /^(?:\.git\/|\.github\/|wwwroot\/|site\.ya?ml$|site\.local\.ya?ml$|CNAME$|robots\.txt$|sitemap\.xml$|README(?:\.md)?$|BRANCHING\.md$|scripts\/|assets\/(?:avatar\.png|avatar\.jpe?g|hero\.jpeg)$)/i;
 
 function createSystemUpdateElements() {
   return {
@@ -279,7 +278,7 @@ function stripCommonArchiveRoot(entries) {
 
 export function isSystemUpdatePath(path) {
   const clean = String(path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
-  return SYSTEM_UPDATE_ALLOWED_PATH_PATTERN.test(clean) && !SYSTEM_UPDATE_BLOCKED_PATH_PATTERN.test(clean);
+  return isPressSystemUpdatePath(clean);
 }
 
 export function collectSystemUpdateArchiveEntries(buffer) {

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.56",
-  "tag": "v3.4.56",
+  "version": "3.4.57",
+  "tag": "v3.4.57",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.55 <3.4.56"
+      ">=3.4.56 <3.4.57"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.55 first."
+    "message": "Update to v3.4.56 first."
   }
 }

--- a/scripts/package-system-release.sh
+++ b/scripts/package-system-release.sh
@@ -12,18 +12,7 @@ fi
 repo_root="$(git rev-parse --show-toplevel)"
 archive_name="press-system-${version}.zip"
 prefix="press-system-${version}/"
-
-system_paths=(
-  "index.html"
-  "index_editor.html"
-  "index_editor_preview.html"
-  "assets/press-system.json"
-  "assets/main.js"
-  "assets/js"
-  "assets/i18n"
-  "assets/schema"
-  "assets/themes/native"
-)
+package_source="${PRESS_PACKAGE_SOURCE:-head}"
 
 mkdir -p "${output_dir}"
 output_dir="$(cd "${output_dir}" && pwd)"
@@ -39,7 +28,39 @@ trap cleanup EXIT
 payload_dir="${tmp_dir}/${prefix%/}"
 mkdir -p "${payload_dir}"
 
-package_source="${PRESS_PACKAGE_SOURCE:-head}"
+case "${package_source}" in
+  head|worktree)
+    ;;
+  *)
+    echo "PRESS_PACKAGE_SOURCE must be head or worktree" >&2
+    exit 2
+    ;;
+esac
+
+surface_cli="${repo_root}/scripts/print-press-system-surface.mjs"
+if [[ "${package_source}" == "head" ]]; then
+  surface_source_dir="${tmp_dir}/surface-source"
+  mkdir -p "${surface_source_dir}"
+  git archive --format=tar HEAD -- scripts/print-press-system-surface.mjs assets/js/press-system-surface.mjs | tar -xf - -C "${surface_source_dir}"
+  surface_cli="${surface_source_dir}/scripts/print-press-system-surface.mjs"
+fi
+
+system_paths_file="${tmp_dir}/system-paths.txt"
+if ! node "${surface_cli}" package-paths > "${system_paths_file}"; then
+  echo "failed to read Press system package paths" >&2
+  exit 1
+fi
+
+system_paths=()
+while IFS= read -r system_path; do
+  system_paths+=("${system_path}")
+done < "${system_paths_file}"
+
+if [[ "${#system_paths[@]}" -eq 0 ]]; then
+  echo "Press system surface produced no package paths" >&2
+  exit 1
+fi
+
 case "${package_source}" in
   head)
     git archive --format=tar --prefix="${prefix}" HEAD -- "${system_paths[@]}" | tar -xf - -C "${tmp_dir}"
@@ -49,10 +70,6 @@ case "${package_source}" in
       mkdir -p "${payload_dir}/$(dirname "${file}")"
       cp "${file}" "${payload_dir}/${file}"
     done < <(git ls-files -z -- "${system_paths[@]}")
-    ;;
-  *)
-    echo "PRESS_PACKAGE_SOURCE must be head or worktree" >&2
-    exit 2
     ;;
 esac
 

--- a/scripts/print-press-system-surface.mjs
+++ b/scripts/print-press-system-surface.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import {
+  getPressSystemPackagePaths,
+  getPressSystemReleasePlanPaths
+} from '../assets/js/press-system-surface.mjs';
+
+const command = process.argv[2] || '';
+
+function printLines(lines) {
+  lines.forEach((line) => console.log(line));
+}
+
+if (command === 'package-paths') {
+  printLines(getPressSystemPackagePaths());
+} else if (command === 'release-plan-paths') {
+  printLines(getPressSystemReleasePlanPaths());
+} else if (command === 'pages-release-plan-paths') {
+  printLines(getPressSystemReleasePlanPaths({ includePagesMaterializer: true }));
+} else {
+  console.error('usage: node scripts/print-press-system-surface.mjs <package-paths|release-plan-paths|pages-release-plan-paths>');
+  process.exit(2);
+}

--- a/scripts/sync-runtime-cache-keys.mjs
+++ b/scripts/sync-runtime-cache-keys.mjs
@@ -4,6 +4,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  getPressSystemRuntimeRoots,
+  isPressSystemManagedRuntimePath,
+  PRESS_SYSTEM_SURFACE
+} from '../assets/js/press-system-surface.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..');
@@ -12,7 +17,7 @@ const VERSIONED_REF_PATTERN = /[?&]v=press-system-v\d+\.\d+\.\d+/;
 const MANAGED_EXTENSIONS = new Set(['.css', '.js', '.mjs']);
 const REWRITE_EXTENSIONS = new Set(['.css', '.html', '.js']);
 const LANGUAGE_MANIFEST = 'assets/i18n/languages.json';
-const RUNTIME_MANIFEST_PATH = 'assets/press-runtime-manifest.json';
+const RUNTIME_MANIFEST_PATH = PRESS_SYSTEM_SURFACE.runtimeManifestPath;
 const NATIVE_CACHE_CONSTANTS = [
   'NATIVE_MODULE_CACHE_KEY',
   'NATIVE_STYLE_CACHE_KEY',
@@ -124,18 +129,7 @@ function normalizeSlash(value) {
 }
 
 function runtimeRoots(includeManifest = false) {
-  const roots = [
-    'index.html',
-    'index_editor.html',
-    'index_editor_preview.html',
-    'assets/main.js',
-    'assets/js',
-    'assets/i18n',
-    'assets/schema',
-    'assets/themes/native'
-  ];
-  if (includeManifest) roots.push(RUNTIME_MANIFEST_PATH);
-  return roots;
+  return getPressSystemRuntimeRoots({ includeRuntimeManifest: includeManifest });
 }
 
 function rewriteTargetFiles(rootDir) {
@@ -184,12 +178,7 @@ function isManagedRuntimeAssetPath(rootDir, resolved) {
   if (!resolved) return false;
   const ext = path.posix.extname(resolved).toLowerCase();
   if (!MANAGED_EXTENSIONS.has(ext)) return false;
-  if (
-    resolved === 'assets/main.js'
-    || resolved.startsWith('assets/js/')
-    || resolved.startsWith('assets/i18n/')
-    || resolved.startsWith('assets/themes/native/')
-  ) {
+  if (isPressSystemManagedRuntimePath(resolved)) {
     return fs.existsSync(path.join(rootDir, resolved));
   }
   return false;

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -60,8 +60,18 @@ if ! grep -F 'git fetch --no-tags --force --depth=1 origin "refs/tags/${latest_t
   exit 1
 fi
 
-if ! grep -F 'changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native scripts/sync-runtime-cache-keys.mjs)"' "${workflow}" >/dev/null; then
-  echo "Pages workflow must compare the Press system surface with the latest release before enforcing cache-key advancement" >&2
+if ! grep -F 'node scripts/print-press-system-surface.mjs pages-release-plan-paths' "${workflow}" >/dev/null; then
+  echo "Pages workflow must read the shared Press system surface before enforcing cache-key advancement" >&2
+  exit 1
+fi
+
+if ! grep -F 'pages_release_plan_paths_file="$(mktemp)"' "${workflow}" >/dev/null || ! grep -F 'Press system Pages release-plan path list is empty' "${workflow}" >/dev/null; then
+  echo "Pages workflow must fail if release-plan path generation fails or returns no paths" >&2
+  exit 1
+fi
+
+if grep -F 'changed_system_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native scripts/sync-runtime-cache-keys.mjs)"' "${workflow}" >/dev/null; then
+  echo "Pages workflow must not keep a hard-coded Press system surface path list" >&2
   exit 1
 fi
 

--- a/scripts/test-press-system-surface.mjs
+++ b/scripts/test-press-system-surface.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  getPressSystemPackagePaths,
+  getPressSystemReleasePlanPaths,
+  getPressSystemRuntimeRoots,
+  isPressSystemManagedRuntimePath,
+  isPressSystemUpdatePath,
+  PRESS_SYSTEM_SURFACE
+} from '../assets/js/press-system-surface.mjs';
+
+const packagePaths = getPressSystemPackagePaths();
+
+assert.equal(PRESS_SYSTEM_SURFACE.schemaVersion, 1);
+assert.equal(PRESS_SYSTEM_SURFACE.type, 'press-system-surface');
+assert.equal(PRESS_SYSTEM_SURFACE.runtimeManifestPath, 'assets/press-runtime-manifest.json');
+assert(packagePaths.includes('index.html'));
+assert(packagePaths.includes('index_editor.html'));
+assert(packagePaths.includes('index_editor_preview.html'));
+assert(packagePaths.includes('assets/press-system.json'));
+assert(packagePaths.includes('assets/main.js'));
+assert(packagePaths.includes('assets/js'));
+assert(packagePaths.includes('assets/i18n'));
+assert(packagePaths.includes('assets/schema'));
+assert(packagePaths.includes('assets/themes/native'));
+assert(!packagePaths.includes('assets/themes/packs.json'));
+assert(!packagePaths.includes('assets/themes/catalog.json'));
+assert(!packagePaths.includes('wwwroot'));
+assert(!packagePaths.includes('scripts'));
+
+assert.deepEqual(
+  execFileSync(process.execPath, ['scripts/print-press-system-surface.mjs', 'package-paths'], { encoding: 'utf8' }).trim().split('\n'),
+  packagePaths
+);
+assert.deepEqual(
+  execFileSync(process.execPath, ['scripts/print-press-system-surface.mjs', 'release-plan-paths'], { encoding: 'utf8' }).trim().split('\n'),
+  getPressSystemReleasePlanPaths()
+);
+assert.deepEqual(
+  execFileSync(process.execPath, ['scripts/print-press-system-surface.mjs', 'pages-release-plan-paths'], { encoding: 'utf8' }).trim().split('\n'),
+  getPressSystemReleasePlanPaths({ includePagesMaterializer: true })
+);
+
+assert(getPressSystemRuntimeRoots({ includeRuntimeManifest: true }).includes('assets/press-runtime-manifest.json'));
+assert(isPressSystemManagedRuntimePath('assets/main.js'));
+assert(isPressSystemManagedRuntimePath('assets/js/system-updates.js'));
+assert(isPressSystemManagedRuntimePath('assets/i18n/en.js'));
+assert(isPressSystemManagedRuntimePath('assets/themes/native/theme.css'));
+assert(!isPressSystemManagedRuntimePath('assets/schema/site.json'));
+assert(!isPressSystemManagedRuntimePath('wwwroot/post/example.md'));
+
+assert(isPressSystemUpdatePath('index.html'));
+assert(isPressSystemUpdatePath('assets/press-system.json'));
+assert(isPressSystemUpdatePath('assets/press-runtime-manifest.json'));
+assert(isPressSystemUpdatePath('assets/js/system-updates.js'));
+assert(isPressSystemUpdatePath('assets/js/press-system-surface.mjs'));
+assert(isPressSystemUpdatePath('assets/i18n/en.js'));
+assert(isPressSystemUpdatePath('assets/schema/site.json'));
+assert(isPressSystemUpdatePath('assets/themes/native/theme.css'));
+assert(!isPressSystemUpdatePath('assets/themes/packs.json'));
+assert(!isPressSystemUpdatePath('assets/themes/catalog.json'));
+assert(!isPressSystemUpdatePath('assets/themes/arcus/theme.json'));
+assert(!isPressSystemUpdatePath('wwwroot/post/example.md'));
+assert(!isPressSystemUpdatePath('site.yaml'));
+assert(!isPressSystemUpdatePath('scripts/package-system-release.sh'));
+assert(!isPressSystemUpdatePath('../assets/main.js'));
+
+console.log('ok - press system surface');

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -29,6 +29,17 @@ if [[ ! -f "${zip_path}" ]]; then
   exit 1
 fi
 
+subdir_zip_dir="${tmp_dir}/subdir"
+mkdir -p "${subdir_zip_dir}"
+(
+  cd "${repo_root}/assets/js"
+  bash "${repo_root}/scripts/package-system-release.sh" "${version}" "${subdir_zip_dir}" >/dev/null
+)
+if [[ ! -f "${subdir_zip_dir}/press-system-${version}.zip" ]]; then
+  echo "expected package script to work from a repository subdirectory" >&2
+  exit 1
+fi
+
 entries_file="${tmp_dir}/entries.txt"
 unzip -Z1 "${zip_path}" | sed '/\/$/d' > "${entries_file}"
 
@@ -59,6 +70,11 @@ fi
 
 if ! grep -qx "press-system-${version}/assets/js/system-updates.js" "${entries_file}"; then
   echo "expected package to include system updater code" >&2
+  exit 1
+fi
+
+if ! grep -qx "press-system-${version}/assets/js/press-system-surface.mjs" "${entries_file}"; then
+  echo "expected package to include the shared Press system surface contract" >&2
   exit 1
 fi
 
@@ -571,6 +587,33 @@ mkdir -p "${dirty_zip_dir}"
 bash "${repo_root}/scripts/package-system-release.sh" "${version}" "${dirty_zip_dir}" >/dev/null
 if unzip -p "${dirty_zip_dir}/press-system-${version}.zip" "press-system-${version}/assets/js/system-updates.js" | grep -F "__dirty_system_release_probe__" >/dev/null; then
   echo "system release package must read tracked files from HEAD, not the worktree" >&2
+  exit 1
+fi
+cp "${tracked_backup}" "${tracked_probe}"
+tracked_probe=""
+tracked_backup=""
+
+tracked_probe="${repo_root}/assets/js/press-system-surface.mjs"
+tracked_backup="${tmp_dir}/press-system-surface.mjs.backup"
+cp "${tracked_probe}" "${tracked_backup}"
+SURFACE_PROBE="${tracked_probe}" node <<'NODE'
+const fs = require('fs');
+const file = process.env.SURFACE_PROBE;
+const source = fs.readFileSync(file, 'utf8');
+const next = source.replace(
+  "  'assets/themes/native'\n]);",
+  "  'assets/themes/native',\n  'wwwroot'\n]);"
+);
+if (next === source) {
+  throw new Error('failed to dirty Press system surface package paths');
+}
+fs.writeFileSync(file, next);
+NODE
+surface_dirty_zip_dir="${tmp_dir}/dirty-surface"
+mkdir -p "${surface_dirty_zip_dir}"
+bash "${repo_root}/scripts/package-system-release.sh" "${version}" "${surface_dirty_zip_dir}" >/dev/null
+if unzip -Z1 "${surface_dirty_zip_dir}/press-system-${version}.zip" | grep -q "press-system-${version}/wwwroot/"; then
+  echo "system release package must read the package path surface from HEAD, not the worktree" >&2
   exit 1
 fi
 cp "${tracked_backup}" "${tracked_probe}"

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -58,8 +58,18 @@ if awk '
   exit 1
 fi
 
-if ! grep -F 'assets/themes/native)' "${workflow}" >/dev/null && ! grep -F 'assets/themes/native"' "${workflow}" >/dev/null; then
-  echo "system release planning must include the native theme" >&2
+if ! grep -F 'node scripts/print-press-system-surface.mjs release-plan-paths' "${workflow}" >/dev/null; then
+  echo "system release planning must read the shared Press system surface" >&2
+  exit 1
+fi
+
+if ! grep -F 'release_plan_paths_file="$(mktemp)"' "${workflow}" >/dev/null || ! grep -F 'Press system release-plan path list is empty' "${workflow}" >/dev/null; then
+  echo "system release planning must fail if release-plan path generation fails or returns no paths" >&2
+  exit 1
+fi
+
+if grep -F 'git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html index_editor_preview.html assets/press-system.json assets/main.js assets/js assets/i18n assets/schema assets/themes/native' "${workflow}" >/dev/null; then
+  echo "system release planning must not keep a hard-coded Press system surface path list" >&2
   exit 1
 fi
 
@@ -78,12 +88,32 @@ if ! grep -F 'node scripts/sync-runtime-cache-keys.mjs --check' "${workflow}" >/
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-press-system-surface.mjs' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the shared Press system surface before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F -- '--materialize-root "${payload_dir}"' scripts/package-system-release.sh >/dev/null; then
   echo "system release package builder must materialize runtime cache keys into the payload" >&2
   exit 1
 fi
 
-if ! grep -F 'assets/press-runtime-manifest.json' scripts/package-system-release.sh >/dev/null && ! grep -F 'press-runtime-manifest.json' scripts/sync-runtime-cache-keys.mjs >/dev/null; then
+if ! grep -F 'print-press-system-surface.mjs' scripts/package-system-release.sh >/dev/null || ! grep -F 'package-paths' scripts/package-system-release.sh >/dev/null; then
+  echo "system release package builder must read the shared Press system surface" >&2
+  exit 1
+fi
+
+if ! grep -F 'system_paths_file="${tmp_dir}/system-paths.txt"' scripts/package-system-release.sh >/dev/null || ! grep -F 'failed to read Press system package paths' scripts/package-system-release.sh >/dev/null; then
+  echo "system release package builder must fail if package path generation fails" >&2
+  exit 1
+fi
+
+if ! grep -F 'git archive --format=tar HEAD -- scripts/print-press-system-surface.mjs assets/js/press-system-surface.mjs' scripts/package-system-release.sh >/dev/null; then
+  echo "system release package builder must read HEAD surface paths in HEAD package mode" >&2
+  exit 1
+fi
+
+if ! grep -F 'runtimeManifestPath' assets/js/press-system-surface.mjs >/dev/null || ! grep -F 'PRESS_SYSTEM_SURFACE.runtimeManifestPath' scripts/sync-runtime-cache-keys.mjs >/dev/null; then
   echo "system release package builder must generate a runtime asset manifest" >&2
   exit 1
 fi

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -666,6 +666,7 @@ await run('normalizes a rooted system update archive to safe site-relative paths
     'press-system-v3.3.5/index.html': '<!doctype html>',
     'press-system-v3.3.5/assets/press-system.json': '{"schemaVersion":1,"type":"press-system","version":"3.3.5","tag":"v3.3.5","upgradeFrom":{"ranges":[">=3.3.0 <3.3.5"],"allowUnknownSource":true,"message":""}}',
     'press-system-v3.3.5/assets/press-runtime-manifest.json': '{"schemaVersion":1,"type":"press-runtime-assets","version":"3.3.5","tag":"v3.3.5","cacheKey":"press-system-v3.3.5","entries":[]}',
+    'press-system-v3.3.5/assets/js/press-system-surface.mjs': 'export {};',
     'press-system-v3.3.5/assets/js/system-updates.js': 'export {};',
     'press-system-v3.3.5/assets/themes/native/theme.json': '{"name":"Native","contractVersion":1}'
   });
@@ -673,6 +674,7 @@ await run('normalizes a rooted system update archive to safe site-relative paths
   const entries = collectSystemUpdateArchiveEntries(buffer);
 
   assert.deepEqual(entries.map((entry) => entry.path).sort(), [
+    'assets/js/press-system-surface.mjs',
     'assets/js/system-updates.js',
     'assets/press-runtime-manifest.json',
     'assets/press-system.json',

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -181,6 +181,9 @@ stage deletions and removes the theme entry from `packs.json`.
 Press system releases may update runtime files, schemas, i18n, Theme Manager,
 and `assets/themes/native/**`. They must not overwrite `assets/themes/packs.json`,
 the external official theme catalog, or arbitrary external theme directories.
+The release package builder, Pages release gate, runtime cache-key materializer,
+and System Updates path validator share this boundary through
+`assets/js/press-system-surface.mjs`.
 Official theme source, checks, release ZIPs, checksums, and `theme-release.json`
 belong to each theme repository.
 


### PR DESCRIPTION
## Summary

- Add `assets/js/press-system-surface.mjs` as the shared Press system surface for package paths, release planning paths, runtime roots, and System Updates path validation.
- Route system release packaging, Pages release planning, runtime cache-key materialization, and System Updates allowlist checks through that shared surface.
- Bump the Press system metadata to `v3.4.57` and add workflow/package guards so future drift is caught locally and in CI.

## Impact

This is a Press system-surface release. It changes the release/package control plane and adds a new runtime module that is included in the system ZIP and materialized Pages artifact. It does not change Connect, YAP-owned starter content, or external theme source directly.

## Validation

- `node scripts/test-press-system-surface.mjs`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-workflow.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js`
- `node scripts/test-ui-components.js`
- `node --experimental-default-type=module scripts/test-composer-identity-grid.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node scripts/test-content-model.js`
- `bash scripts/test-product-state-workflow.sh`
- `node scripts/test-product-state-ledger.js`
- `node scripts/test-product-state-dashboard.js`
- `git diff --check HEAD`

## Review note

I also performed a local pre-PR review pass over the changed release/runtime boundary. Spawned subagent review was not used because the current agent runtime requires explicit user authorization for spawned agents.