### PR TITLE
Require Connect publish telemetry in product state

### DIFF
--- a/scripts/product-state-dashboard.js
+++ b/scripts/product-state-dashboard.js
@@ -154,6 +154,9 @@ function renderProductStateDashboard(state) {
   const themes = source.themes && typeof source.themes === 'object' ? source.themes : {};
   const catalog = themes.catalog && typeof themes.catalog === 'object' ? themes.catalog : {};
   const connect = source.connect && typeof source.connect === 'object' ? source.connect : {};
+  const publishTelemetry = connect.publishTelemetry && typeof connect.publishTelemetry === 'object'
+    ? connect.publishTelemetry
+    : {};
   const verdict = source.verdict && typeof source.verdict === 'object' ? source.verdict : {};
   const runtime = pressSystem.runtime && typeof pressSystem.runtime === 'object' ? pressSystem.runtime : {};
   const generatedAt = valueOrDash(source.generatedAt);
@@ -220,6 +223,7 @@ function renderProductStateDashboard(state) {
       <div class="metric"><span>Converged</span><strong>${escapeHtml(convergenceLabel)} ${statusBadge(verdictStatus)}</strong></div>
       <div class="metric"><span>Catalog</span><strong>${escapeHtml(String(catalog.count || 0))} themes ${statusBadge(catalog.status)}</strong></div>
       <div class="metric"><span>Connect</span><strong>${escapeHtml(valueOrDash(connect.service || connect.label))} ${statusBadge(connect.status)}</strong></div>
+      <div class="metric"><span>Publish Telemetry</span><strong>${escapeHtml(String(Number(publishTelemetry.publishSuccess || 0)))} ok / ${escapeHtml(String(Number(publishTelemetry.publishFailure || 0)))} failed ${statusBadge(publishTelemetry.status)}</strong></div>
       <div class="metric"><span>Blocking Problems</span><strong>${escapeHtml(String(Number(verdict.blockingProblemCount || 0)))}</strong></div>
     </div>
 

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -259,6 +259,94 @@ function normalizeStatus(status) {
   return ['ok', 'pending', 'unknown', 'drift'].includes(value) ? value : 'unknown';
 }
 
+function normalizeConnectPublishTelemetry(input) {
+  const source = input && typeof input === 'object' ? input : null;
+  if (!source) {
+    return {
+      schemaVersion: 0,
+      status: 'drift',
+      error: 'Connect health is missing publishTelemetry'
+    };
+  }
+  const hasWindow = source.window && typeof source.window === 'object';
+  const telemetry = {
+    schemaVersion: Number(source.schemaVersion || 0),
+    status: normalizeStatus(source.status),
+    migrationRequired: source.migrationRequired === true,
+    window: hasWindow ? {
+      since: numberOrZero(source.window.since),
+      until: numberOrZero(source.window.until),
+      seconds: numberOrZero(source.window.seconds)
+    } : {},
+    totalEvents: numberOrZero(source.totalEvents),
+    grantsIssued: numberOrZero(source.grantsIssued),
+    publishSuccess: numberOrZero(source.publishSuccess),
+    publishFailure: numberOrZero(source.publishFailure),
+    lastEventAt: source.lastEventAt == null ? null : numberOrZero(source.lastEventAt),
+    upstreamFailures: Array.isArray(source.upstreamFailures)
+      ? source.upstreamFailures.map((entry) => ({
+        errorCode: String(entry && entry.errorCode || '').trim(),
+        upstreamStatus: entry && entry.upstreamStatus != null ? Number(entry.upstreamStatus) : null,
+        upstreamCode: String(entry && entry.upstreamCode || '').trim(),
+        count: numberOrZero(entry && entry.count),
+        lastAt: entry && entry.lastAt != null ? numberOrZero(entry.lastAt) : null
+      }))
+      : []
+  };
+  if (telemetry.migrationRequired) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry migration must be applied before product-state convergence';
+  } else if (telemetry.schemaVersion !== 1) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry must use schemaVersion 1';
+  } else if (telemetry.status !== 'ok') {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry status must be ok';
+  } else if (!isValidTelemetryWindow(telemetry.window)) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry window must contain finite seconds with until - since consistency';
+  } else if ([telemetry.totalEvents, telemetry.grantsIssued, telemetry.publishSuccess, telemetry.publishFailure].some((value) => !isNonNegativeInteger(value))) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry counters must be non-negative integers';
+  } else if (telemetry.lastEventAt != null && !isNonNegativeInteger(telemetry.lastEventAt)) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry lastEventAt must be a non-negative integer when present';
+  } else if (telemetry.grantsIssued + telemetry.publishSuccess + telemetry.publishFailure > telemetry.totalEvents) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry event counters cannot exceed totalEvents';
+  } else if (telemetry.upstreamFailures.some((entry) => !isValidUpstreamFailure(entry))) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry upstream failure entries must include valid errorCode, status, count, and timestamp fields';
+  } else if (telemetry.upstreamFailures.reduce((total, entry) => total + entry.count, 0) > telemetry.publishFailure) {
+    telemetry.status = 'drift';
+    telemetry.error = 'Connect publishTelemetry upstream failure counts cannot exceed publishFailure';
+  }
+  return telemetry;
+}
+
+function numberOrZero(value) {
+  return value == null || value === '' ? 0 : Number(value);
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isValidTelemetryWindow(window) {
+  return window && isNonNegativeInteger(window.since)
+    && isNonNegativeInteger(window.until)
+    && isNonNegativeInteger(window.seconds)
+    && window.until >= window.since
+    && window.seconds === window.until - window.since;
+}
+
+function isValidUpstreamFailure(entry) {
+  if (!entry.errorCode || !isNonNegativeInteger(entry.count)) return false;
+  if (entry.upstreamStatus != null && (!Number.isInteger(entry.upstreamStatus) || entry.upstreamStatus < 100 || entry.upstreamStatus > 599)) return false;
+  if (entry.lastAt != null && !isNonNegativeInteger(entry.lastAt)) return false;
+  return true;
+}
+
 function aggregateStatus(statuses) {
   const values = statuses.map(normalizeStatus);
   if (values.includes('drift')) return 'drift';
@@ -459,7 +547,8 @@ function buildDesiredState({ sources, systemRelease, systemSource }) {
     },
     connect: sources.connect && sources.connect.source ? {
       label: sources.connect.label,
-      source: sources.connect.source
+      source: sources.connect.source,
+      requiresPublishTelemetry: true
     } : null
   };
 }
@@ -545,7 +634,8 @@ async function buildProductState(options = {}) {
     connect: {
       label: sources.connect.label,
       source: sources.connect.source,
-      status: 'unknown'
+      status: 'unknown',
+      publishTelemetry: null
     },
     problems: []
   };
@@ -727,14 +817,24 @@ async function buildProductState(options = {}) {
       });
     } else {
       const payload = connectResult.value && typeof connectResult.value === 'object' ? connectResult.value : {};
-      state.connect.status = payload.ok === true ? 'ok' : 'drift';
+      const telemetry = normalizeConnectPublishTelemetry(payload.publishTelemetry);
+      state.connect.publishTelemetry = telemetry;
+      state.connect.status = payload.ok === true && telemetry.status === 'ok' ? 'ok' : 'drift';
       state.connect.service = String(payload.service || '').trim();
       state.connect.version = String(payload.version || '').trim();
-      if (state.connect.status !== 'ok') {
+      if (payload.ok !== true) {
         addProblem(state, {
           component: 'connect',
           code: 'connect_unhealthy',
           message: 'Connect health endpoint did not return ok: true',
+          owner: 'Connect'
+        });
+      }
+      if (telemetry.status !== 'ok') {
+        addProblem(state, {
+          component: 'connect.publishTelemetry',
+          code: 'publish_telemetry_invalid',
+          message: telemetry.error || 'Connect health must expose publish telemetry with schemaVersion 1 and status ok',
           owner: 'Connect'
         });
       }

--- a/scripts/test-product-state-dashboard.js
+++ b/scripts/test-product-state-dashboard.js
@@ -81,7 +81,15 @@ function sampleState(overrides = {}) {
         }
       ]
     },
-    connect: { status: 'ok', service: 'ekily-connect' },
+    connect: {
+      status: 'ok',
+      service: 'ekily-connect',
+      publishTelemetry: {
+        status: 'ok',
+        publishSuccess: 1,
+        publishFailure: 0
+      }
+    },
     verdict: {
       status: 'ok',
       converged: true,
@@ -124,6 +132,27 @@ test('renderProductStateDashboard renders human-readable product status sections
   assert.match(html, /Official Themes/);
   assert.match(html, /Arcus/);
   assert.match(html, /ekily-connect/);
+  assert.match(html, /Publish Telemetry/);
+  assert.match(html, /1 ok \/ 0 failed/);
+});
+
+test('renderProductStateDashboard surfaces Connect publish telemetry drift', () => {
+  const html = renderProductStateDashboard(sampleState({
+    status: 'drift',
+    connect: {
+      status: 'drift',
+      service: 'ekily-connect',
+      publishTelemetry: {
+        status: 'drift',
+        publishSuccess: 0,
+        publishFailure: 2
+      }
+    }
+  }));
+
+  assert.match(html, /Publish Telemetry/);
+  assert.match(html, /0 ok \/ 2 failed/);
+  assert.match(html, /class="status drift">drift/);
 });
 
 test('renderProductStateDashboard includes drift problems without trusting markup', () => {

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -131,9 +131,41 @@ function makeFixtures(overrides = {}) {
     'fixture:connect': {
       ok: true,
       service: 'ekily-connect',
-      version: 'test'
+      version: 'test',
+      publishTelemetry: {
+        schemaVersion: 1,
+        status: 'ok',
+        window: {
+          since: 1779700000,
+          until: 1779786400,
+          seconds: 86400
+        },
+        totalEvents: 3,
+        grantsIssued: 1,
+        publishSuccess: 1,
+        publishFailure: 1,
+        lastEventAt: 1779780000,
+        upstreamFailures: [
+          {
+            errorCode: 'github_forbidden',
+            upstreamStatus: 403,
+            upstreamCode: 'github_forbidden',
+            count: 1,
+            lastAt: 1779780000
+          }
+        ]
+      }
     },
     ...overrides
+  };
+}
+
+function connectWithTelemetry(publishTelemetry) {
+  return {
+    ok: true,
+    service: 'ekily-connect',
+    version: 'test',
+    publishTelemetry
   };
 }
 
@@ -418,6 +450,10 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   assert.equal(state.themes.catalog.status, 'ok');
   assert.equal(state.themes.entries[0].status, 'ok');
   assert.equal(state.connect.status, 'ok');
+  assert.equal(state.desired.connect.requiresPublishTelemetry, true);
+  assert.equal(state.connect.publishTelemetry.status, 'ok');
+  assert.equal(state.connect.publishTelemetry.grantsIssued, 1);
+  assert.equal(state.connect.publishTelemetry.upstreamFailures[0].errorCode, 'github_forbidden');
   assert.equal(state.observed.checkedAt, '2026-05-25T00:00:00Z');
   assert.equal(state.observed.downstream.yap.status, 'ok');
   assert.equal(state.verdict.status, 'ok');
@@ -426,6 +462,132 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   assert.equal(state.verdict.counts.pending, 0);
   assert.equal(shouldFailCheck(state), false);
   assert.equal(shouldFailCheck(state, { requireConverged: true }), false);
+});
+
+test('buildProductState marks missing Connect publish telemetry as drift', async () => {
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:connect': {
+        ok: true,
+        service: 'ekily-connect',
+        version: 'test'
+      }
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.connect.status, 'drift');
+  assert.equal(state.connect.publishTelemetry.status, 'drift');
+  assert.match(state.problems.map((problem) => problem.code).join('\n'), /publish_telemetry_invalid/);
+  assert.equal(shouldFailCheck(state), true);
+});
+
+test('buildProductState marks Connect publish telemetry migration and unknown states as drift', async () => {
+  const baseTelemetry = makeFixtures()['fixture:connect'].publishTelemetry;
+  const cases = [
+    {
+      telemetry: {
+        ...clone(baseTelemetry),
+        status: 'unknown'
+      },
+      message: /status must be ok/
+    },
+    {
+      telemetry: {
+        schemaVersion: 0,
+        status: 'unknown',
+        migrationRequired: true,
+        window: {
+          since: 1779700000,
+          until: 1779786400,
+          seconds: 86400
+        },
+        totalEvents: 3,
+        lastEventAt: 1779780000,
+        reason: 'publish_telemetry_migration_required'
+      },
+      message: /migration must be applied/
+    }
+  ];
+
+  for (const scenario of cases) {
+    const state = await buildProductState({
+      sources: makeSources(),
+      loadJson: loader(makeFixtures({
+        'fixture:connect': connectWithTelemetry(scenario.telemetry)
+      })),
+      generatedAt: '2026-05-25T00:00:00Z'
+    });
+
+    assert.equal(state.status, 'drift');
+    assert.equal(state.connect.status, 'drift');
+    assert.match(state.problems.map((problem) => problem.message).join('\n'), scenario.message);
+  }
+});
+
+test('buildProductState rejects impossible Connect publish telemetry shapes', async () => {
+  const baseTelemetry = makeFixtures()['fixture:connect'].publishTelemetry;
+  const cases = [
+    {
+      telemetry: {
+        ...clone(baseTelemetry),
+        window: {
+          since: 1779700000,
+          until: 1779786400,
+          seconds: 10
+        }
+      },
+      message: /window/
+    },
+    {
+      telemetry: {
+        ...clone(baseTelemetry),
+        totalEvents: 2,
+        grantsIssued: 1,
+        publishSuccess: 1,
+        publishFailure: 1
+      },
+      message: /cannot exceed totalEvents/
+    },
+    {
+      telemetry: {
+        ...clone(baseTelemetry),
+        upstreamFailures: [
+          {
+            errorCode: 'github_forbidden',
+            upstreamStatus: 'not-a-status',
+            upstreamCode: 'github_forbidden',
+            count: 1,
+            lastAt: 1779780000
+          }
+        ]
+      },
+      message: /upstream failure entries/
+    },
+    {
+      telemetry: {
+        ...clone(baseTelemetry),
+        publishFailure: 0
+      },
+      message: /upstream failure counts/
+    }
+  ];
+
+  for (const scenario of cases) {
+    const state = await buildProductState({
+      sources: makeSources(),
+      loadJson: loader(makeFixtures({
+        'fixture:connect': connectWithTelemetry(scenario.telemetry)
+      })),
+      generatedAt: '2026-05-25T00:00:00Z'
+    });
+
+    assert.equal(state.status, 'drift');
+    assert.equal(state.connect.publishTelemetry.status, 'drift');
+    assert.match(state.problems.map((problem) => problem.message).join('\n'), scenario.message);
+  }
 });
 
 test('buildProductState marks a release without runtime asset graph metadata as drift', async () => {


### PR DESCRIPTION
## Summary

- require Connect `/api/health` to expose publish telemetry with `schemaVersion: 1` and `status: ok`
- validate telemetry window, counter, and upstream failure invariants before product-state convergence
- show publish telemetry success/failure counts on the product-state dashboard
- add regression coverage for missing telemetry, migration-required telemetry, invalid telemetry shapes, and dashboard drift display

## Deployment Notes

This PR depends on Connect PR #8, which is already merged and deployed. The remote D1 telemetry migration has been applied, and live Connect health now reports `publishTelemetry.schemaVersion: 1`, `status: ok`, and no `migrationRequired`.

This diff touches only `scripts/product-state-*` files. It should not publish a new Press system zip/tag, but it will still run the System Release workflow and then Product State with `REQUIRE_CONVERGED=true`; live Connect was checked with the new ledger before opening this PR.

## Verification

- `node scripts/test-product-state-ledger.js`
- `node scripts/test-product-state-dashboard.js`
- `bash scripts/test-product-state-workflow.sh`
- `bash scripts/test-system-release-workflow.sh`
- `git diff --check`
- `node scripts/product-state-ledger.js --connect https://connect-8mr.pages.dev/api/health --out /tmp/ekily-product-state-connect-telemetry.json --allow-pending --allow-unknown`
- `node scripts/product-state-ledger.js --state /tmp/ekily-product-state-connect-telemetry.json --check --require-converged --quiet`
- `gh api repos/EkilyHQ/Press/compare/v3.4.59...main` returned `identical` before opening this PR