### PR TITLE
[codex] Introduce editor feature lifecycle kernel

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -25,5 +25,6 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-press-system-surface.mjs
+          node scripts/test-editor-app-kernel.mjs
           node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-pages-workflow.sh

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-press-system-surface.mjs
+          node scripts/test-editor-app-kernel.mjs
           node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-system-release-package.sh
           bash scripts/test-system-release-workflow.sh

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ bash scripts/test-frontmatter-roundtrip.sh
 bash scripts/test-system-release-package.sh
 bash scripts/test-system-release-workflow.sh
 bash scripts/test-product-state-workflow.sh
+node scripts/test-editor-app-kernel.mjs
 node scripts/test-product-state-ledger.js
 node scripts/test-product-state-dashboard.js
 node --experimental-default-type=module scripts/test-encrypted-content.js

--- a/assets/js/composer-bootstrap.js
+++ b/assets/js/composer-bootstrap.js
@@ -1,3 +1,5 @@
+import { createEditorAppKernel } from './editor-app-kernel.js';
+
 function noop() {}
 
 function getElement(documentRef, id) {
@@ -346,28 +348,79 @@ export function assembleComposerWorkspace({
 export async function initializeComposerOnDomReady(options = {}) {
   const {
     documentRef,
+    setActiveComposerState = noop
+  } = options;
+
+  const context = {
+    documentRef,
+    result: null,
+    state: null
+  };
+  const kernel = createEditorAppKernel({
+    name: 'composer-bootstrap',
+    context,
+    provides: ['documentRef']
+  });
+
+  createComposerBootstrapFeatures({
+    ...options,
+    setActiveComposerState
+  }).forEach(feature => kernel.registerFeature(feature));
+
+  const runResult = await kernel.run();
+  return runResult.context.result;
+}
+
+export function createComposerBootstrapFeatures(options = {}) {
+  const {
     markdownToolbar,
     initialState,
     workspace,
     setActiveComposerState = noop
   } = options;
 
-  bindComposerMarkdownToolbar({
-    documentRef,
-    ...(markdownToolbar || {})
-  });
-
-  const state = await loadInitialComposerState(initialState || {});
-  setActiveComposerState(state);
-  const workspaceResult = assembleComposerWorkspace({
-    documentRef,
-    state,
-    ...(workspace || {})
-  });
-  return {
-    state,
-    ...workspaceResult
-  };
+  return [
+    {
+      name: 'composer.markdownToolbar',
+      requires: ['documentRef'],
+      provides: ['markdownToolbar'],
+      bind(context) {
+        bindComposerMarkdownToolbar({
+          documentRef: context.documentRef,
+          ...(markdownToolbar || {})
+        });
+        context.markdownToolbar = true;
+      }
+    },
+    {
+      name: 'composer.initialState',
+      requires: ['markdownToolbar'],
+      provides: ['initialComposerState'],
+      async start(context) {
+        const state = await loadInitialComposerState(initialState || {});
+        context.initialComposerState = state;
+        setActiveComposerState(state);
+      }
+    },
+    {
+      name: 'composer.workspace',
+      requires: ['initialComposerState'],
+      provides: ['composerWorkspace'],
+      start(context) {
+        const state = context.initialComposerState || { index: {}, tabs: {}, site: {} };
+        const workspaceResult = assembleComposerWorkspace({
+          documentRef: context.documentRef,
+          state,
+          ...(workspace || {})
+        });
+        context.composerWorkspace = workspaceResult;
+        context.result = {
+          state,
+          ...workspaceResult
+        };
+      }
+    }
+  ];
 }
 
 export function initializeComposerApp(options = {}) {

--- a/assets/js/editor-app-kernel.js
+++ b/assets/js/editor-app-kernel.js
@@ -1,0 +1,155 @@
+const DEFAULT_PHASES = Object.freeze(['init', 'bind', 'start']);
+
+function safeName(value) {
+  return String(value || '').trim();
+}
+
+function normalizeList(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map(safeName).filter(Boolean);
+}
+
+function makeKernelError(appName, message) {
+  return new Error(`${appName}: ${message}`);
+}
+
+function normalizeFeature(feature, appName) {
+  if (!feature || typeof feature !== 'object') {
+    throw makeKernelError(appName, 'feature must be an object');
+  }
+  const name = safeName(feature.name);
+  if (!name) throw makeKernelError(appName, 'feature name is required');
+  return {
+    ...feature,
+    name,
+    requires: normalizeList(feature.requires),
+    provides: normalizeList(feature.provides)
+  };
+}
+
+function sortFeatures(features, initialProvides, appName) {
+  const providerByToken = new Map();
+  const initialTokens = new Set(normalizeList(initialProvides));
+  const featureNames = new Set();
+
+  features.forEach((feature) => {
+    if (featureNames.has(feature.name)) {
+      throw makeKernelError(appName, `duplicate feature "${feature.name}"`);
+    }
+    featureNames.add(feature.name);
+    [feature.name, ...feature.provides].forEach((token) => {
+      if (initialTokens.has(token)) {
+        throw makeKernelError(appName, `feature "${feature.name}" provides initial token "${token}"`);
+      }
+      const previous = providerByToken.get(token);
+      if (previous) {
+        throw makeKernelError(appName, `token "${token}" is provided by both "${previous.name}" and "${feature.name}"`);
+      }
+      providerByToken.set(token, feature);
+    });
+  });
+
+  features.forEach((feature) => {
+    feature.requires.forEach((token) => {
+      if (!initialTokens.has(token) && !providerByToken.has(token)) {
+        throw makeKernelError(appName, `feature "${feature.name}" requires missing token "${token}"`);
+      }
+      if (feature.provides.includes(token) || feature.name === token) {
+        throw makeKernelError(appName, `feature "${feature.name}" requires token "${token}" that it provides itself`);
+      }
+    });
+  });
+
+  const edges = new Map(features.map(feature => [feature.name, new Set()]));
+  features.forEach((feature) => {
+    feature.requires.forEach((token) => {
+      if (initialTokens.has(token)) return;
+      const provider = providerByToken.get(token);
+      if (provider && provider.name !== feature.name) edges.get(feature.name).add(provider.name);
+    });
+  });
+
+  const sorted = [];
+  const temporary = new Set();
+  const permanent = new Set();
+  const byName = new Map(features.map(feature => [feature.name, feature]));
+
+  function visit(name, path = []) {
+    if (permanent.has(name)) return;
+    if (temporary.has(name)) {
+      throw makeKernelError(appName, `feature dependency cycle: ${[...path, name].join(' -> ')}`);
+    }
+    temporary.add(name);
+    [...(edges.get(name) || [])].forEach(dep => visit(dep, [...path, name]));
+    temporary.delete(name);
+    permanent.add(name);
+    sorted.push(byName.get(name));
+  }
+
+  features.forEach(feature => visit(feature.name));
+  return sorted;
+}
+
+export function createEditorAppKernel(options = {}) {
+  const appName = safeName(options.name) || 'editor-app';
+  const phases = normalizeList(options.phases).length ? normalizeList(options.phases) : [...DEFAULT_PHASES];
+  const initialProvides = normalizeList(options.provides || options.initialProvides);
+  const baseContext = options.context && typeof options.context === 'object' ? options.context : {};
+  const features = [];
+
+  function registerFeature(feature) {
+    const normalized = normalizeFeature(feature, appName);
+    features.push(normalized);
+    return normalized;
+  }
+
+  async function run(extraContext = {}) {
+    const orderedFeatures = sortFeatures(features, initialProvides, appName);
+    const context = {
+      ...baseContext,
+      ...extraContext,
+      appName,
+      lifecycle: Object.freeze({
+        phases: [...phases],
+        features: orderedFeatures.map(feature => ({
+          name: feature.name,
+          requires: [...feature.requires],
+          provides: [...feature.provides]
+        }))
+      })
+    };
+
+    for (const phase of phases) {
+      for (const feature of orderedFeatures) {
+        const handler = feature[phase];
+        if (typeof handler === 'function') await handler(context);
+      }
+    }
+
+    return {
+      context,
+      features: orderedFeatures
+    };
+  }
+
+  return {
+    registerFeature,
+    run,
+    getLifecyclePlan: () => sortFeatures(features, initialProvides, appName).map(feature => ({
+      name: feature.name,
+      requires: [...feature.requires],
+      provides: [...feature.provides]
+    })),
+    getFeatures: () => features.map(feature => ({
+      name: feature.name,
+      requires: [...feature.requires],
+      provides: [...feature.provides]
+    }))
+  };
+}
+
+export function runEditorFeatureLifecycle(features, options = {}) {
+  const kernel = createEditorAppKernel(options);
+  (Array.isArray(features) ? features : []).forEach(feature => kernel.registerFeature(feature));
+  return kernel.run();
+}

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -18,8 +18,417 @@ import { createEditorMainScrollSession } from './editor-main-scroll-session.js';
 import { createEditorMainServiceRegistry } from './editor-main-service-registry.js';
 import { createEditorMainShellService } from './editor-main-shell-service.js';
 import { createEditorMainRuntime } from './editor-main-runtime.js';
+import { createEditorAppKernel } from './editor-app-kernel.js';
 
 const FORCE_MARKDOWN_WRAP = true;
+
+export function createEditorMainFeatures() {
+  return [
+    {
+      name: 'editorMain.editor',
+      requires: ['runtime', 'documentRef', 'dom'],
+      provides: ['editor'],
+      init(context) {
+        const { runtime, documentRef, dom } = context;
+        context.editor = createHiEditor(dom.textarea, 'markdown', false, {
+          documentRef,
+          windowRef: runtime.windowRef,
+          setTimeoutRef: (handler, delay) => runtime.setTimer(handler, delay),
+          getComputedStyle: (node) => runtime.getComputedStyle(node),
+          getResizeObserver: () => runtime.getResizeObserver(),
+          addDocumentListener: (type, handler, options) => runtime.onDocument(type, handler, options),
+          addWindowListener: (type, handler, options) => runtime.onWindow(type, handler, options),
+          writeClipboardText: (text) => runtime.writeClipboardText(text),
+          editorRegistry: runtime.getHiEditorRegistry(),
+          allowAmbient: false
+        });
+      }
+    },
+    {
+      name: 'editorMain.metadataPanel',
+      requires: ['runtime', 'documentRef', 'getContentRoot', 'appServices'],
+      provides: ['metadataPanel'],
+      init(context) {
+        context.metadataPanel = context.appServices.setMetadataPanel(createEditorMainMetadataPanel({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          translate: t,
+          getCurrentLang,
+          normalizeLangKey,
+          getContentRoot: context.getContentRoot,
+          onChange: context.appServices.notifyDocumentChange
+        }));
+      }
+    },
+    {
+      name: 'editorMain.linkCardContext',
+      requires: ['runtime', 'getContentRoot'],
+      provides: ['linkCardContext'],
+      init(context) {
+        context.linkCardContext = createEditorMainLinkCardContext({
+          getCurrentLang,
+          normalizeLangKey,
+          getContentRoot: context.getContentRoot,
+          fetch: (url, options) => context.runtime.fetchContent(url, options),
+          translate: t,
+          makeHref: (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`)
+        });
+      }
+    },
+    {
+      name: 'editorMain.shellService',
+      requires: ['runtime', 'editor', 'dom'],
+      provides: ['shellService'],
+      init(context) {
+        context.shellService = createEditorMainShellService({
+          runtime: context.runtime,
+          editor: context.editor,
+          textarea: context.dom.textarea
+        });
+      }
+    },
+    {
+      name: 'editorMain.workspaceSession',
+      requires: ['runtime', 'documentRef', 'editor', 'dom', 'shellService', 'appServices'],
+      provides: ['workspaceSession'],
+      init(context) {
+        context.workspaceSession = context.appServices.setWorkspaceSession(createEditorMainWorkspaceSession({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          forceMarkdownWrap: FORCE_MARKDOWN_WRAP,
+          editor: context.editor,
+          textarea: context.dom.textarea,
+          getPreviewSession: context.appServices.getPreviewSession,
+          getBlocksEditor: context.appServices.getBlocksEditor,
+          syncBlocksFromSource: context.appServices.syncBlocksFromSource,
+          requestLayout: context.shellService.requestLayout
+        }));
+      }
+    },
+    {
+      name: 'editorMain.fileContextService',
+      requires: ['workspaceSession', 'appServices'],
+      provides: ['fileContextService'],
+      init(context) {
+        context.fileContextService = createEditorMainFileContextService({
+          getCurrentFileSession: context.appServices.getCurrentFileSession,
+          getMetadataPanel: context.appServices.getMetadataPanel,
+          getPreviewSession: context.appServices.getPreviewSession,
+          getDocumentSession: context.appServices.getDocumentSession
+        });
+      }
+    },
+    {
+      name: 'editorMain.contentService',
+      requires: ['runtime', 'getContentRoot', 'linkCardContext', 'fileContextService', 'appServices'],
+      provides: ['contentService'],
+      init(context) {
+        context.contentService = context.appServices.setContentService(createEditorMainContentService({
+          runtime: context.runtime,
+          getContentRoot: context.getContentRoot,
+          fetch: (url, options) => context.runtime.fetchContent(url, options),
+          linkCardContext: context.linkCardContext,
+          getPreviewSession: context.appServices.getPreviewSession,
+          getDocumentSession: context.appServices.getDocumentSession,
+          getWorkspaceSession: context.appServices.getWorkspaceSession,
+          setCurrentFileLabel: context.fileContextService.setCurrentFileLabel,
+          warn: (...args) => context.runtime.warn(...args),
+          alert: (message) => context.runtime.showAlert(message)
+        }));
+      }
+    },
+    {
+      name: 'editorMain.documentSession',
+      requires: ['runtime', 'editor', 'dom', 'metadataPanel', 'workspaceSession', 'contentService', 'fileContextService', 'shellService', 'appServices'],
+      provides: ['documentSession'],
+      init(context) {
+        context.documentSession = context.appServices.setDocumentSession(createEditorMainDocumentSession({
+          runtime: context.runtime,
+          editor: context.editor,
+          textarea: context.dom.textarea,
+          metadataPanel: context.metadataPanel,
+          workspaceSession: context.workspaceSession,
+          getPreviewSession: context.appServices.getPreviewSession,
+          getBlocksSession: context.appServices.getBlocksSession,
+          requestLayout: context.shellService.requestLayout,
+          setBaseDir: context.contentService.setBaseDir,
+          setCurrentFileLabel: context.fileContextService.setCurrentFileLabel
+        }));
+      }
+    },
+    {
+      name: 'editorMain.currentFileSession',
+      requires: ['runtime', 'documentRef', 'fileContextService', 'workspaceSession', 'documentSession', 'appServices'],
+      provides: ['currentFileSession'],
+      init(context) {
+        context.currentFileSession = context.appServices.setCurrentFileSession(createEditorMainCurrentFileSession({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          translate: t,
+          getCurrentLang,
+          normalizeLangKey,
+          inferCurrentFileSource: context.fileContextService.inferCurrentFileSource,
+          applyEditorEmptyState: context.workspaceSession.applyEditorEmptyState,
+          onRendered: context.fileContextService.handleCurrentFileRendered
+        }));
+      }
+    },
+    {
+      name: 'editorMain.previewSession',
+      requires: ['runtime', 'documentRef', 'getContentRoot', 'linkCardContext', 'fileContextService', 'appServices'],
+      provides: ['previewSession'],
+      init(context) {
+        context.previewSession = context.appServices.setPreviewSession(createEditorMainPreviewSession({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          getContentRoot: context.getContentRoot,
+          getEditorValue: context.appServices.getEditorValue,
+          getCurrentFileInfo: context.fileContextService.getCurrentFileInfo,
+          getSiteConfig: context.appServices.getSiteConfig,
+          getPostsIndex: () => context.linkCardContext.getPostsIndex(),
+          getPostsByLocationTitle: () => context.linkCardContext.getPostsByLocationTitle(),
+          isLinkCardReady: () => context.linkCardContext.isReady(),
+          getAllowedLocations: () => context.linkCardContext.getAllowedLocations(),
+          getLocationAliases: () => context.linkCardContext.getLocationAliases(),
+          consoleRef: {
+            warn: (...args) => context.runtime.warn(...args)
+          },
+          fetch: (url, options) => context.runtime.fetchContent(url, options)
+        }));
+      }
+    },
+    {
+      name: 'editorMain.imageSession',
+      requires: ['runtime', 'dom', 'getContentRoot', 'documentSession', 'fileContextService', 'shellService', 'appServices'],
+      provides: ['imageSession'],
+      init(context) {
+        context.imageSession = context.appServices.setImageSession(createEditorMainImageSession({
+          runtime: context.runtime,
+          translate: t,
+          imageButton: context.dom.imageButton,
+          imageInput: context.dom.imageInput,
+          getCurrentMarkdownPath: context.fileContextService.getCurrentMarkdownPath,
+          getContentRoot: context.getContentRoot,
+          getEditorTextarea: context.documentSession.getEditorTextarea,
+          getEditorBody: context.documentSession.getEditorBody,
+          buildMarkdown: context.documentSession.buildMarkdown,
+          setValue: context.documentSession.setValue,
+          getBlocksEditor: context.appServices.getBlocksEditor,
+          consoleRef: {
+            error: (...args) => context.runtime.error(...args)
+          },
+          emitToast: context.shellService.emitToast
+        }));
+      }
+    },
+    {
+      name: 'editorMain.blocksSession',
+      requires: ['runtime', 'dom', 'getContentRoot', 'resolveEditorImageSrc', 'documentSession', 'fileContextService', 'previewSession', 'imageSession', 'linkCardContext', 'appServices'],
+      provides: ['blocksSession'],
+      init(context) {
+        context.blocksSession = context.appServices.setBlocksSession(createEditorMainBlocksSession({
+          runtime: context.runtime,
+          root: context.dom.blocksWrap,
+          translate: t,
+          getContentRoot: context.getContentRoot,
+          getEditorBody: context.documentSession.getEditorBody,
+          onBodyChange: context.documentSession.setBodyFromBlocks,
+          getCurrentMarkdownPath: context.fileContextService.getCurrentMarkdownPath,
+          getSiteConfig: context.appServices.getSiteConfig,
+          getPreviewSession: context.appServices.getPreviewSession,
+          getImageSession: context.appServices.getImageSession,
+          linkCardContext: context.linkCardContext,
+          resolveImageSrc: context.resolveEditorImageSrc
+        }));
+      }
+    },
+    {
+      name: 'editorMain.toolbarSession',
+      requires: ['runtime', 'documentRef', 'dom', 'documentSession', 'linkCardContext', 'appServices'],
+      provides: ['toolbarSession'],
+      init(context) {
+        context.toolbarSession = context.appServices.setToolbarSession(createEditorMainToolbarSession({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          translate: t,
+          getEditorTextarea: context.documentSession.getEditorTextarea,
+          editorToolbarEl: context.dom.editorToolbarEl,
+          cardButton: context.dom.cardButton,
+          cardPopover: context.dom.cardPopover,
+          cardSearchInput: context.dom.cardSearchInput,
+          cardListEl: context.dom.cardListEl,
+          cardEmptyEl: context.dom.cardEmptyEl,
+          getCardEntries: () => context.linkCardContext.getCardEntries()
+        }));
+      }
+    },
+    {
+      name: 'editorMain.languageSession',
+      requires: ['runtime', 'toolbarSession', 'currentFileSession', 'blocksSession', 'metadataPanel', 'appServices'],
+      provides: ['languageSession'],
+      init(context) {
+        context.languageSession = createEditorMainLanguageSession({
+          runtime: context.runtime,
+          getToolbarSession: context.appServices.getToolbarSession,
+          getCurrentFileSession: context.appServices.getCurrentFileSession,
+          getBlocksSession: context.appServices.getBlocksSession,
+          getMetadataPanel: context.appServices.getMetadataPanel
+        });
+      }
+    },
+    {
+      name: 'editorMain.workspaceBinding',
+      requires: ['workspaceSession'],
+      provides: ['workspaceBinding'],
+      bind(context) {
+        context.workspaceSession.initialize();
+      }
+    },
+    {
+      name: 'editorMain.previewBinding',
+      requires: ['previewSession', 'workspaceBinding'],
+      provides: ['previewBinding'],
+      bind(context) {
+        context.previewSession.bind();
+      }
+    },
+    {
+      name: 'editorMain.contentBinding',
+      requires: ['contentService', 'previewBinding'],
+      provides: ['contentBinding'],
+      bind(context) {
+        context.contentService.bind();
+      }
+    },
+    {
+      name: 'editorMain.blocksBinding',
+      requires: ['blocksSession', 'contentBinding'],
+      provides: ['blocksBinding'],
+      bind(context) {
+        context.blocksSession.initialize();
+      }
+    },
+    {
+      name: 'editorMain.toolbarBinding',
+      requires: ['toolbarSession', 'blocksBinding'],
+      provides: ['toolbarBinding'],
+      bind(context) {
+        context.toolbarSession.bind();
+      }
+    },
+    {
+      name: 'editorMain.languageBinding',
+      requires: ['languageSession', 'toolbarBinding'],
+      provides: ['languageBinding'],
+      bind(context) {
+        context.languageSession.bind();
+      }
+    },
+    {
+      name: 'editorMain.linkCardToolbarSync',
+      requires: ['linkCardContext', 'toolbarSession', 'languageBinding'],
+      provides: ['linkCardToolbarSync'],
+      bind(context) {
+        context.linkCardContext.onCardEntriesChange((entries) => context.toolbarSession.setCardEntries(entries));
+        context.toolbarSession.setCardEntries(context.linkCardContext.getCardEntries());
+      }
+    },
+    {
+      name: 'editorMain.currentFileRender',
+      requires: ['currentFileSession', 'previewBinding', 'linkCardToolbarSync'],
+      provides: ['currentFileRender'],
+      bind(context) {
+        context.fileContextService.renderCurrentFile();
+      }
+    },
+    {
+      name: 'editorMain.documentInputBinding',
+      requires: ['documentSession', 'currentFileRender'],
+      provides: ['documentInputBinding'],
+      bind(context) {
+        context.documentSession.bindInput();
+      }
+    },
+    {
+      name: 'editorMain.initialDocumentState',
+      requires: ['seed', 'documentInputBinding', 'contentService'],
+      provides: ['initialDocumentState'],
+      start(context) {
+        context.documentSession.renderInitial(context.seed);
+        context.contentService.setBaseDir('');
+      }
+    },
+    {
+      name: 'editorMain.imageBinding',
+      requires: ['imageSession', 'initialDocumentState'],
+      provides: ['imageBinding'],
+      start(context) {
+        context.imageSession.bind();
+      }
+    },
+    {
+      name: 'editorMain.primaryEditorApi',
+      requires: ['documentSession', 'imageBinding'],
+      provides: ['primaryEditorApi'],
+      start(context) {
+        context.documentSession.registerPrimaryEditorApi();
+      }
+    },
+    {
+      name: 'editorMain.defaultWorkspaceView',
+      requires: ['workspaceSession', 'primaryEditorApi'],
+      provides: ['defaultWorkspaceView'],
+      start(context) {
+        context.workspaceSession.setView('blocks');
+      }
+    },
+    {
+      name: 'editorMain.scrollSession',
+      requires: ['runtime'],
+      provides: ['scrollSession'],
+      init(context) {
+        context.scrollSession = createEditorMainScrollSession({ runtime: context.runtime });
+      }
+    },
+    {
+      name: 'editorMain.scrollBinding',
+      requires: ['scrollSession', 'defaultWorkspaceView'],
+      provides: ['scrollBinding'],
+      start(context) {
+        context.scrollSession.bind();
+      }
+    },
+    {
+      name: 'editorMain.sidebarSession',
+      requires: ['runtime', 'documentRef', 'fileContextService', 'contentService'],
+      provides: ['sidebarSession'],
+      init(context) {
+        context.sidebarSession = createEditorMainSidebarSession({
+          runtime: context.runtime,
+          documentRef: context.documentRef,
+          normalizeLangKey,
+          bindCurrentFileElement: context.fileContextService.bindCurrentFileElement,
+          loadSiteConfig: context.contentService.loadSiteConfig,
+          loadIndexData: context.contentService.loadIndexData,
+          loadTabsConfig: context.contentService.loadTabsConfig,
+          onSiteConfigLoaded: context.contentService.handleSiteConfigLoaded,
+          onIndexLoaded: context.contentService.handleIndexLoaded,
+          onOpenMarkdown: context.contentService.openMarkdown,
+          onWarn: context.contentService.warn,
+          alert: context.contentService.alert
+        });
+      }
+    },
+    {
+      name: 'editorMain.sidebarStartup',
+      requires: ['sidebarSession', 'scrollBinding'],
+      provides: ['sidebarStartup'],
+      start(context) {
+        context.sidebarSession.initialize();
+      }
+    }
+  ];
+}
 
 export function createEditorMainController(editorMainRuntime = createEditorMainRuntime()) {
   const editorMainDocument = editorMainRuntime.documentRef;
@@ -33,235 +442,41 @@ export function createEditorMainController(editorMainRuntime = createEditorMainR
 
   function start() {
     editorMainRuntime.onDocumentReady(() => {
-      const ta = editorMainRuntime.getElementById('mdInput');
-      const editor = createHiEditor(ta, 'markdown', false, {
-        documentRef: editorMainDocument,
-        windowRef: editorMainRuntime.windowRef,
-        setTimeoutRef: (handler, delay) => editorMainRuntime.setTimer(handler, delay),
-        getComputedStyle: (node) => editorMainRuntime.getComputedStyle(node),
-        getResizeObserver: () => editorMainRuntime.getResizeObserver(),
-        addDocumentListener: (type, handler, options) => editorMainRuntime.onDocument(type, handler, options),
-        addWindowListener: (type, handler, options) => editorMainRuntime.onWindow(type, handler, options),
-        writeClipboardText: (text) => editorMainRuntime.writeClipboardText(text),
-        editorRegistry: editorMainRuntime.getHiEditorRegistry(),
-        allowAmbient: false
-      });
-      const imageButton = editorMainRuntime.getElementById('btnInsertImage');
-      const imageInput = editorMainRuntime.getElementById('editorImageInput');
-      const editorToolbarEl = editorMainRuntime.getElementById('editorToolbar');
-      const blocksWrap = editorMainRuntime.getElementById('blocks-wrap');
-      const cardButton = editorMainRuntime.getElementById('btnInsertCard');
-      const cardPopover = editorMainRuntime.getElementById('editorCardPicker');
-      const cardSearchInput = editorMainRuntime.getElementById('cardPickerSearch');
-      const cardListEl = editorMainRuntime.getElementById('cardPickerList');
-      const cardEmptyEl = editorMainRuntime.getElementById('cardPickerEmpty');
-
-      const seed = `# 新文章标题\n\n> 在左侧编辑 Markdown，切换到 Preview 查看渲染效果。\n\n- 支持代码块、表格、待办列表\n- 图片与视频语法\n\n\`\`\`js\nconsole.log('Hello, Press!');\n\`\`\`\n`;
-
-      const appServices = createEditorMainServiceRegistry();
-
-      const metadataPanel = appServices.setMetadataPanel(createEditorMainMetadataPanel({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        translate: t,
-        getCurrentLang,
-        normalizeLangKey,
-        getContentRoot,
-        onChange: appServices.notifyDocumentChange
-      }));
-
-      const linkCardContext = createEditorMainLinkCardContext({
-        getCurrentLang,
-        normalizeLangKey,
-        getContentRoot,
-        fetch: (url, options) => editorMainRuntime.fetchContent(url, options),
-        translate: t,
-        makeHref: (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`)
+      const kernel = createEditorAppKernel({
+        name: 'editor-main',
+        provides: ['runtime', 'documentRef', 'dom', 'appServices', 'getContentRoot', 'resolveEditorImageSrc', 'seed'],
+        context: {
+          runtime: editorMainRuntime,
+          documentRef: editorMainDocument,
+          getContentRoot,
+          resolveEditorImageSrc,
+          appServices: createEditorMainServiceRegistry(),
+          dom: {
+            textarea: editorMainRuntime.getElementById('mdInput'),
+            imageButton: editorMainRuntime.getElementById('btnInsertImage'),
+            imageInput: editorMainRuntime.getElementById('editorImageInput'),
+            editorToolbarEl: editorMainRuntime.getElementById('editorToolbar'),
+            blocksWrap: editorMainRuntime.getElementById('blocks-wrap'),
+            cardButton: editorMainRuntime.getElementById('btnInsertCard'),
+            cardPopover: editorMainRuntime.getElementById('editorCardPicker'),
+            cardSearchInput: editorMainRuntime.getElementById('cardPickerSearch'),
+            cardListEl: editorMainRuntime.getElementById('cardPickerList'),
+            cardEmptyEl: editorMainRuntime.getElementById('cardPickerEmpty')
+          },
+          seed: `# 新文章标题\n\n> 在左侧编辑 Markdown，切换到 Preview 查看渲染效果。\n\n- 支持代码块、表格、待办列表\n- 图片与视频语法\n\n\`\`\`js\nconsole.log('Hello, Press!');\n\`\`\`\n`
+        }
       });
 
-      const shellService = createEditorMainShellService({
-        runtime: editorMainRuntime,
-        editor,
-        textarea: ta
+      createEditorMainFeatures().forEach(feature => kernel.registerFeature(feature));
+      kernel.run().catch((err) => {
+        editorMainRuntime.error('Editor main lifecycle failed', err);
       });
-
-      const workspaceSession = appServices.setWorkspaceSession(createEditorMainWorkspaceSession({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        forceMarkdownWrap: FORCE_MARKDOWN_WRAP,
-        editor,
-        textarea: ta,
-        getPreviewSession: appServices.getPreviewSession,
-        getBlocksEditor: appServices.getBlocksEditor,
-        syncBlocksFromSource: appServices.syncBlocksFromSource,
-        requestLayout: shellService.requestLayout
-      }));
-      workspaceSession.initialize();
-
-      const fileContextService = createEditorMainFileContextService({
-        getCurrentFileSession: appServices.getCurrentFileSession,
-        getMetadataPanel: appServices.getMetadataPanel,
-        getPreviewSession: appServices.getPreviewSession,
-        getDocumentSession: appServices.getDocumentSession
-      });
-
-      const contentService = appServices.setContentService(createEditorMainContentService({
-        runtime: editorMainRuntime,
-        getContentRoot,
-        fetch: (url, options) => editorMainRuntime.fetchContent(url, options),
-        linkCardContext,
-        getPreviewSession: appServices.getPreviewSession,
-        getDocumentSession: appServices.getDocumentSession,
-        getWorkspaceSession: appServices.getWorkspaceSession,
-        setCurrentFileLabel: fileContextService.setCurrentFileLabel,
-        warn: (...args) => editorMainRuntime.warn(...args),
-        alert: (message) => editorMainRuntime.showAlert(message)
-      }));
-
-      const documentSession = appServices.setDocumentSession(createEditorMainDocumentSession({
-        runtime: editorMainRuntime,
-        editor,
-        textarea: ta,
-        metadataPanel,
-        workspaceSession,
-        getPreviewSession: appServices.getPreviewSession,
-        getBlocksSession: appServices.getBlocksSession,
-        requestLayout: shellService.requestLayout,
-        setBaseDir: contentService.setBaseDir,
-        setCurrentFileLabel: fileContextService.setCurrentFileLabel
-      }));
-
-      const currentFileSession = appServices.setCurrentFileSession(createEditorMainCurrentFileSession({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        translate: t,
-        getCurrentLang,
-        normalizeLangKey,
-        inferCurrentFileSource: fileContextService.inferCurrentFileSource,
-        applyEditorEmptyState: workspaceSession.applyEditorEmptyState,
-        onRendered: fileContextService.handleCurrentFileRendered
-      }));
-
-      const previewSession = appServices.setPreviewSession(createEditorMainPreviewSession({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        getContentRoot,
-        getEditorValue: appServices.getEditorValue,
-        getCurrentFileInfo: fileContextService.getCurrentFileInfo,
-        getSiteConfig: appServices.getSiteConfig,
-        getPostsIndex: () => linkCardContext.getPostsIndex(),
-        getPostsByLocationTitle: () => linkCardContext.getPostsByLocationTitle(),
-        isLinkCardReady: () => linkCardContext.isReady(),
-        getAllowedLocations: () => linkCardContext.getAllowedLocations(),
-        getLocationAliases: () => linkCardContext.getLocationAliases(),
-        consoleRef: {
-          warn: (...args) => editorMainRuntime.warn(...args)
-        },
-        fetch: (url, options) => editorMainRuntime.fetchContent(url, options)
-      }));
-      previewSession.bind();
-      contentService.bind();
-
-      const imageSession = appServices.setImageSession(createEditorMainImageSession({
-        runtime: editorMainRuntime,
-        translate: t,
-        imageButton,
-        imageInput,
-        getCurrentMarkdownPath: fileContextService.getCurrentMarkdownPath,
-        getContentRoot,
-        getEditorTextarea: documentSession.getEditorTextarea,
-        getEditorBody: documentSession.getEditorBody,
-        buildMarkdown: documentSession.buildMarkdown,
-        setValue: documentSession.setValue,
-        getBlocksEditor: appServices.getBlocksEditor,
-        consoleRef: {
-          error: (...args) => editorMainRuntime.error(...args)
-        },
-        emitToast: shellService.emitToast
-      }));
-
-      const blocksSession = appServices.setBlocksSession(createEditorMainBlocksSession({
-        runtime: editorMainRuntime,
-        root: blocksWrap,
-        translate: t,
-        getContentRoot,
-        getEditorBody: documentSession.getEditorBody,
-        onBodyChange: documentSession.setBodyFromBlocks,
-        getCurrentMarkdownPath: fileContextService.getCurrentMarkdownPath,
-        getSiteConfig: appServices.getSiteConfig,
-        getPreviewSession: appServices.getPreviewSession,
-        getImageSession: appServices.getImageSession,
-        linkCardContext,
-        resolveImageSrc: resolveEditorImageSrc
-      }));
-      blocksSession.initialize();
-
-      const toolbarSession = appServices.setToolbarSession(createEditorMainToolbarSession({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        translate: t,
-        getEditorTextarea: documentSession.getEditorTextarea,
-        editorToolbarEl,
-        cardButton,
-        cardPopover,
-        cardSearchInput,
-        cardListEl,
-        cardEmptyEl,
-        getCardEntries: () => linkCardContext.getCardEntries()
-      }));
-      toolbarSession.bind();
-
-      const languageSession = createEditorMainLanguageSession({
-        runtime: editorMainRuntime,
-        getToolbarSession: appServices.getToolbarSession,
-        getCurrentFileSession: appServices.getCurrentFileSession,
-        getBlocksSession: appServices.getBlocksSession,
-        getMetadataPanel: appServices.getMetadataPanel
-      });
-      languageSession.bind();
-
-      linkCardContext.onCardEntriesChange((entries) => toolbarSession.setCardEntries(entries));
-      toolbarSession.setCardEntries(linkCardContext.getCardEntries());
-
-      fileContextService.renderCurrentFile();
-      documentSession.bindInput();
-
-      // If empty, seed default text; otherwise render current content once.
-      documentSession.renderInitial(seed);
-
-      contentService.setBaseDir('');
-      imageSession.bind();
-      documentSession.registerPrimaryEditorApi();
-
-      // Clear draft action removed (no local storage drafts)
-
-      // Draft persistence on unload removed
-
-      // Default to blocks view
-      workspaceSession.setView('blocks');
-
-      const scrollSession = createEditorMainScrollSession({ runtime: editorMainRuntime });
-      scrollSession.bind();
-
-      const sidebarSession = createEditorMainSidebarSession({
-        runtime: editorMainRuntime,
-        documentRef: editorMainDocument,
-        normalizeLangKey,
-        bindCurrentFileElement: fileContextService.bindCurrentFileElement,
-        loadSiteConfig: contentService.loadSiteConfig,
-        loadIndexData: contentService.loadIndexData,
-        loadTabsConfig: contentService.loadTabsConfig,
-        onSiteConfigLoaded: contentService.handleSiteConfigLoaded,
-        onIndexLoaded: contentService.handleIndexLoaded,
-        onOpenMarkdown: contentService.openMarkdown,
-        onWarn: contentService.warn,
-        alert: contentService.alert
-      });
-      sidebarSession.initialize();
     });
   }
 
   return { start };
 }
 
-createEditorMainController().start();
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  createEditorMainController().start();
+}

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.58",
-  "tag": "v3.4.58",
+  "version": "3.4.59",
+  "tag": "v3.4.59",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.57 <3.4.58"
+      ">=3.4.58 <3.4.59"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.57 first."
+    "message": "Update to v3.4.58 first."
   }
 }

--- a/scripts/test-composer-bootstrap.js
+++ b/scripts/test-composer-bootstrap.js
@@ -6,6 +6,7 @@ import {
   assembleComposerWorkspace,
   bindComposerMarkdownToolbar,
   bindComposerWorkspaceUi,
+  createComposerBootstrapFeatures,
   initializeComposerApp,
   initializeComposerOnDomReady
 } from '../assets/js/composer-bootstrap.js';
@@ -326,12 +327,27 @@ class FakeDocument {
 }
 
 {
+  const features = createComposerBootstrapFeatures({});
+  assert.deepEqual(
+    features.map(feature => feature.name),
+    ['composer.markdownToolbar', 'composer.initialState', 'composer.workspace'],
+    'composer bootstrap should expose an explicit feature lifecycle'
+  );
+  assert.deepEqual(features[1].requires, ['markdownToolbar']);
+  assert.deepEqual(features[2].requires, ['initialComposerState']);
+}
+
+{
   const here = dirname(fileURLToPath(import.meta.url));
   const composerSource = readFileSync(resolve(here, '../assets/js/composer.js'), 'utf8');
   const bootstrapSource = readFileSync(resolve(here, '../assets/js/composer-bootstrap.js'), 'utf8');
   assert.doesNotMatch(composerSource, /document\.addEventListener\('DOMContentLoaded'/);
   assert.doesNotMatch(composerSource, /function bindComposerUI\(/);
   assert.match(composerSource, /from '\.\/composer-bootstrap\.js'/);
+  assert.match(bootstrapSource, /from '\.\/editor-app-kernel\.js'/);
+  assert.match(bootstrapSource, /createComposerBootstrapFeatures/);
+  assert.match(bootstrapSource, /documentRef: context\.documentRef/);
+  assert.match(bootstrapSource, /context\.initialComposerState = state/);
   assert.match(bootstrapSource, /const onDocumentReady = typeof options\.onDocumentReady === 'function'/);
   assert.doesNotMatch(bootstrapSource, /documentRef\.addEventListener\('DOMContentLoaded'|\bwindowRef\b|(^|[^.])\bsetTimeout\s*\(/m);
   assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1437,7 +1437,13 @@ assert.match(
 
 assert.match(
   editorMainSource,
-  /export function createEditorMainController\(editorMainRuntime = createEditorMainRuntime\(\)\) \{[\s\S]*const editorMainDocument = editorMainRuntime\.documentRef;[\s\S]*function start\(\) \{[\s\S]*editorMainRuntime\.onDocumentReady\(\(\) => \{[\s\S]*const appServices = createEditorMainServiceRegistry\(\);[\s\S]*const metadataPanel = appServices\.setMetadataPanel\(createEditorMainMetadataPanel\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*translate: t,[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*getContentRoot,[\s\S]*onChange: appServices\.notifyDocumentChange[\s\S]*\}\)\);/,
+  /from '\.\/editor-app-kernel\.js'/,
+  'editor main should use the shared app lifecycle kernel'
+);
+
+assert.match(
+  editorMainSource,
+  /export function createEditorMainFeatures\(\) \{[\s\S]*name: 'editorMain\.metadataPanel'[\s\S]*provides: \['metadataPanel'\][\s\S]*context\.metadataPanel = context\.appServices\.setMetadataPanel\(createEditorMainMetadataPanel\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*translate: t,[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*onChange: context\.appServices\.notifyDocumentChange[\s\S]*\}\)\);/,
   'editor main should compose front matter and tabs metadata through the metadata panel session'
 );
 
@@ -1449,31 +1455,31 @@ assert.doesNotMatch(
 
 assert.match(
   editorMainSource,
-  /const linkCardContext = createEditorMainLinkCardContext\(\{[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*getContentRoot,[\s\S]*fetch: \(url, options\) => editorMainRuntime\.fetchContent\(url, options\),[\s\S]*translate: t,[\s\S]*makeHref: \(loc\) => withLangParam\(`\?id=\$\{encodeURIComponent\(loc\)\}`\)[\s\S]*\}\);/,
+  /name: 'editorMain\.linkCardContext'[\s\S]*provides: \['linkCardContext'\][\s\S]*context\.linkCardContext = createEditorMainLinkCardContext\(\{[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*fetch: \(url, options\) => context\.runtime\.fetchContent\(url, options\),[\s\S]*translate: t,[\s\S]*makeHref: \(loc\) => withLangParam\(`\?id=\$\{encodeURIComponent\(loc\)\}`\)[\s\S]*\}\);/,
   'editor main should compose link-card index state through the explicit link-card context service'
 );
 
 assert.match(
   editorMainSource,
-  /const shellService = createEditorMainShellService\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*editor,[\s\S]*textarea: ta[\s\S]*\}\);/,
+  /name: 'editorMain\.shellService'[\s\S]*provides: \['shellService'\][\s\S]*context\.shellService = createEditorMainShellService\(\{[\s\S]*runtime: context\.runtime,[\s\S]*editor: context\.editor,[\s\S]*textarea: context\.dom\.textarea[\s\S]*\}\);/,
   'editor main should compose layout refresh and editor toasts through the shell service'
 );
 
 assert.match(
   editorMainSource,
-  /const workspaceSession = appServices\.setWorkspaceSession\(createEditorMainWorkspaceSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*forceMarkdownWrap: FORCE_MARKDOWN_WRAP,[\s\S]*editor,[\s\S]*textarea: ta,[\s\S]*getPreviewSession: appServices\.getPreviewSession,[\s\S]*getBlocksEditor: appServices\.getBlocksEditor,[\s\S]*syncBlocksFromSource: appServices\.syncBlocksFromSource,[\s\S]*requestLayout: shellService\.requestLayout[\s\S]*\}\)\);[\s\S]*workspaceSession\.initialize\(\);/,
+  /name: 'editorMain\.workspaceSession'[\s\S]*requires: \[[^\]]*'shellService'[\s\S]*provides: \['workspaceSession'\][\s\S]*context\.workspaceSession = context\.appServices\.setWorkspaceSession\(createEditorMainWorkspaceSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*forceMarkdownWrap: FORCE_MARKDOWN_WRAP,[\s\S]*editor: context\.editor,[\s\S]*textarea: context\.dom\.textarea,[\s\S]*getPreviewSession: context\.appServices\.getPreviewSession,[\s\S]*getBlocksEditor: context\.appServices\.getBlocksEditor,[\s\S]*syncBlocksFromSource: context\.appServices\.syncBlocksFromSource,[\s\S]*requestLayout: context\.shellService\.requestLayout[\s\S]*name: 'editorMain\.workspaceBinding'[\s\S]*requires: \['workspaceSession'\][\s\S]*context\.workspaceSession\.initialize\(\);/,
   'editor main should compose workspace view, wrap, preview button, and empty-state controls through the workspace session'
 );
 
 assert.match(
   editorMainSource,
-  /const documentSession = appServices\.setDocumentSession\(createEditorMainDocumentSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*editor,[\s\S]*textarea: ta,[\s\S]*metadataPanel,[\s\S]*workspaceSession,[\s\S]*getPreviewSession: appServices\.getPreviewSession,[\s\S]*getBlocksSession: appServices\.getBlocksSession,[\s\S]*requestLayout: shellService\.requestLayout,[\s\S]*setBaseDir: contentService\.setBaseDir,[\s\S]*setCurrentFileLabel: fileContextService\.setCurrentFileLabel[\s\S]*\}\)\);/,
+  /name: 'editorMain\.documentSession'[\s\S]*requires: \[[^\]]*'metadataPanel'[\s\S]*'workspaceSession'[\s\S]*'contentService'[\s\S]*provides: \['documentSession'\][\s\S]*context\.documentSession = context\.appServices\.setDocumentSession\(createEditorMainDocumentSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*editor: context\.editor,[\s\S]*textarea: context\.dom\.textarea,[\s\S]*metadataPanel: context\.metadataPanel,[\s\S]*workspaceSession: context\.workspaceSession,[\s\S]*getPreviewSession: context\.appServices\.getPreviewSession,[\s\S]*getBlocksSession: context\.appServices\.getBlocksSession,[\s\S]*requestLayout: context\.shellService\.requestLayout,[\s\S]*setBaseDir: context\.contentService\.setBaseDir,[\s\S]*setCurrentFileLabel: context\.fileContextService\.setCurrentFileLabel[\s\S]*\}\)\);/,
   'editor main should compose document value, input, change listeners, and primary-editor API through the document session'
 );
 
 assert.match(
   editorMainSource,
-  /const contentService = appServices\.setContentService\(createEditorMainContentService\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*getContentRoot,[\s\S]*fetch: \(url, options\) => editorMainRuntime\.fetchContent\(url, options\),[\s\S]*linkCardContext,[\s\S]*getPreviewSession: appServices\.getPreviewSession,[\s\S]*getDocumentSession: appServices\.getDocumentSession,[\s\S]*getWorkspaceSession: appServices\.getWorkspaceSession,[\s\S]*setCurrentFileLabel: fileContextService\.setCurrentFileLabel,[\s\S]*warn: \(\.\.\.args\) => editorMainRuntime\.warn\(\.\.\.args\),[\s\S]*alert: \(message\) => editorMainRuntime\.showAlert\(message\)[\s\S]*\}\)\);/,
+  /name: 'editorMain\.contentService'[\s\S]*requires: \[[^\]]*'linkCardContext'[\s\S]*'fileContextService'[\s\S]*provides: \['contentService'\][\s\S]*context\.contentService = context\.appServices\.setContentService\(createEditorMainContentService\(\{[\s\S]*runtime: context\.runtime,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*fetch: \(url, options\) => context\.runtime\.fetchContent\(url, options\),[\s\S]*linkCardContext: context\.linkCardContext,[\s\S]*getPreviewSession: context\.appServices\.getPreviewSession,[\s\S]*getDocumentSession: context\.appServices\.getDocumentSession,[\s\S]*getWorkspaceSession: context\.appServices\.getWorkspaceSession,[\s\S]*setCurrentFileLabel: context\.fileContextService\.setCurrentFileLabel,[\s\S]*warn: \(\.\.\.args\) => context\.runtime\.warn\(\.\.\.args\),[\s\S]*alert: \(message\) => context\.runtime\.showAlert\(message\)[\s\S]*\}\)\);/,
   'editor main should compose site config, content loading, and open-markdown orchestration through the content service'
 );
 
@@ -1485,55 +1491,55 @@ assert.doesNotMatch(
 
 assert.match(
   editorMainSource,
-  /const fileContextService = createEditorMainFileContextService\(\{[\s\S]*getCurrentFileSession: appServices\.getCurrentFileSession,[\s\S]*getMetadataPanel: appServices\.getMetadataPanel,[\s\S]*getPreviewSession: appServices\.getPreviewSession,[\s\S]*getDocumentSession: appServices\.getDocumentSession[\s\S]*\}\);/,
+  /name: 'editorMain\.fileContextService'[\s\S]*provides: \['fileContextService'\][\s\S]*context\.fileContextService = createEditorMainFileContextService\(\{[\s\S]*getCurrentFileSession: context\.appServices\.getCurrentFileSession,[\s\S]*getMetadataPanel: context\.appServices\.getMetadataPanel,[\s\S]*getPreviewSession: context\.appServices\.getPreviewSession,[\s\S]*getDocumentSession: context\.appServices\.getDocumentSession[\s\S]*\}\);/,
   'editor main should compose current-file cross-session fan-out through the file context service'
 );
 
 assert.match(
   editorMainSource,
-  /const languageSession = createEditorMainLanguageSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*getToolbarSession: appServices\.getToolbarSession,[\s\S]*getCurrentFileSession: appServices\.getCurrentFileSession,[\s\S]*getBlocksSession: appServices\.getBlocksSession,[\s\S]*getMetadataPanel: appServices\.getMetadataPanel[\s\S]*\}\);[\s\S]*languageSession\.bind\(\);/,
+  /name: 'editorMain\.languageSession'[\s\S]*requires: \[[^\]]*'toolbarSession'[\s\S]*'currentFileSession'[\s\S]*'blocksSession'[\s\S]*provides: \['languageSession'\][\s\S]*context\.languageSession = createEditorMainLanguageSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*getToolbarSession: context\.appServices\.getToolbarSession,[\s\S]*getCurrentFileSession: context\.appServices\.getCurrentFileSession,[\s\S]*getBlocksSession: context\.appServices\.getBlocksSession,[\s\S]*getMetadataPanel: context\.appServices\.getMetadataPanel[\s\S]*name: 'editorMain\.languageBinding'[\s\S]*requires: \[[^\]]*'toolbarBinding'[\s\S]*context\.languageSession\.bind\(\);/,
   'editor main should compose language-event fan-out through the language session'
 );
 
 assert.match(
   editorMainSource,
-  /const scrollSession = createEditorMainScrollSession\(\{ runtime: editorMainRuntime \}\);[\s\S]*scrollSession\.bind\(\);/,
+  /name: 'editorMain\.scrollSession'[\s\S]*provides: \['scrollSession'\][\s\S]*context\.scrollSession = createEditorMainScrollSession\(\{ runtime: context\.runtime \}\);[\s\S]*name: 'editorMain\.scrollBinding'[\s\S]*requires: \[[^\]]*'defaultWorkspaceView'[\s\S]*context\.scrollSession\.bind\(\);/,
   'editor main should compose back-to-top scroll UI through the scroll session'
 );
 
 assert.match(
   editorMainSource,
-  /const currentFileSession = appServices\.setCurrentFileSession\(createEditorMainCurrentFileSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*translate: t,[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*inferCurrentFileSource: fileContextService\.inferCurrentFileSource,[\s\S]*applyEditorEmptyState: workspaceSession\.applyEditorEmptyState,[\s\S]*onRendered: fileContextService\.handleCurrentFileRendered[\s\S]*\}\)\);/,
+  /name: 'editorMain\.currentFileSession'[\s\S]*requires: \[[^\]]*'documentSession'[\s\S]*provides: \['currentFileSession'\][\s\S]*context\.currentFileSession = context\.appServices\.setCurrentFileSession\(createEditorMainCurrentFileSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*translate: t,[\s\S]*getCurrentLang,[\s\S]*normalizeLangKey,[\s\S]*inferCurrentFileSource: context\.fileContextService\.inferCurrentFileSource,[\s\S]*applyEditorEmptyState: context\.workspaceSession\.applyEditorEmptyState,[\s\S]*onRendered: context\.fileContextService\.handleCurrentFileRendered[\s\S]*name: 'editorMain\.currentFileRender'[\s\S]*requires: \[[^\]]*'previewBinding'[\s\S]*'linkCardToolbarSync'[\s\S]*context\.fileContextService\.renderCurrentFile\(\);/,
   'editor main should compose current file state and header rendering through the current-file session'
 );
 
 assert.match(
   editorMainSource,
-  /const previewSession = appServices\.setPreviewSession\(createEditorMainPreviewSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*getContentRoot,[\s\S]*getEditorValue: appServices\.getEditorValue,[\s\S]*getCurrentFileInfo: fileContextService\.getCurrentFileInfo,[\s\S]*getSiteConfig: appServices\.getSiteConfig,[\s\S]*getPostsIndex: \(\) => linkCardContext\.getPostsIndex\(\),[\s\S]*getPostsByLocationTitle: \(\) => linkCardContext\.getPostsByLocationTitle\(\),[\s\S]*isLinkCardReady: \(\) => linkCardContext\.isReady\(\),[\s\S]*getAllowedLocations: \(\) => linkCardContext\.getAllowedLocations\(\),[\s\S]*getLocationAliases: \(\) => linkCardContext\.getLocationAliases\(\),[\s\S]*consoleRef: \{[\s\S]*warn: \(\.\.\.args\) => editorMainRuntime\.warn\(\.\.\.args\)[\s\S]*\},[\s\S]*fetch: \(url, options\) => editorMainRuntime\.fetchContent\(url, options\)[\s\S]*\}\)\);[\s\S]*previewSession\.bind\(\);/,
+  /name: 'editorMain\.previewSession'[\s\S]*requires: \[[^\]]*'linkCardContext'[\s\S]*'fileContextService'[\s\S]*provides: \['previewSession'\][\s\S]*context\.previewSession = context\.appServices\.setPreviewSession\(createEditorMainPreviewSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*getEditorValue: context\.appServices\.getEditorValue,[\s\S]*getCurrentFileInfo: context\.fileContextService\.getCurrentFileInfo,[\s\S]*getSiteConfig: context\.appServices\.getSiteConfig,[\s\S]*getPostsIndex: \(\) => context\.linkCardContext\.getPostsIndex\(\),[\s\S]*getPostsByLocationTitle: \(\) => context\.linkCardContext\.getPostsByLocationTitle\(\),[\s\S]*isLinkCardReady: \(\) => context\.linkCardContext\.isReady\(\),[\s\S]*getAllowedLocations: \(\) => context\.linkCardContext\.getAllowedLocations\(\),[\s\S]*getLocationAliases: \(\) => context\.linkCardContext\.getLocationAliases\(\),[\s\S]*warn: \(\.\.\.args\) => context\.runtime\.warn\(\.\.\.args\)[\s\S]*fetch: \(url, options\) => context\.runtime\.fetchContent\(url, options\)[\s\S]*name: 'editorMain\.previewBinding'[\s\S]*requires: \[[^\]]*'workspaceBinding'[\s\S]*context\.previewSession\.bind\(\);/,
   'editor main should compose preview overlay, iframe messaging, and asset-preview state through the preview session'
 );
 
 assert.match(
   editorMainSource,
-  /const sidebarSession = createEditorMainSidebarSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*normalizeLangKey,[\s\S]*bindCurrentFileElement: fileContextService\.bindCurrentFileElement,[\s\S]*loadSiteConfig: contentService\.loadSiteConfig,[\s\S]*loadIndexData: contentService\.loadIndexData,[\s\S]*loadTabsConfig: contentService\.loadTabsConfig,[\s\S]*onSiteConfigLoaded: contentService\.handleSiteConfigLoaded,[\s\S]*onIndexLoaded: contentService\.handleIndexLoaded,[\s\S]*onOpenMarkdown: contentService\.openMarkdown,[\s\S]*onWarn: contentService\.warn,[\s\S]*alert: contentService\.alert[\s\S]*\}\);[\s\S]*sidebarSession\.initialize\(\);/,
+  /name: 'editorMain\.sidebarSession'[\s\S]*provides: \['sidebarSession'\][\s\S]*context\.sidebarSession = createEditorMainSidebarSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*normalizeLangKey,[\s\S]*bindCurrentFileElement: context\.fileContextService\.bindCurrentFileElement,[\s\S]*loadSiteConfig: context\.contentService\.loadSiteConfig,[\s\S]*loadIndexData: context\.contentService\.loadIndexData,[\s\S]*loadTabsConfig: context\.contentService\.loadTabsConfig,[\s\S]*onSiteConfigLoaded: context\.contentService\.handleSiteConfigLoaded,[\s\S]*onIndexLoaded: context\.contentService\.handleIndexLoaded,[\s\S]*onOpenMarkdown: context\.contentService\.openMarkdown,[\s\S]*onWarn: context\.contentService\.warn,[\s\S]*alert: context\.contentService\.alert[\s\S]*name: 'editorMain\.sidebarStartup'[\s\S]*requires: \[[^\]]*'scrollBinding'[\s\S]*context\.sidebarSession\.initialize\(\);/,
   'editor main should compose file sidebar rendering through the sidebar session and route loading/open actions through the content service'
 );
 
 assert.match(
   editorMainSource,
-  /const toolbarSession = appServices\.setToolbarSession\(createEditorMainToolbarSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*documentRef: editorMainDocument,[\s\S]*translate: t,[\s\S]*getEditorTextarea: documentSession\.getEditorTextarea,[\s\S]*editorToolbarEl,[\s\S]*cardButton,[\s\S]*cardPopover,[\s\S]*cardSearchInput,[\s\S]*cardListEl,[\s\S]*cardEmptyEl,[\s\S]*getCardEntries: \(\) => linkCardContext\.getCardEntries\(\)[\s\S]*\}\)\);[\s\S]*toolbarSession\.bind\(\);/,
+  /name: 'editorMain\.toolbarSession'[\s\S]*requires: \[[^\]]*'documentSession'[\s\S]*'linkCardContext'[\s\S]*provides: \['toolbarSession'\][\s\S]*context\.toolbarSession = context\.appServices\.setToolbarSession\(createEditorMainToolbarSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*documentRef: context\.documentRef,[\s\S]*translate: t,[\s\S]*getEditorTextarea: context\.documentSession\.getEditorTextarea,[\s\S]*editorToolbarEl: context\.dom\.editorToolbarEl,[\s\S]*cardButton: context\.dom\.cardButton,[\s\S]*cardPopover: context\.dom\.cardPopover,[\s\S]*cardSearchInput: context\.dom\.cardSearchInput,[\s\S]*cardListEl: context\.dom\.cardListEl,[\s\S]*cardEmptyEl: context\.dom\.cardEmptyEl,[\s\S]*getCardEntries: \(\) => context\.linkCardContext\.getCardEntries\(\)[\s\S]*name: 'editorMain\.toolbarBinding'[\s\S]*requires: \[[^\]]*'blocksBinding'[\s\S]*context\.toolbarSession\.bind\(\);/,
   'editor main should compose markdown toolbar and article-card picker through the toolbar session'
 );
 
 assert.match(
   editorMainSource,
-  /const imageSession = appServices\.setImageSession\(createEditorMainImageSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*translate: t,[\s\S]*imageButton,[\s\S]*imageInput,[\s\S]*getCurrentMarkdownPath: fileContextService\.getCurrentMarkdownPath,[\s\S]*getContentRoot,[\s\S]*getEditorTextarea: documentSession\.getEditorTextarea,[\s\S]*getEditorBody: documentSession\.getEditorBody,[\s\S]*buildMarkdown: documentSession\.buildMarkdown,[\s\S]*setValue: documentSession\.setValue,[\s\S]*getBlocksEditor: appServices\.getBlocksEditor,[\s\S]*consoleRef: \{[\s\S]*error: \(\.\.\.args\) => editorMainRuntime\.error\(\.\.\.args\)[\s\S]*\},[\s\S]*emitToast: shellService\.emitToast[\s\S]*\}\)\);/,
+  /name: 'editorMain\.imageSession'[\s\S]*requires: \[[^\]]*'documentSession'[\s\S]*'fileContextService'[\s\S]*'shellService'[\s\S]*provides: \['imageSession'\][\s\S]*context\.imageSession = context\.appServices\.setImageSession\(createEditorMainImageSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*translate: t,[\s\S]*imageButton: context\.dom\.imageButton,[\s\S]*imageInput: context\.dom\.imageInput,[\s\S]*getCurrentMarkdownPath: context\.fileContextService\.getCurrentMarkdownPath,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*getEditorTextarea: context\.documentSession\.getEditorTextarea,[\s\S]*getEditorBody: context\.documentSession\.getEditorBody,[\s\S]*buildMarkdown: context\.documentSession\.buildMarkdown,[\s\S]*setValue: context\.documentSession\.setValue,[\s\S]*getBlocksEditor: context\.appServices\.getBlocksEditor,[\s\S]*error: \(\.\.\.args\) => context\.runtime\.error\(\.\.\.args\)[\s\S]*emitToast: context\.shellService\.emitToast[\s\S]*\}\)\);/,
   'editor main should compose image picker, upload, drop, and block image actions through the image session'
 );
 
 assert.match(
   editorMainSource,
-  /const blocksSession = appServices\.setBlocksSession\(createEditorMainBlocksSession\(\{[\s\S]*runtime: editorMainRuntime,[\s\S]*root: blocksWrap,[\s\S]*translate: t,[\s\S]*getContentRoot,[\s\S]*getEditorBody: documentSession\.getEditorBody,[\s\S]*onBodyChange: documentSession\.setBodyFromBlocks,[\s\S]*getCurrentMarkdownPath: fileContextService\.getCurrentMarkdownPath,[\s\S]*getSiteConfig: appServices\.getSiteConfig,[\s\S]*getPreviewSession: appServices\.getPreviewSession,[\s\S]*getImageSession: appServices\.getImageSession,[\s\S]*linkCardContext,[\s\S]*resolveImageSrc[\s\S]*\}\)\);[\s\S]*blocksSession\.initialize\(\);/,
+  /name: 'editorMain\.blocksSession'[\s\S]*requires: \[[^\]]*'documentSession'[\s\S]*'previewSession'[\s\S]*'imageSession'[\s\S]*'linkCardContext'[\s\S]*provides: \['blocksSession'\][\s\S]*context\.blocksSession = context\.appServices\.setBlocksSession\(createEditorMainBlocksSession\(\{[\s\S]*runtime: context\.runtime,[\s\S]*root: context\.dom\.blocksWrap,[\s\S]*translate: t,[\s\S]*getContentRoot: context\.getContentRoot,[\s\S]*getEditorBody: context\.documentSession\.getEditorBody,[\s\S]*onBodyChange: context\.documentSession\.setBodyFromBlocks,[\s\S]*getCurrentMarkdownPath: context\.fileContextService\.getCurrentMarkdownPath,[\s\S]*getSiteConfig: context\.appServices\.getSiteConfig,[\s\S]*getPreviewSession: context\.appServices\.getPreviewSession,[\s\S]*getImageSession: context\.appServices\.getImageSession,[\s\S]*linkCardContext: context\.linkCardContext,[\s\S]*resolveImageSrc: context\.resolveEditorImageSrc[\s\S]*name: 'editorMain\.blocksBinding'[\s\S]*requires: \[[^\]]*'contentBinding'[\s\S]*context\.blocksSession\.initialize\(\);/,
   'editor main should compose the Blocks editor through an explicit blocks session service'
 );
 
@@ -1658,14 +1664,20 @@ assert.doesNotMatch(
 
 assert.match(
   editorMainSource,
-  /export function createEditorMainController\(editorMainRuntime = createEditorMainRuntime\(\)\) \{[\s\S]*function start\(\) \{[\s\S]*editorMainRuntime\.onDocumentReady\(\(\) => \{[\s\S]*const ta = editorMainRuntime\.getElementById\('mdInput'\)[\s\S]*const appServices = createEditorMainServiceRegistry\(\);[\s\S]*const previewSession = appServices\.setPreviewSession\(createEditorMainPreviewSession[\s\S]*previewSession\.bind\(\);[\s\S]*createEditorMainController\(\)\.start\(\);/,
+  /export function createEditorMainController\(editorMainRuntime = createEditorMainRuntime\(\)\) \{[\s\S]*function start\(\) \{[\s\S]*editorMainRuntime\.onDocumentReady\(\(\) => \{[\s\S]*const kernel = createEditorAppKernel\(\{[\s\S]*name: 'editor-main'[\s\S]*appServices: createEditorMainServiceRegistry\(\)[\s\S]*createEditorMainFeatures\(\)\.forEach\(feature => kernel\.registerFeature\(feature\)\)[\s\S]*kernel\.run\(\)\.catch[\s\S]*createEditorMainController\(\)\.start\(\);/,
   'editor main startup should wire the preview session through the editor runtime boundary'
 );
 
 assert.match(
   editorMainSource,
-  /import \{ resolveImageSrc \} from '\.\/safe-html\.js';[\s\S]*const getContentRoot = \(\) => editorMainRuntime\.getContentRoot\(\);[\s\S]*const resolveEditorImageSrc = \(src, baseDir\) => resolveImageSrc\(src, baseDir, \{[\s\S]*contentRoot: editorMainRuntime\.getContentRoot\(\),[\s\S]*origin: editorMainRuntime\.getLocationOrigin\(\)[\s\S]*resolveImageSrc: resolveEditorImageSrc/,
+  /import \{ resolveImageSrc \} from '\.\/safe-html\.js';[\s\S]*const getContentRoot = \(\) => editorMainRuntime\.getContentRoot\(\);[\s\S]*const resolveEditorImageSrc = \(src, baseDir\) => resolveImageSrc\(src, baseDir, \{[\s\S]*contentRoot: editorMainRuntime\.getContentRoot\(\),[\s\S]*origin: editorMainRuntime\.getLocationOrigin\(\)[\s\S]*resolveEditorImageSrc,/,
   'editor main should route content-root and image resolution through the explicit runtime boundary'
+);
+
+assert.match(
+  editorMainSource,
+  /resolveImageSrc: context\.resolveEditorImageSrc/,
+  'editor blocks feature should consume the injected editor image resolver'
 );
 
 assert.doesNotMatch(
@@ -1676,7 +1688,7 @@ assert.doesNotMatch(
 
 assert.match(
   editorMainSource,
-  /const editor = createHiEditor\(ta, 'markdown', false, \{[\s\S]*documentRef: editorMainDocument,[\s\S]*windowRef: editorMainRuntime\.windowRef,[\s\S]*setTimeoutRef: \(handler, delay\) => editorMainRuntime\.setTimer\(handler, delay\),[\s\S]*getComputedStyle: \(node\) => editorMainRuntime\.getComputedStyle\(node\),[\s\S]*getResizeObserver: \(\) => editorMainRuntime\.getResizeObserver\(\),[\s\S]*addDocumentListener: \(type, handler, options\) => editorMainRuntime\.onDocument\(type, handler, options\),[\s\S]*addWindowListener: \(type, handler, options\) => editorMainRuntime\.onWindow\(type, handler, options\),[\s\S]*writeClipboardText: \(text\) => editorMainRuntime\.writeClipboardText\(text\),[\s\S]*editorRegistry: editorMainRuntime\.getHiEditorRegistry\(\),[\s\S]*allowAmbient: false[\s\S]*\}\);/,
+  /name: 'editorMain\.editor'[\s\S]*context\.editor = createHiEditor\(dom\.textarea, 'markdown', false, \{[\s\S]*documentRef,[\s\S]*windowRef: runtime\.windowRef,[\s\S]*setTimeoutRef: \(handler, delay\) => runtime\.setTimer\(handler, delay\),[\s\S]*getComputedStyle: \(node\) => runtime\.getComputedStyle\(node\),[\s\S]*getResizeObserver: \(\) => runtime\.getResizeObserver\(\),[\s\S]*addDocumentListener: \(type, handler, options\) => runtime\.onDocument\(type, handler, options\),[\s\S]*addWindowListener: \(type, handler, options\) => runtime\.onWindow\(type, handler, options\),[\s\S]*writeClipboardText: \(text\) => runtime\.writeClipboardText\(text\),[\s\S]*editorRegistry: runtime\.getHiEditorRegistry\(\),[\s\S]*allowAmbient: false[\s\S]*\}\);/,
   'editor main should create the primary HiEditor through explicit runtime refs and browser-effect adapters'
 );
 

--- a/scripts/test-editor-app-kernel.mjs
+++ b/scripts/test-editor-app-kernel.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createEditorAppKernel,
+  runEditorFeatureLifecycle
+} from '../assets/js/editor-app-kernel.js';
+import { createEditorMainFeatures } from '../assets/js/editor-main.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (path) => readFileSync(resolve(here, '..', path), 'utf8');
+
+{
+  const calls = [];
+  const kernel = createEditorAppKernel({
+    name: 'test-editor',
+    provides: ['runtime'],
+    context: { calls }
+  });
+  kernel.registerFeature({
+    name: 'feature.a',
+    requires: ['runtime'],
+    provides: ['aService'],
+    init: context => context.calls.push('a:init'),
+    bind: context => context.calls.push('a:bind'),
+    start: context => context.calls.push('a:start')
+  });
+  kernel.registerFeature({
+    name: 'feature.b',
+    requires: ['aService'],
+    provides: ['bService'],
+    init: context => context.calls.push('b:init'),
+    bind: context => context.calls.push('b:bind'),
+    start: context => context.calls.push('b:start')
+  });
+
+  const result = await kernel.run();
+  assert.deepEqual(calls, [
+    'a:init',
+    'b:init',
+    'a:bind',
+    'b:bind',
+    'a:start',
+    'b:start'
+  ]);
+  assert.deepEqual(result.context.lifecycle.features.map(feature => feature.name), ['feature.a', 'feature.b']);
+}
+
+await assert.rejects(
+  runEditorFeatureLifecycle([
+    { name: 'feature.a', requires: ['missingService'] }
+  ], { name: 'missing-dependency' }),
+  /missing-dependency: feature "feature\.a" requires missing token "missingService"/
+);
+
+await assert.rejects(
+  runEditorFeatureLifecycle([
+    { name: 'feature.a', provides: ['shared'] },
+    { name: 'feature.b', provides: ['shared'] }
+  ], { name: 'duplicate-provider' }),
+  /duplicate-provider: token "shared" is provided by both "feature\.a" and "feature\.b"/
+);
+
+await assert.rejects(
+  runEditorFeatureLifecycle([
+    { name: 'feature.a', requires: ['bService'], provides: ['aService'] },
+    { name: 'feature.b', requires: ['aService'], provides: ['bService'] }
+  ], { name: 'cycle-test' }),
+  /cycle-test: feature dependency cycle:/
+);
+
+await assert.rejects(
+  runEditorFeatureLifecycle([
+    { name: 'feature.a', requires: ['aService'], provides: ['aService'] }
+  ], { name: 'self-dependency-test' }),
+  /self-dependency-test: feature "feature\.a" requires token "aService" that it provides itself/
+);
+
+const composerBootstrap = read('assets/js/composer-bootstrap.js');
+assert.match(composerBootstrap, /from '\.\/editor-app-kernel\.js'/, 'composer bootstrap should use the shared app kernel');
+assert.match(composerBootstrap, /export function createComposerBootstrapFeatures/, 'composer bootstrap should expose feature declarations for tests');
+assert.match(composerBootstrap, /name: 'composer\.markdownToolbar'[\s\S]*provides: \['markdownToolbar'\]/, 'composer toolbar binding should be a lifecycle feature');
+assert.match(composerBootstrap, /name: 'composer\.initialState'[\s\S]*requires: \['markdownToolbar'\][\s\S]*provides: \['initialComposerState'\]/, 'composer initial state should depend on toolbar setup');
+assert.match(composerBootstrap, /name: 'composer\.workspace'[\s\S]*requires: \['initialComposerState'\]/, 'composer workspace assembly should depend on loaded state');
+
+const editorMain = read('assets/js/editor-main.js');
+assert.match(editorMain, /from '\.\/editor-app-kernel\.js'/, 'editor-main should use the shared app kernel');
+assert.match(editorMain, /export function createEditorMainFeatures/, 'editor-main should expose lifecycle feature declarations');
+assert.match(editorMain, /name: 'editorMain\.metadataPanel'[\s\S]*provides: \['metadataPanel'\]/, 'editor metadata panel should be a feature');
+assert.match(editorMain, /name: 'editorMain\.previewSession'[\s\S]*requires: \[[^\]]*'linkCardContext'[\s\S]*provides: \['previewSession'\]/, 'editor preview should declare feature dependencies');
+assert.match(editorMain, /name: 'editorMain\.documentInputBinding'[\s\S]*requires: \[[^\]]*'currentFileRender'[\s\S]*context\.documentSession\.bindInput\(\)/, 'editor input binding should declare its current-file render dependency');
+assert.match(editorMain, /name: 'editorMain\.initialDocumentState'[\s\S]*requires: \[[^\]]*'documentInputBinding'[\s\S]*context\.documentSession\.renderInitial\(context\.seed\)/, 'editor initial render should start after input wiring is explicit');
+assert.match(editorMain, /name: 'editorMain\.sidebarStartup'[\s\S]*requires: \[[^\]]*'scrollBinding'[\s\S]*start\(context\) \{[\s\S]*context\.sidebarSession\.initialize\(\)/, 'editor sidebar should start after initial document and scroll startup');
+assert.match(editorMain, /createEditorMainFeatures\(\)\.forEach\(feature => kernel\.registerFeature\(feature\)\)/, 'editor-main root should register declared features through the kernel');
+
+{
+  const kernel = createEditorAppKernel({
+    name: 'editor-main-plan',
+    provides: ['runtime', 'documentRef', 'dom', 'appServices', 'getContentRoot', 'resolveEditorImageSrc', 'seed']
+  });
+  createEditorMainFeatures().forEach(feature => kernel.registerFeature(feature));
+  const plan = kernel.getLifecyclePlan();
+  const order = plan.map(feature => feature.name);
+  const byName = new Map(plan.map(feature => [feature.name, feature]));
+  const assertBefore = (first, second) => {
+    assert.ok(
+      order.indexOf(first) >= 0 && order.indexOf(first) < order.indexOf(second),
+      `${first} should run before ${second}`
+    );
+  };
+
+  assert.equal(byName.get('editorMain.metadataPanel').requires.includes('getContentRoot'), true);
+  assert.equal(byName.get('editorMain.linkCardContext').requires.includes('getContentRoot'), true);
+  assert.equal(byName.get('editorMain.blocksSession').requires.includes('resolveEditorImageSrc'), true);
+  assert.equal(byName.get('editorMain.initialDocumentState').requires.includes('seed'), true);
+  assert.equal(plan.some(feature => feature.requires.includes('document')), false);
+
+  [
+    ['editorMain.workspaceBinding', 'editorMain.previewBinding'],
+    ['editorMain.previewBinding', 'editorMain.contentBinding'],
+    ['editorMain.contentBinding', 'editorMain.blocksBinding'],
+    ['editorMain.blocksBinding', 'editorMain.toolbarBinding'],
+    ['editorMain.toolbarBinding', 'editorMain.languageBinding'],
+    ['editorMain.languageBinding', 'editorMain.linkCardToolbarSync'],
+    ['editorMain.linkCardToolbarSync', 'editorMain.currentFileRender'],
+    ['editorMain.currentFileRender', 'editorMain.documentInputBinding'],
+    ['editorMain.documentInputBinding', 'editorMain.initialDocumentState'],
+    ['editorMain.initialDocumentState', 'editorMain.imageBinding'],
+    ['editorMain.imageBinding', 'editorMain.primaryEditorApi'],
+    ['editorMain.primaryEditorApi', 'editorMain.defaultWorkspaceView'],
+    ['editorMain.defaultWorkspaceView', 'editorMain.scrollBinding'],
+    ['editorMain.scrollBinding', 'editorMain.sidebarStartup']
+  ].forEach(([first, second]) => assertBefore(first, second));
+}
+
+console.log('ok - editor app kernel');

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -443,6 +443,11 @@ if ! grep -qx "press-system-${version}/assets/js/composer-bootstrap.js" "${entri
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/editor-app-kernel.js" "${entries_file}"; then
+  echo "expected package to include editor app lifecycle kernel code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/composer-ui-motion.js" "${entries_file}"; then
   echo "expected package to include composer UI motion helper code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -93,6 +93,11 @@ if ! grep -F 'node scripts/test-press-system-surface.mjs' "${workflow}" >/dev/nu
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-editor-app-kernel.mjs' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the editor app lifecycle kernel before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node --experimental-default-type=module scripts/test-theme-contracts.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the shared Press theme contract surface before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Add a shared editor app kernel that validates feature dependencies, duplicate providers, cycles, self-dependencies, and exposes the resolved lifecycle plan.
- Move the browser editor and composer bootstrap roots onto explicit feature declarations with `init` / `bind` / `start` phases instead of a long callback-assembled startup body.
- Split editor startup side effects into named binding/startup features so the old ordering is encoded in the graph, and make root context tokens match the real context fields.
- Bump the Press system release manifest to `v3.4.59` and include the new kernel in system-release package/workflow checks.

## Validation

- `node --check assets/js/editor-app-kernel.js && node --check assets/js/composer-bootstrap.js && node --check assets/js/editor-main.js`
- `node scripts/test-editor-app-kernel.mjs`
- `node --experimental-default-type=module scripts/test-composer-bootstrap.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-ui-components.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js`
- `node scripts/test-content-model.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node --experimental-default-type=module scripts/test-encrypted-content.js`
- `bash scripts/test-pages-workflow.sh`
- `node scripts/test-press-system-surface.mjs`
- `node scripts/test-product-state-ledger.js`
- `node scripts/test-product-state-dashboard.js`
- Browser smoke: `http://127.0.0.1:8000/index_editor.html?smoke=feature-lifecycle-4`, verified editor DOM controls, sidebar tree item clicks, and no warning/error logs.

## Release impact

This is a Press system-surface change (`assets/js/**`) and should publish `press-system-v3.4.59.zip` after merge. The package boundary now explicitly checks `assets/js/editor-app-kernel.js`.