### PR TITLE
[codex] Centralize theme contract surface

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -25,4 +25,5 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-press-system-surface.mjs
+          node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-pages-workflow.sh

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-press-system-surface.mjs
+          node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-system-release-package.sh
           bash scripts/test-system-release-workflow.sh
           bash scripts/test-pages-workflow.sh

--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -1,0 +1,85 @@
+const REQUIRED_THEME_VIEWS = Object.freeze(['post', 'posts', 'search', 'tab']);
+const OPTIONAL_THEME_VIEWS = Object.freeze(['error', 'loading']);
+const REQUIRED_THEME_REGIONS = Object.freeze(['main', 'toc', 'search', 'nav', 'tags', 'footer']);
+const REQUIRED_THEME_COMPONENTS = Object.freeze(['press-search', 'press-toc', 'press-post-card']);
+const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
+  'rawMarkdown',
+  'html',
+  'blocks',
+  'tocTree',
+  'headings',
+  'metadata',
+  'assets',
+  'links'
+]);
+const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
+const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
+const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
+  '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
+  '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'
+]);
+const THEME_TEXT_EXTENSIONS = Object.freeze(['.css', '.js', '.json', '.mjs', '.svg', '.txt']);
+
+export const PRESS_THEME_CONTRACT = Object.freeze({
+  schemaVersion: 1,
+  type: 'press-theme-contract',
+  contractVersion: 1,
+  manifestSchemaPath: 'assets/schema/theme.json',
+  manifest: Object.freeze({
+    requiredFields: REQUIRED_THEME_MANIFEST_FIELDS,
+    defaultStyles: DEFAULT_THEME_STYLES,
+    requiredViews: REQUIRED_THEME_VIEWS,
+    optionalViews: OPTIONAL_THEME_VIEWS,
+    requiredRegions: REQUIRED_THEME_REGIONS,
+    requiredComponents: REQUIRED_THEME_COMPONENTS,
+    requiredContentShapes: REQUIRED_THEME_CONTENT_SHAPES
+  }),
+  archive: Object.freeze({
+    allowedExtensions: THEME_ARCHIVE_ALLOWED_EXTENSIONS,
+    textExtensions: THEME_TEXT_EXTENSIONS
+  })
+});
+
+export function getRequiredThemeManifestFields() {
+  return [...REQUIRED_THEME_MANIFEST_FIELDS];
+}
+
+export function getDefaultThemeStyles() {
+  return [...DEFAULT_THEME_STYLES];
+}
+
+export function getRequiredThemeViews() {
+  return [...REQUIRED_THEME_VIEWS];
+}
+
+export function getOptionalThemeViews() {
+  return [...OPTIONAL_THEME_VIEWS];
+}
+
+export function getThemeViewNames() {
+  return [...REQUIRED_THEME_VIEWS, ...OPTIONAL_THEME_VIEWS];
+}
+
+export function getRequiredThemeRegions() {
+  return [...REQUIRED_THEME_REGIONS];
+}
+
+export function getRequiredThemeComponents() {
+  return [...REQUIRED_THEME_COMPONENTS];
+}
+
+export function getRequiredThemeContentShapes() {
+  return [...REQUIRED_THEME_CONTENT_SHAPES];
+}
+
+export function getThemeArchiveAllowedExtensions() {
+  return [...THEME_ARCHIVE_ALLOWED_EXTENSIONS];
+}
+
+export function getThemeTextExtensions() {
+  return [...THEME_TEXT_EXTENSIONS];
+}
+
+export function isPressThemeContractVersionSupported(value) {
+  return Number(value) === PRESS_THEME_CONTRACT.contractVersion;
+}

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -21,6 +21,11 @@ import {
   getDefaultThemeRegionController,
   mergeThemeRegions,
 } from './theme-regions.js';
+import {
+  PRESS_THEME_CONTRACT,
+  getDefaultThemeStyles,
+  getRequiredThemeContentShapes
+} from './theme-contract-surface.mjs';
 
 function createThemeLayoutState(options = {}) {
   return {
@@ -34,7 +39,9 @@ function createThemeLayoutState(options = {}) {
 const defaultThemeLayoutState = createThemeLayoutState();
 
 const DEFAULT_PACK = 'native';
-const CONTRACT_VERSION = 1;
+const CONTRACT_VERSION = PRESS_THEME_CONTRACT.contractVersion;
+const DEFAULT_THEME_STYLES = getDefaultThemeStyles();
+const REQUIRED_CONTENT_SHAPES = getRequiredThemeContentShapes();
 const NATIVE_MODULE_CACHE_KEY = '';
 const NATIVE_STYLE_CACHE_KEY = '';
 
@@ -137,7 +144,7 @@ function validateManifestContract(pack, manifest) {
   const content = manifest.content;
   if (content && typeof content === 'object') {
     const shapes = asStringList(content.shapes || content.provides || []);
-    ['html', 'blocks', 'tocTree'].forEach((shape) => {
+    REQUIRED_CONTENT_SHAPES.forEach((shape) => {
       if (shapes.length && !shapes.includes(shape)) {
         themeDevWarn(`Theme "${pack}" content.shapes should include "${shape}".`);
       }
@@ -176,7 +183,7 @@ function safeThemeAssetPath(pack, entry, extension, manifest) {
 
 function applyManifestStyles(pack, manifest) {
   const styles = asStringList(manifest && manifest.styles);
-  const declared = styles.length ? styles : ['theme.css'];
+  const declared = styles.length ? styles : DEFAULT_THEME_STYLES;
   const hrefs = declared.map((entry) => safeThemeAssetPath(pack, entry, '.css', manifest)).filter(Boolean);
   if (!hrefs.length) return;
   const primary = hrefs[0];

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,23 +1,33 @@
 import { t } from './i18n.js';
 import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js';
 import { getProductStateThemeEntry, loadProductState } from './product-state.js';
+import {
+  PRESS_THEME_CONTRACT,
+  getDefaultThemeStyles,
+  getRequiredThemeComponents,
+  getRequiredThemeContentShapes,
+  getRequiredThemeRegions,
+  getRequiredThemeViews,
+  getOptionalThemeViews,
+  getThemeArchiveAllowedExtensions,
+  getThemeTextExtensions,
+  isPressThemeContractVersionSupported
+} from './theme-contract-surface.mjs';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';
-const REQUIRED_CONTRACT_VERSION = 1;
+const REQUIRED_CONTRACT_VERSION = PRESS_THEME_CONTRACT.contractVersion;
 export const OFFICIAL_THEME_CATALOG_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Catalog/main/catalog.json';
 const THEME_SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 const THEME_RELEASE_ASSET_PATTERN = /^press-theme-[a-z0-9_-]+-v\d+\.\d+\.\d+\.zip$/i;
-const THEME_ARCHIVE_ALLOWED_EXTENSIONS = new Set([
-  '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
-  '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'
-]);
-const THEME_TEXT_EXTENSIONS = new Set(['.css', '.js', '.json', '.mjs', '.svg', '.txt']);
-const REQUIRED_THEME_VIEWS = ['post', 'posts', 'search', 'tab'];
-const OPTIONAL_THEME_VIEWS = ['error', 'loading'];
-const REQUIRED_THEME_REGIONS = ['main', 'toc', 'search', 'nav', 'tags', 'footer'];
-const REQUIRED_THEME_COMPONENTS = ['press-search', 'press-toc', 'press-post-card'];
-const REQUIRED_THEME_CONTENT_SHAPES = ['rawMarkdown', 'html', 'blocks', 'tocTree', 'headings', 'metadata', 'assets', 'links'];
+const THEME_ARCHIVE_ALLOWED_EXTENSIONS = new Set(getThemeArchiveAllowedExtensions());
+const THEME_TEXT_EXTENSIONS = new Set(getThemeTextExtensions());
+const DEFAULT_THEME_STYLES = getDefaultThemeStyles();
+const REQUIRED_THEME_VIEWS = getRequiredThemeViews();
+const OPTIONAL_THEME_VIEWS = getOptionalThemeViews();
+const REQUIRED_THEME_REGIONS = getRequiredThemeRegions();
+const REQUIRED_THEME_COMPONENTS = getRequiredThemeComponents();
+const REQUIRED_THEME_CONTENT_SHAPES = getRequiredThemeContentShapes();
 
 function createThemeManagerElements() {
   return {
@@ -251,7 +261,7 @@ function validateThemeManifestFiles(themeManifest, availablePaths) {
   if (themeManifest.styles != null) {
     styles = requireThemeStringList(themeManifest, 'styles', 'styles');
   }
-  if (!styles.length) styles = ['theme.css'];
+  if (!styles.length) styles = DEFAULT_THEME_STYLES;
   const modules = requireThemeStringList(themeManifest, 'modules', 'modules');
   if (!modules.length) throw new Error('Theme manifest modules must not be empty.');
 
@@ -285,20 +295,18 @@ function validateThemeManifestContract(themeManifest, availablePaths) {
   requireThemeString(themeManifest.version, 'version');
   normalizeThemeEngines(themeManifest.engines, { required: true });
   const contractVersion = Number(themeManifest.contractVersion);
-  if (contractVersion !== REQUIRED_CONTRACT_VERSION) {
+  if (!isPressThemeContractVersionSupported(contractVersion)) {
     throw new Error(`Theme contractVersion ${contractVersion || '(missing)'} is not supported.`);
   }
 
   const modules = validateThemeManifestFiles(themeManifest, availablePaths);
-  if (themeManifest.views != null) {
-    const views = requireThemeObject(themeManifest.views, 'views');
-    REQUIRED_THEME_VIEWS.forEach((view) => {
-      validateThemeViewDeclaration(views, view, modules);
-    });
-    OPTIONAL_THEME_VIEWS.forEach((view) => {
-      if (views[view] != null) validateThemeViewDeclaration(views, view, modules);
-    });
-  }
+  const views = requireThemeObject(themeManifest.views, 'views');
+  REQUIRED_THEME_VIEWS.forEach((view) => {
+    validateThemeViewDeclaration(views, view, modules);
+  });
+  OPTIONAL_THEME_VIEWS.forEach((view) => {
+    if (views[view] != null) validateThemeViewDeclaration(views, view, modules);
+  });
 
   const regions = requireThemeObject(themeManifest.regions, 'regions');
   REQUIRED_THEME_REGIONS.forEach((region) => {
@@ -422,7 +430,7 @@ export function normalizeThemeReleaseManifest(input) {
   const version = safeString(input.version || '').trim();
   if (!version) throw new Error('Theme release manifest version is required.');
   const contractVersion = Number(input.contractVersion);
-  if (contractVersion !== REQUIRED_CONTRACT_VERSION) {
+  if (!isPressThemeContractVersionSupported(contractVersion)) {
     throw new Error(`Theme contractVersion ${contractVersion || '(missing)'} is not supported.`);
   }
   const engines = normalizeThemeEngines(input.engines, { required: true });
@@ -664,7 +672,7 @@ function themeFilesFromManifest(manifest) {
     ? manifest.styles.map((entry) => safeString(entry).trim()).filter(Boolean)
     : [];
   if (styles.length) addList(styles);
-  else add('theme.css');
+  else addList(DEFAULT_THEME_STYLES);
   addList(manifest && manifest.modules);
   addList(manifest && manifest.files);
 

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.57",
-  "tag": "v3.4.57",
+  "version": "3.4.58",
+  "tag": "v3.4.58",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.56 <3.4.57"
+      ">=3.4.57 <3.4.58"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.56 first."
+    "message": "Update to v3.4.57 first."
   }
 }

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -78,6 +78,11 @@ if ! grep -qx "press-system-${version}/assets/js/press-system-surface.mjs" "${en
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/theme-contract-surface.mjs" "${entries_file}"; then
+  echo "expected package to include the shared Press theme contract surface" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/theme-manager.js" "${entries_file}"; then
   echo "expected package to include theme manager code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -93,6 +93,11 @@ if ! grep -F 'node scripts/test-press-system-surface.mjs' "${workflow}" >/dev/nu
   exit 1
 fi
 
+if ! grep -F 'node --experimental-default-type=module scripts/test-theme-contracts.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the shared Press theme contract surface before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F -- '--materialize-root "${payload_dir}"' scripts/package-system-release.sh >/dev/null; then
   echo "system release package builder must materialize runtime cache keys into the payload" >&2
   exit 1

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -1,16 +1,28 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import {
+  PRESS_THEME_CONTRACT,
+  getDefaultThemeStyles,
+  getOptionalThemeViews,
+  getRequiredThemeComponents,
+  getRequiredThemeContentShapes,
+  getRequiredThemeManifestFields,
+  getRequiredThemeRegions,
+  getRequiredThemeViews
+} from '../assets/js/theme-contract-surface.mjs';
 
 const root = process.cwd();
 const themesDir = path.join(root, 'assets', 'themes');
 const schemaPath = path.join(root, 'assets', 'schema', 'theme.json');
 const failures = [];
 
-const REQUIRED_VIEWS = ['post', 'posts', 'search', 'tab', 'error', 'loading'];
-const REQUIRED_REGIONS = ['main', 'toc', 'search', 'nav', 'tags', 'footer'];
-const REQUIRED_CONTENT_SHAPES = ['rawMarkdown', 'html', 'blocks', 'tocTree', 'headings', 'metadata', 'assets', 'links'];
-const REQUIRED_COMPONENTS = ['press-search', 'press-toc', 'press-post-card'];
+const REQUIRED_VIEWS = [...getRequiredThemeViews(), ...getOptionalThemeViews()];
+const REQUIRED_REGIONS = getRequiredThemeRegions();
+const REQUIRED_CONTENT_SHAPES = getRequiredThemeContentShapes();
+const REQUIRED_COMPONENTS = getRequiredThemeComponents();
+const REQUIRED_MANIFEST_FIELDS = getRequiredThemeManifestFields();
+const DEFAULT_THEME_STYLES = getDefaultThemeStyles();
 const REQUIRED_STYLE_TOKENS = ['--press-color-text', '--press-color-surface', '--press-font-body', '--press-radius-card', '--press-space-page'];
 const FORMER_DOM_IDS = [
   ['main', 'view'],
@@ -146,9 +158,40 @@ if (!schema) fail('assets/schema/theme.json must be readable');
 const componentSource = read(path.join(root, 'assets', 'js', 'components.js'));
 const themeRegionsSource = read(path.join(root, 'assets', 'js', 'theme-regions.js'));
 const themeLayoutSource = read(path.join(root, 'assets', 'js', 'theme-layout.js'));
+const themeManagerSource = read(path.join(root, 'assets', 'js', 'theme-manager.js'));
 const mainSource = read(path.join(root, 'assets', 'main.js'));
 const contentModelSource = read(path.join(root, 'assets', 'js', 'content-model.js'));
 const themeContractSource = read(path.join(root, 'wwwroot', 'post', 'theme-contract', 'theme-contract_en.md'));
+
+if (PRESS_THEME_CONTRACT.schemaVersion !== 1 || PRESS_THEME_CONTRACT.type !== 'press-theme-contract') {
+  fail('assets/js/theme-contract-surface.mjs must declare the press-theme-contract surface');
+}
+if (PRESS_THEME_CONTRACT.manifestSchemaPath !== 'assets/schema/theme.json') {
+  fail('theme contract surface must point at assets/schema/theme.json');
+}
+if ((schema.properties && schema.properties.contractVersion && schema.properties.contractVersion.const) !== PRESS_THEME_CONTRACT.contractVersion) {
+  fail('assets/schema/theme.json contractVersion must match the shared theme contract surface');
+}
+if (JSON.stringify(schema.required || []) !== JSON.stringify(REQUIRED_MANIFEST_FIELDS)) {
+  fail('assets/schema/theme.json required fields must match the shared theme contract surface');
+}
+if (JSON.stringify(PRESS_THEME_CONTRACT.manifest.defaultStyles || []) !== JSON.stringify(DEFAULT_THEME_STYLES)) {
+  fail('theme contract surface default styles helper must match the declared manifest default styles');
+}
+const schemaRequiredViews = schema.properties && schema.properties.views && schema.properties.views.required;
+if (JSON.stringify(schemaRequiredViews || []) !== JSON.stringify(getRequiredThemeViews())) {
+  fail('assets/schema/theme.json required views must match the shared theme contract surface');
+}
+const schemaContentShapes = schema.$defs && schema.$defs.contentShapeList && schema.$defs.contentShapeList.items && schema.$defs.contentShapeList.items.enum;
+if (JSON.stringify(schemaContentShapes || []) !== JSON.stringify(REQUIRED_CONTENT_SHAPES)) {
+  fail('assets/schema/theme.json content shape enum must match the shared theme contract surface');
+}
+if (!themeLayoutSource.includes('theme-contract-surface.mjs') || !themeManagerSource.includes('theme-contract-surface.mjs')) {
+  fail('theme runtime and Theme Manager must import the shared theme contract surface');
+}
+if (!themeLayoutSource.includes('getDefaultThemeStyles') || !themeManagerSource.includes('getDefaultThemeStyles')) {
+  fail('theme runtime and Theme Manager must read default theme styles from the shared theme contract surface');
+}
 
 REQUIRED_COMPONENTS.forEach((component) => {
   const localName = component.replace(/^press-/, '');
@@ -252,7 +295,9 @@ themeNames.forEach((themeName) => {
   }
   if (!manifest.name) fail(`${relManifest} must declare name`);
   if (!manifest.version) fail(`${relManifest} must declare version`);
-  if (manifest.contractVersion !== 1) fail(`${relManifest} contractVersion must be 1`);
+  if (manifest.contractVersion !== PRESS_THEME_CONTRACT.contractVersion) {
+    fail(`${relManifest} contractVersion must be ${PRESS_THEME_CONTRACT.contractVersion}`);
+  }
   if (!manifest.engines || typeof manifest.engines.press !== 'string' || !manifest.engines.press.trim()) {
     fail(`${relManifest} must declare engines.press`);
   }

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -773,16 +773,17 @@ await run('accepts theme manifests without optional view states', async () => {
   assert.equal(archive.files.some((file) => file.path === 'theme.json'), true);
 });
 
-await run('accepts theme manifests without top-level views', async () => {
+await run('rejects theme manifests without top-level views', async () => {
   const manifest = makeThemeManifest();
   delete manifest.views;
-  const archive = collectThemeArchiveEntries(makeZip({
-    'press-theme-test/theme.json': JSON.stringify(manifest, null, 2),
-    'press-theme-test/theme.css': ':root{}',
-    'press-theme-test/modules/layout.js': 'export default { views: { post() {}, posts() {}, search() {}, tab() {} } };'
-  }));
-  assert.equal(archive.slug, 'test');
-  assert.equal(archive.files.some((file) => file.path === 'theme.json'), true);
+  assert.throws(
+    () => collectThemeArchiveEntries(makeZip({
+      'press-theme-test/theme.json': JSON.stringify(manifest, null, 2),
+      'press-theme-test/theme.css': ':root{}',
+      'press-theme-test/modules/layout.js': 'export default { views: { post() {}, posts() {}, search() {}, tab() {} } };'
+    })),
+    /views/i
+  );
 });
 
 await run('accepts theme manifests without explicit styles', async () => {

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -28,6 +28,12 @@ into a site through Theme Manager. Press never executes a theme directly from a
 remote repository at runtime; a selected theme must exist locally under
 `assets/themes/<pack>/`.
 
+The shared machine-readable contract surface lives in
+`assets/js/theme-contract-surface.mjs`. Theme Manager, runtime development
+warnings, contract tests, and the JSON schema are expected to agree with that
+surface for the current `contractVersion`, required views, regions, components,
+content shapes, and archive file-type rules.
+
 ## Manifest
 
 ```json


### PR DESCRIPTION
## Summary

- Add `assets/js/theme-contract-surface.mjs` as the shared Press theme-contract surface for the current contract version, manifest requirements, views, regions, components, content shapes, default styles, and theme archive file rules.
- Route Theme Manager validation and runtime theme development warnings through the shared surface.
- Extend contract/release guards so `assets/schema/theme.json`, docs, runtime, Theme Manager, and release packaging agree with the shared surface.
- Bump Press system metadata to `v3.4.58`.

## Impact

This is a Press system-surface release. It tightens manual/imported theme validation by requiring top-level `views` in theme manifests, matching the published theme contract. Existing official installed themes already satisfy the contract.

## Validation

- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node --experimental-default-type=module scripts/test-theme-runtime.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-workflow.sh`
- `bash scripts/test-main-guard.sh`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `node scripts/test-ui-components.js`
- `node --experimental-default-type=module scripts/test-composer-identity-grid.js`
- `git diff --check HEAD`

## Review note

A local pre-PR subagent review found one medium contract-authority issue and one low default-style drift risk. Both were fixed before opening this PR.