### PR TITLE
Add composer service lifecycle contract

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Verify runtime cache keys
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
+          node scripts/test-composer-app-services.js
+          node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs
           node scripts/test-editor-app-kernel.mjs
           node --experimental-default-type=module scripts/test-theme-contracts.js

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Verify release package boundary
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
+          node scripts/test-composer-app-services.js
+          node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs
           node scripts/test-editor-app-kernel.mjs
           node --experimental-default-type=module scripts/test-theme-contracts.js

--- a/assets/js/composer-app-services.js
+++ b/assets/js/composer-app-services.js
@@ -1,0 +1,159 @@
+export const COMPOSER_SERVICE_PLAN = Object.freeze([
+  Object.freeze({
+    slot: 'markdownDraftController',
+    setter: 'setMarkdownDraftController',
+    getter: 'getMarkdownDraftController',
+    label: 'Markdown draft controller',
+    requires: []
+  }),
+  Object.freeze({
+    slot: 'markdownLoader',
+    setter: 'setMarkdownLoader',
+    getter: 'getMarkdownLoader',
+    label: 'Markdown loader',
+    requires: ['markdownDraftController']
+  }),
+  Object.freeze({
+    slot: 'markdownActionsUi',
+    setter: 'setMarkdownActionsUi',
+    getter: 'getMarkdownActionsUi',
+    label: 'Markdown actions UI',
+    requires: ['markdownDraftController', 'markdownLoader']
+  }),
+  Object.freeze({
+    slot: 'markdownSessionController',
+    setter: 'setMarkdownSessionController',
+    getter: 'getMarkdownSessionController',
+    label: 'Markdown session controller',
+    requires: ['markdownDraftController', 'markdownLoader', 'markdownActionsUi']
+  }),
+  Object.freeze({
+    slot: 'markdownWorkspaceController',
+    setter: 'setMarkdownWorkspaceController',
+    getter: 'getMarkdownWorkspaceController',
+    label: 'Markdown workspace controller',
+    requires: ['markdownSessionController', 'markdownActionsUi', 'markdownLoader']
+  }),
+  Object.freeze({
+    slot: 'modeController',
+    setter: 'setModeController',
+    getter: 'getCurrentMode',
+    label: 'Mode controller',
+    requires: ['markdownWorkspaceController', 'markdownSessionController']
+  }),
+  Object.freeze({
+    slot: 'unsyncedSummaryController',
+    setter: 'setUnsyncedSummaryController',
+    getter: 'getUnsyncedSummaryController',
+    label: 'Unsynced summary controller',
+    requires: ['modeController', 'markdownWorkspaceController', 'markdownDraftController']
+  })
+]);
+
+export const COMPOSER_SERVICE_SLOTS = Object.freeze(COMPOSER_SERVICE_PLAN.map(item => item.slot));
+const PLAN_BY_SETTER = new Map(COMPOSER_SERVICE_PLAN.map(item => [item.setter, item]));
+
+function normalizePlan(plan = COMPOSER_SERVICE_PLAN) {
+  const entries = Array.isArray(plan) ? plan : [];
+  const slots = new Set();
+  const setters = new Set();
+  const normalized = entries.map((entry) => ({
+    ...entry,
+    slot: String(entry && entry.slot || '').trim(),
+    setter: String(entry && entry.setter || '').trim(),
+    label: String(entry && entry.label || '').trim(),
+    requires: Array.isArray(entry && entry.requires)
+      ? entry.requires.map(value => String(value || '').trim()).filter(Boolean)
+      : []
+  }));
+
+  normalized.forEach((entry) => {
+    if (!entry.slot || !entry.setter || !entry.label) {
+      throw new Error('Composer service plan entries require slot, setter, and label');
+    }
+    if (slots.has(entry.slot)) throw new Error(`Duplicate composer service slot: ${entry.slot}`);
+    if (setters.has(entry.setter)) throw new Error(`Duplicate composer service setter: ${entry.setter}`);
+    slots.add(entry.slot);
+    setters.add(entry.setter);
+  });
+
+  normalized.forEach((entry) => {
+    entry.requires.forEach((slot) => {
+      if (!slots.has(slot)) {
+        throw new Error(`Composer service "${entry.slot}" requires unknown slot "${slot}"`);
+      }
+      if (slot === entry.slot) {
+        throw new Error(`Composer service "${entry.slot}" cannot require itself`);
+      }
+    });
+  });
+
+  return normalized;
+}
+
+export function getComposerServiceLifecyclePlan() {
+  return normalizePlan().map(entry => ({
+    slot: entry.slot,
+    setter: entry.setter,
+    getter: entry.getter || '',
+    label: entry.label,
+    requires: [...entry.requires]
+  }));
+}
+
+export function createComposerServiceLifecycle(registry, options = {}) {
+  if (!registry || typeof registry !== 'object') {
+    throw new Error('Composer service lifecycle requires a registry');
+  }
+  const appName = String(options.name || 'composer-services').trim() || 'composer-services';
+  const plan = normalizePlan();
+  const initialized = new Set();
+
+  function register(setterName, service) {
+    const entry = PLAN_BY_SETTER.get(setterName);
+    if (!entry) throw new Error(`${appName}: unknown composer service setter "${setterName}"`);
+    if (initialized.has(entry.slot)) {
+      throw new Error(`${appName}: composer service "${entry.slot}" is already initialized`);
+    }
+    if (service === null || service === undefined) {
+      throw new Error(`${appName}: composer service "${entry.slot}" cannot be null or undefined`);
+    }
+    entry.requires.forEach((slot) => {
+      if (!initialized.has(slot)) {
+        throw new Error(`${appName}: composer service "${entry.slot}" requires "${slot}" first`);
+      }
+    });
+    const setter = registry[setterName];
+    if (typeof setter !== 'function') {
+      throw new Error(`${appName}: registry is missing setter "${setterName}"`);
+    }
+    const value = setter(service);
+    if (value === null || value === undefined) {
+      throw new Error(`${appName}: registry rejected composer service "${entry.slot}"`);
+    }
+    initialized.add(entry.slot);
+    return value;
+  }
+
+  function assertReady() {
+    const missing = plan
+      .map(entry => entry.slot)
+      .filter(slot => !initialized.has(slot));
+    if (missing.length) {
+      throw new Error(`${appName}: missing composer services: ${missing.join(', ')}`);
+    }
+    return true;
+  }
+
+  const lifecycle = {
+    assertReady,
+    getInitializedSlots: () => [...initialized],
+    getPlan: getComposerServiceLifecyclePlan
+  };
+
+  plan.forEach((entry) => {
+    lifecycle[entry.setter] = (service) => register(entry.setter, service);
+  });
+
+  return lifecycle;
+}

--- a/assets/js/composer-service-registry.js
+++ b/assets/js/composer-service-registry.js
@@ -1,15 +1,7 @@
-const SERVICE_NAMES = [
-  'markdownActionsUi',
-  'markdownDraftController',
-  'markdownLoader',
-  'markdownSessionController',
-  'markdownWorkspaceController',
-  'modeController',
-  'unsyncedSummaryController'
-];
+import { COMPOSER_SERVICE_PLAN, COMPOSER_SERVICE_SLOTS } from './composer-app-services.js';
 
 function createEmptyServices() {
-  return SERVICE_NAMES.reduce((result, name) => {
+  return COMPOSER_SERVICE_SLOTS.reduce((result, name) => {
     result[name] = null;
     return result;
   }, {});
@@ -21,6 +13,7 @@ function createMissingServiceError(label) {
 
 export function createComposerServiceRegistry() {
   const services = createEmptyServices();
+  const labelsBySlot = new Map(COMPOSER_SERVICE_PLAN.map(entry => [entry.slot, entry.label]));
 
   const get = (name) => services[name] || null;
   const set = (name, service) => {
@@ -42,12 +35,12 @@ export function createComposerServiceRegistry() {
   return {
     applyMode: (...args) => call('modeController', 'applyMode', false, ...args),
     getCurrentMode: () => call('modeController', 'getCurrentMode', null),
-    getMarkdownActionsUi: () => requireService('markdownActionsUi', 'Markdown actions UI'),
-    getMarkdownDraftController: () => requireService('markdownDraftController', 'Markdown draft controller'),
-    getMarkdownLoader: () => requireService('markdownLoader', 'Markdown loader'),
-    getMarkdownSessionController: () => requireService('markdownSessionController', 'Markdown session controller'),
-    getMarkdownWorkspaceController: () => requireService('markdownWorkspaceController', 'Markdown workspace controller'),
-    getUnsyncedSummaryController: () => requireService('unsyncedSummaryController', 'Unsynced summary controller'),
+    getMarkdownActionsUi: () => requireService('markdownActionsUi', labelsBySlot.get('markdownActionsUi')),
+    getMarkdownDraftController: () => requireService('markdownDraftController', labelsBySlot.get('markdownDraftController')),
+    getMarkdownLoader: () => requireService('markdownLoader', labelsBySlot.get('markdownLoader')),
+    getMarkdownSessionController: () => requireService('markdownSessionController', labelsBySlot.get('markdownSessionController')),
+    getMarkdownWorkspaceController: () => requireService('markdownWorkspaceController', labelsBySlot.get('markdownWorkspaceController')),
+    getUnsyncedSummaryController: () => requireService('unsyncedSummaryController', labelsBySlot.get('unsyncedSummaryController')),
     setMarkdownActionsUi: (service) => set('markdownActionsUi', service),
     setMarkdownDraftController: (service) => set('markdownDraftController', service),
     setMarkdownLoader: (service) => set('markdownLoader', service),

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -46,6 +46,7 @@ import {
   createComposerRuntime
 } from './composer-runtime.js';
 import { createComposerServiceRegistry } from './composer-service-registry.js';
+import { createComposerServiceLifecycle } from './composer-app-services.js';
 import { createComposerFilePanelController } from './composer-file-panel-controller.js';
 import { createComposerPublishService } from './composer-publish-service.js';
 import { createComposerNotificationController } from './composer-notifications.js';
@@ -424,6 +425,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     registerExternalStagingProviders: (registry) => composerSystemThemeBridge.registerStagingProviders(registry)
   });
   const composerServices = createComposerServiceRegistry();
+  const composerServiceLifecycle = createComposerServiceLifecycle(composerServices);
   const editorSessionStateStore = createEditorSessionStateStore({
     storage: editorRuntime.storage,
     scopeKey: scopedEditorStorageKey,
@@ -434,7 +436,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     editorStateVersion: EDITOR_STATE_VERSION
   });
   const expandedEditorTreeNodeIds = editorRuntime.getExpandedEditorTreeNodeIds();
-  composerServices.setMarkdownDraftController(createComposerMarkdownDraftController({
+  composerServiceLifecycle.setMarkdownDraftController(createComposerMarkdownDraftController({
     markdownDraftStore,
     normalizeRelPath,
     normalizeAssetDescriptor,
@@ -462,7 +464,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     setTimeoutRef: (handler, delay) => editorRuntime.setTimer(handler, delay),
     clearTimeoutRef: (id) => editorRuntime.clearTimer(id)
   }));
-  composerServices.setMarkdownLoader(createComposerMarkdownLoader({
+  composerServiceLifecycle.setMarkdownLoader(createComposerMarkdownLoader({
     getContentRootSafe,
     normalizeRelPath,
     normalizeMarkdownContent,
@@ -484,7 +486,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     openProtectionTitle: () => t('editor.composer.markdown.protection.openTitle'),
     openProtectionMessage: () => t('editor.composer.markdown.protection.openMessage')
   }));
-  composerServices.setMarkdownActionsUi(createComposerMarkdownActionsUi({
+  composerServiceLifecycle.setMarkdownActionsUi(createComposerMarkdownActionsUi({
     documentRef: composerDocument,
     translate: t,
     getCurrentMode: () => getCurrentComposerMode(),
@@ -674,7 +676,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     setEditorDetailPanelMode,
     setEditorStructurePanelVisible
   } = editorDetailPanelController;
-  composerServices.setMarkdownSessionController(createComposerMarkdownSessionController({
+  composerServiceLifecycle.setMarkdownSessionController(createComposerMarkdownSessionController({
     editorStateVersion: EDITOR_STATE_VERSION,
     editorSessionStateStore,
     normalizeRelPath,
@@ -714,7 +716,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     updateMarkdownActionsForTab,
     updateComposerMarkdownDraftIndicators
   }));
-  composerServices.setMarkdownWorkspaceController(createComposerMarkdownWorkspaceController({
+  composerServiceLifecycle.setMarkdownWorkspaceController(createComposerMarkdownWorkspaceController({
     getPrimaryEditorApi: () => editorRuntime.globals.getPrimaryEditorApi(),
     getMarkdownSessionController,
     getMarkdownActionsUi,
@@ -727,7 +729,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     inferMarkdownSourceFromPath,
     buildCurrentFileBreadcrumb
   }));
-  composerServices.setModeController(createComposerModeController({
+  composerServiceLifecycle.setModeController(createComposerModeController({
     documentRef: composerDocument,
     getDynamicEditorTabs: () => getDynamicEditorTabs(),
     isDynamicMode,
@@ -871,7 +873,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     renderComposerInlineSummary,
     renderOrderStatsChips
   } = composerDiffUi;
-  composerServices.setUnsyncedSummaryController(createComposerUnsyncedSummaryController({
+  composerServiceLifecycle.setUnsyncedSummaryController(createComposerUnsyncedSummaryController({
     documentRef: composerDocument,
     getDynamicEditorTabs: () => getDynamicEditorTabs(),
     normalizeRelPath,
@@ -1977,6 +1979,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function start() {
+    composerServiceLifecycle.assertReady();
     initializeComposerApp({
       documentRef: composerDocument,
       onDocumentReady: editorRuntime.onDocumentReady,

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.60",
-  "tag": "v3.4.60",
+  "version": "3.4.61",
+  "tag": "v3.4.61",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.59 <3.4.60"
+      ">=3.4.60 <3.4.61"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.59 first."
+    "message": "Update to v3.4.60 first."
   }
 }

--- a/scripts/test-composer-app-services.js
+++ b/scripts/test-composer-app-services.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  COMPOSER_SERVICE_PLAN,
+  COMPOSER_SERVICE_SLOTS,
+  createComposerServiceLifecycle,
+  getComposerServiceLifecyclePlan
+} from '../assets/js/composer-app-services.js';
+import { createComposerServiceRegistry } from '../assets/js/composer-service-registry.js';
+import { runEditorFeatureLifecycle } from '../assets/js/editor-app-kernel.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const composerSource = readFileSync(resolve(here, '../assets/js/composer.js'), 'utf8');
+const registrySource = readFileSync(resolve(here, '../assets/js/composer-service-registry.js'), 'utf8');
+
+const expectedSlots = [
+  'markdownDraftController',
+  'markdownLoader',
+  'markdownActionsUi',
+  'markdownSessionController',
+  'markdownWorkspaceController',
+  'modeController',
+  'unsyncedSummaryController'
+];
+const expectedSetters = [
+  'setMarkdownDraftController',
+  'setMarkdownLoader',
+  'setMarkdownActionsUi',
+  'setMarkdownSessionController',
+  'setMarkdownWorkspaceController',
+  'setModeController',
+  'setUnsyncedSummaryController'
+];
+
+assert.deepEqual(COMPOSER_SERVICE_SLOTS, expectedSlots);
+assert.deepEqual(COMPOSER_SERVICE_PLAN.map(entry => entry.slot), expectedSlots);
+assert.deepEqual(COMPOSER_SERVICE_PLAN.map(entry => entry.setter), expectedSetters);
+assert.deepEqual(getComposerServiceLifecyclePlan().map(entry => entry.slot), expectedSlots);
+assert.equal(new Set(COMPOSER_SERVICE_SLOTS).size, COMPOSER_SERVICE_SLOTS.length);
+
+await runEditorFeatureLifecycle(
+  getComposerServiceLifecyclePlan().map(entry => ({
+    name: `composer.service.${entry.slot}`,
+    provides: [entry.slot],
+    requires: entry.requires
+  })),
+  { name: 'composer-service-plan' }
+);
+
+{
+  const registry = createComposerServiceRegistry();
+  const lifecycle = createComposerServiceLifecycle(registry, { name: 'test-composer-services' });
+  assert.throws(
+    () => lifecycle.assertReady(),
+    /test-composer-services: missing composer services: markdownDraftController, markdownLoader, markdownActionsUi, markdownSessionController, markdownWorkspaceController, modeController, unsyncedSummaryController/
+  );
+  assert.throws(
+    () => lifecycle.setMarkdownLoader({}),
+    /test-composer-services: composer service "markdownLoader" requires "markdownDraftController" first/
+  );
+  assert.throws(
+    () => lifecycle.setMarkdownDraftController(null),
+    /test-composer-services: composer service "markdownDraftController" cannot be null or undefined/
+  );
+  assert.throws(
+    () => lifecycle.setMarkdownDraftController(undefined),
+    /test-composer-services: composer service "markdownDraftController" cannot be null or undefined/
+  );
+  assert.deepEqual(lifecycle.getInitializedSlots(), []);
+
+  const services = Object.fromEntries(expectedSlots.map(slot => [slot, { slot }]));
+  expectedSetters.forEach((setter, index) => {
+    assert.equal(lifecycle[setter](services[expectedSlots[index]]), services[expectedSlots[index]]);
+  });
+  assert.deepEqual(lifecycle.getInitializedSlots(), expectedSlots);
+  assert.equal(lifecycle.assertReady(), true);
+  assert.equal(registry.getMarkdownDraftController(), services.markdownDraftController);
+  assert.equal(registry.getMarkdownLoader(), services.markdownLoader);
+  assert.equal(registry.getMarkdownActionsUi(), services.markdownActionsUi);
+  assert.equal(registry.getMarkdownSessionController(), services.markdownSessionController);
+  assert.equal(registry.getMarkdownWorkspaceController(), services.markdownWorkspaceController);
+  assert.equal(registry.getUnsyncedSummaryController(), services.unsyncedSummaryController);
+  assert.throws(
+    () => lifecycle.setMarkdownDraftController({}),
+    /test-composer-services: composer service "markdownDraftController" is already initialized/
+  );
+}
+
+{
+  const registry = {};
+  const lifecycle = createComposerServiceLifecycle(registry, { name: 'missing-setter-test' });
+  assert.throws(
+    () => lifecycle.setMarkdownDraftController({}),
+    /missing-setter-test: registry is missing setter "setMarkdownDraftController"/
+  );
+}
+
+{
+  const registry = {
+    setMarkdownDraftController: () => null
+  };
+  const lifecycle = createComposerServiceLifecycle(registry, { name: 'rejecting-registry-test' });
+  assert.throws(
+    () => lifecycle.setMarkdownDraftController({}),
+    /rejecting-registry-test: registry rejected composer service "markdownDraftController"/
+  );
+  assert.deepEqual(lifecycle.getInitializedSlots(), []);
+}
+
+assert.match(
+  registrySource,
+  /import \{ COMPOSER_SERVICE_PLAN, COMPOSER_SERVICE_SLOTS \} from '\.\/composer-app-services\.js';/,
+  'composer service registry should read slot metadata from the service lifecycle plan'
+);
+
+assert.match(
+  composerSource,
+  /const composerServices = createComposerServiceRegistry\(\);\s*const composerServiceLifecycle = createComposerServiceLifecycle\(composerServices\);/,
+  'composer should create a lifecycle wrapper for late-bound app services'
+);
+
+expectedSetters.forEach((setter) => {
+  assert.match(
+    composerSource,
+    new RegExp(`composerServiceLifecycle\\.${setter}\\(`),
+    `composer should register ${setter} through the lifecycle wrapper`
+  );
+  assert.doesNotMatch(
+    composerSource,
+    new RegExp(`composerServices\\.${setter}\\(`),
+    `composer should not bypass the lifecycle wrapper for ${setter}`
+  );
+});
+
+const actualSetterOrder = [...composerSource.matchAll(/composerServiceLifecycle\.(set[A-Za-z]+)\(/g)]
+  .map(match => match[1])
+  .filter(setter => expectedSetters.includes(setter));
+assert.deepEqual(actualSetterOrder, expectedSetters);
+assert.match(
+  composerSource,
+  /function start\(\) \{\s*composerServiceLifecycle\.assertReady\(\);[\s\S]*initializeComposerApp\(/,
+  'composer should assert service readiness before bootstrap starts'
+);
+
+console.log('ok - composer app services');

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -50,6 +50,7 @@ const composerSystemThemeBridgePath = resolve(here, '../assets/js/composer-syste
 const composerBootstrapPath = resolve(here, '../assets/js/composer-bootstrap.js');
 const composerRuntimePath = resolve(here, '../assets/js/composer-runtime.js');
 const composerServiceRegistryPath = resolve(here, '../assets/js/composer-service-registry.js');
+const composerAppServicesPath = resolve(here, '../assets/js/composer-app-services.js');
 const composerFilePanelControllerPath = resolve(here, '../assets/js/composer-file-panel-controller.js');
 const composerEditorDetailPanelControllerPath = resolve(here, '../assets/js/composer-editor-detail-panel-controller.js');
 const composerUiMotionPath = resolve(here, '../assets/js/composer-ui-motion.js');
@@ -173,6 +174,7 @@ const composerSystemThemeBridgeSource = readFileSync(composerSystemThemeBridgePa
 const composerBootstrapSource = readFileSync(composerBootstrapPath, 'utf8');
 const composerRuntimeSource = readFileSync(composerRuntimePath, 'utf8');
 const composerServiceRegistrySource = readFileSync(composerServiceRegistryPath, 'utf8');
+const composerAppServicesSource = readFileSync(composerAppServicesPath, 'utf8');
 const composerFilePanelControllerSource = readFileSync(composerFilePanelControllerPath, 'utf8');
 const composerEditorDetailPanelControllerSource = readFileSync(composerEditorDetailPanelControllerPath, 'utf8');
 const composerUiMotionSource = readFileSync(composerUiMotionPath, 'utf8');
@@ -1221,8 +1223,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /const composerServices = createComposerServiceRegistry\(\);[\s\S]*composerServices\.setMarkdownDraftController\(createComposerMarkdownDraftController\(\{[\s\S]*composerServices\.setMarkdownLoader\(createComposerMarkdownLoader\(\{[\s\S]*composerServices\.setMarkdownActionsUi\(createComposerMarkdownActionsUi\(\{[\s\S]*composerServices\.setMarkdownSessionController\(createComposerMarkdownSessionController\(\{[\s\S]*composerServices\.setMarkdownWorkspaceController\(createComposerMarkdownWorkspaceController\(\{[\s\S]*composerServices\.setModeController\(createComposerModeController\(\{[\s\S]*composerServices\.setUnsyncedSummaryController\(createComposerUnsyncedSummaryController\(\{/,
-  'composer should register late-bound controllers through the explicit composer service registry'
+  /const composerServices = createComposerServiceRegistry\(\);\s*const composerServiceLifecycle = createComposerServiceLifecycle\(composerServices\);[\s\S]*composerServiceLifecycle\.setMarkdownDraftController\(createComposerMarkdownDraftController\(\{[\s\S]*composerServiceLifecycle\.setMarkdownLoader\(createComposerMarkdownLoader\(\{[\s\S]*composerServiceLifecycle\.setMarkdownActionsUi\(createComposerMarkdownActionsUi\(\{[\s\S]*composerServiceLifecycle\.setMarkdownSessionController\(createComposerMarkdownSessionController\(\{[\s\S]*composerServiceLifecycle\.setMarkdownWorkspaceController\(createComposerMarkdownWorkspaceController\(\{[\s\S]*composerServiceLifecycle\.setModeController\(createComposerModeController\(\{[\s\S]*composerServiceLifecycle\.setUnsyncedSummaryController\(createComposerUnsyncedSummaryController\(\{/,
+  'composer should register late-bound controllers through the explicit composer service lifecycle'
 );
 
 assert.doesNotMatch(
@@ -1232,14 +1234,14 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  composerServiceRegistrySource,
-  /const SERVICE_NAMES = \[[\s\S]*'markdownActionsUi'[\s\S]*'markdownDraftController'[\s\S]*'markdownLoader'[\s\S]*'markdownSessionController'[\s\S]*'markdownWorkspaceController'[\s\S]*'modeController'[\s\S]*'unsyncedSummaryController'[\s\S]*\];/,
-  'composer service registry should name every allowed late-bound composer dependency'
+  composerAppServicesSource,
+  /export const COMPOSER_SERVICE_PLAN = Object\.freeze\(\[[\s\S]*slot: 'markdownDraftController'[\s\S]*slot: 'markdownLoader'[\s\S]*slot: 'markdownActionsUi'[\s\S]*slot: 'markdownSessionController'[\s\S]*slot: 'markdownWorkspaceController'[\s\S]*slot: 'modeController'[\s\S]*slot: 'unsyncedSummaryController'[\s\S]*\]\);/,
+  'composer app service plan should name every allowed late-bound composer dependency'
 );
 
 assert.match(
   composerServiceRegistrySource,
-  /getCurrentMode: \(\) => call\('modeController', 'getCurrentMode', null\),[\s\S]*getMarkdownDraftController: \(\) => requireService\('markdownDraftController', 'Markdown draft controller'\),[\s\S]*getMarkdownWorkspaceController: \(\) => requireService\('markdownWorkspaceController', 'Markdown workspace controller'\),[\s\S]*setModeController: \(service\) => set\('modeController', service\),/,
+  /import \{ COMPOSER_SERVICE_PLAN, COMPOSER_SERVICE_SLOTS \} from '\.\/composer-app-services\.js';[\s\S]*getCurrentMode: \(\) => call\('modeController', 'getCurrentMode', null\),[\s\S]*getMarkdownDraftController: \(\) => requireService\('markdownDraftController', labelsBySlot\.get\('markdownDraftController'\)\),[\s\S]*getMarkdownWorkspaceController: \(\) => requireService\('markdownWorkspaceController', labelsBySlot\.get\('markdownWorkspaceController'\)\),[\s\S]*setModeController: \(service\) => set\('modeController', service\),/,
   'composer service registry should expose explicit service getters and setters instead of anonymous root slots'
 );
 
@@ -1263,7 +1265,7 @@ assert.match(
 
 assert.match(
   source,
-  /composerServices\.setModeController\(createComposerModeController\(\{[\s\S]*documentRef: composerDocument,[\s\S]*requestAnimationFrameRef: \(handler\) => editorRuntime\.requestFrame\(handler\),[\s\S]*alertRef: \(message\) => editorRuntime\.showAlert\(message\),[\s\S]*consoleRef: composerLogger[\s\S]*\}\)\);/,
+  /composerServiceLifecycle\.setModeController\(createComposerModeController\(\{[\s\S]*documentRef: composerDocument,[\s\S]*requestAnimationFrameRef: \(handler\) => editorRuntime\.requestFrame\(handler\),[\s\S]*alertRef: \(message\) => editorRuntime\.showAlert\(message\),[\s\S]*consoleRef: composerLogger[\s\S]*\}\)\);/,
   'composer should inject mode-controller frame scheduling, alerts, and logging through the runtime boundary'
 );
 

--- a/scripts/test-composer-service-registry.js
+++ b/scripts/test-composer-service-registry.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { COMPOSER_SERVICE_PLAN, COMPOSER_SERVICE_SLOTS } from '../assets/js/composer-app-services.js';
 import { createComposerServiceRegistry } from '../assets/js/composer-service-registry.js';
 
 const registry = createComposerServiceRegistry();
@@ -24,6 +25,14 @@ assert.deepEqual(
   ],
   'composer service registry should expose only named composer service slots'
 );
+assert.deepEqual(
+  COMPOSER_SERVICE_SLOTS,
+  COMPOSER_SERVICE_PLAN.map(entry => entry.slot),
+  'composer service plan should be the registry slot source of truth'
+);
+COMPOSER_SERVICE_PLAN.forEach((entry) => {
+  assert.equal(typeof registry[entry.setter], 'function', `${entry.setter} should be exposed`);
+});
 
 assert.equal(registry.getCurrentMode(), null, 'missing mode controller should read as no active mode');
 assert.equal(registry.applyMode('site'), false, 'missing mode controller should ignore apply requests');

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -38,6 +38,8 @@ for command in \
   'node scripts/test-release-targets.js' \
   'node scripts/test-dispatch-system-release.js' \
   'node scripts/test-product-state-ledger.js' \
+  'node scripts/test-composer-app-services.js' \
+  'node scripts/test-composer-service-registry.js' \
   'bash scripts/test-pages-artifact.sh'
 do
   if ! grep -F "${command}" "${workflow}" >/dev/null; then

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -423,6 +423,11 @@ if ! grep -qx "press-system-${version}/assets/js/composer-service-registry.js" "
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/composer-app-services.js" "${entries_file}"; then
+  echo "expected package to include composer app service lifecycle code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/composer-file-panel-controller.js" "${entries_file}"; then
   echo "expected package to include composer file panel controller code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -88,6 +88,16 @@ if ! grep -F 'node scripts/sync-runtime-cache-keys.mjs --check' "${workflow}" >/
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-composer-app-services.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the composer app service lifecycle before publishing" >&2
+  exit 1
+fi
+
+if ! grep -F 'node scripts/test-composer-service-registry.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the composer service registry before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node scripts/test-press-system-surface.mjs' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the shared Press system surface before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary

- add a canonical composer app service lifecycle plan for the seven late-bound composer services
- route composer service registration through the lifecycle wrapper and assert readiness before editor bootstrap
- make the service registry consume slot labels from the shared plan, with regression coverage for ordering, missing services, duplicate registration, null services, and rejected registry writes

## Impact

This is a Press system-surface change and bumps the runtime to `v3.4.61`. The release surface is limited to `assets/js/composer-app-services.js`, `assets/js/composer-service-registry.js`, `assets/js/composer.js`, and `assets/press-system.json`; workflow/test changes only expand the guard coverage.

## Validation

- `node --check assets/js/composer-app-services.js && node --check assets/js/composer-service-registry.js && node --check assets/js/composer.js && node --check scripts/test-composer-app-services.js`
- `node scripts/test-composer-app-services.js`
- `node scripts/test-composer-service-registry.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-composer-bootstrap.js`
- `node scripts/test-editor-app-kernel.mjs`
- `node scripts/test-ui-components.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- local browser smoke at `http://127.0.0.1:8000/index_editor.html`: editor loaded, composer controls visible, no console warnings/errors

## Review

Pre-PR subagent review found one non-blocking lifecycle readiness gap; this branch now rejects null/undefined services and rejected registry setter returns before marking a slot initialized. The follow-up review found no blockers.