### PR TITLE
[codex] Prefer Connect release status surfaces

### DIFF
--- a/assets/js/connect-status.js
+++ b/assets/js/connect-status.js
@@ -1,0 +1,77 @@
+import {
+  CONNECT_PUBLISH_BASE_URL_STORAGE_KEY,
+  getDefaultConnectPublishBaseUrl,
+  normalizeConnectPublishBaseUrl
+} from './publish/settings-store.js';
+import { createScopedStorageKey, resolveEditorStorageScope } from './editor-storage.js';
+
+export const CONNECT_PRODUCT_STATE_PATH = '/api/product-state';
+export const CONNECT_SYSTEM_RELEASE_PATH = '/api/press/system-release';
+
+function getWindowRef(options = {}) {
+  if (options.windowRef) return options.windowRef;
+  return typeof window !== 'undefined' ? window : null;
+}
+
+function getStorage(options = {}) {
+  if (options.localStorageRef) return options.localStorageRef;
+  const win = getWindowRef(options);
+  try {
+    if (win && win.localStorage) return win.localStorage;
+  } catch (_) {
+    return null;
+  }
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getLocationRef(options = {}) {
+  if (options.locationRef) return options.locationRef;
+  const win = getWindowRef(options);
+  return win && win.location ? win.location : null;
+}
+
+function readStorageValue(storage, key) {
+  try {
+    return storage && typeof storage.getItem === 'function' ? storage.getItem(key) : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function getStoredConnectBaseUrl(options = {}) {
+  const storage = getStorage(options);
+  if (!storage) return '';
+  const keys = [];
+  const scope = options.storageScope || resolveEditorStorageScope(getLocationRef(options));
+  if (scope) keys.push(createScopedStorageKey(scope, CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
+  keys.push(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY);
+  for (const key of keys) {
+    const value = readStorageValue(storage, key);
+    if (value && String(value).trim()) return value;
+  }
+  return '';
+}
+
+export function resolveConnectStatusBaseUrl(options = {}) {
+  const explicit = normalizeConnectPublishBaseUrl(
+    options.connectBaseUrl || options.baseUrl || (options.connect && options.connect.baseUrl) || ''
+  );
+  if (explicit) return explicit;
+  const stored = normalizeConnectPublishBaseUrl(getStoredConnectBaseUrl(options));
+  if (stored) return stored;
+  return options.defaultConnect === false ? null : getDefaultConnectPublishBaseUrl();
+}
+
+export function buildConnectStatusUrl(path, options = {}) {
+  const baseUrl = resolveConnectStatusBaseUrl(options);
+  if (!baseUrl) return '';
+  try {
+    return new URL(path, baseUrl).href;
+  } catch (_) {
+    return '';
+  }
+}

--- a/assets/js/product-state.js
+++ b/assets/js/product-state.js
@@ -1,3 +1,5 @@
+import { buildConnectStatusUrl, CONNECT_PRODUCT_STATE_PATH } from './connect-status.js';
+
 export const PRODUCT_STATE_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/product-state.json';
 
 const PRODUCT_STATE_TYPE = 'ekily-product-state';
@@ -199,13 +201,41 @@ export function getProductStateThemeEntry(productState, slug) {
   return productState.themes.entries.find((entry) => entry.slug === value) || null;
 }
 
+function productStateUrls(options = {}) {
+  if (options.url) return [String(options.url)];
+  const urls = [];
+  const connectUrl = buildConnectStatusUrl(CONNECT_PRODUCT_STATE_PATH, options);
+  if (connectUrl) urls.push(connectUrl);
+  urls.push(PRODUCT_STATE_URL);
+  return Array.from(new Set(urls.filter(Boolean)));
+}
+
+function unwrapProductStatePayload(input) {
+  if (input && typeof input === 'object' && input.ok === true && input.productState) {
+    return input.productState;
+  }
+  return input;
+}
+
 export async function loadProductState(options = {}) {
   const fetchImpl = typeof options.fetchImpl === 'function'
     ? options.fetchImpl
     : (typeof fetch === 'function' ? fetch : null);
   if (typeof fetchImpl !== 'function') throw new Error('Product state fetch is unavailable.');
-  const url = options.url || PRODUCT_STATE_URL;
-  const response = await fetchImpl(url, { cache: 'no-store' });
-  if (!response || !response.ok) throw new Error('Unable to load product state.');
-  return normalizeProductState(await response.json());
+  const urls = productStateUrls(options);
+  let lastError = null;
+  for (const url of urls) {
+    try {
+      const response = await fetchImpl(url, {
+        headers: { accept: 'application/json' },
+        cache: 'no-store'
+      });
+      if (!response || !response.ok) throw new Error('Unable to load product state.');
+      return normalizeProductState(unwrapProductStatePayload(await response.json()));
+    } catch (err) {
+      lastError = err;
+      if (options.url) break;
+    }
+  }
+  throw lastError || new Error('Unable to load product state.');
 }

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -2,8 +2,8 @@ import { mdParse } from './markdown.js';
 import { renderPressMath } from './math-render.js';
 import { setSafeHtml } from './safe-html.js';
 import { t } from './i18n.js';
+import { buildConnectStatusUrl, CONNECT_SYSTEM_RELEASE_PATH } from './connect-status.js';
 import {
-  compareSemver,
   isUpgradeAllowed,
   loadPressSystemManifest,
   normalizePressSystemManifest,
@@ -65,6 +65,14 @@ function createSystemUpdatesRuntime(options = {}) {
   const state = createSystemUpdatesState();
   const documentRef = options.documentRef || null;
   const fetchImpl = typeof options.fetchImpl === 'function' ? options.fetchImpl : null;
+  const connectStatusOptions = {
+    connectBaseUrl: options.connectBaseUrl || '',
+    defaultConnect: options.defaultConnect,
+    localStorageRef: options.localStorageRef || null,
+    locationRef: options.locationRef || null,
+    storageScope: options.storageScope || '',
+    windowRef: options.windowRef || null
+  };
 
   return {
     state,
@@ -75,6 +83,9 @@ function createSystemUpdatesRuntime(options = {}) {
       if (fetchImpl) return fetchImpl;
       if (typeof fetch === 'function') return fetch;
       throw new Error('System update fetch is unavailable.');
+    },
+    getConnectStatusOptions() {
+      return connectStatusOptions;
     }
   };
 }
@@ -319,12 +330,8 @@ export function selectSystemUpdateAsset(releaseData) {
   };
 }
 
-function compareReleaseTags(a, b) {
-  return compareSemver(a, b);
-}
-
 function isFetchableSystemUpdateAssetUrl(url) {
-  return /^https:\/\/raw\.githubusercontent\.com\/[^/]+\/Press\/release-artifacts\/v\d+\.\d+\.\d+\/press-system-v\d+\.\d+\.\d+\.zip$/i
+  return /^https:\/\/raw\.githubusercontent\.com\/EkilyHQ\/Press\/release-artifacts\/v\d+\.\d+\.\d+\/press-system-v\d+\.\d+\.\d+\.zip$/i
     .test(String(url || '').trim());
 }
 
@@ -525,14 +532,15 @@ async function fetchLatestReleaseFromApi(runtime) {
   return normalizeReleaseCache(data);
 }
 
-function getManifestUrls() {
-  return [RELEASE_MANIFEST_URL];
+function getManifestUrls(runtime) {
+  const connectUrl = buildConnectStatusUrl(CONNECT_SYSTEM_RELEASE_PATH, runtime.getConnectStatusOptions());
+  return Array.from(new Set([connectUrl, RELEASE_MANIFEST_URL].filter(Boolean)));
 }
 
 async function fetchLatestReleaseFromManifest(runtime) {
   const fetchImpl = runtime.getFetch();
   let lastError = null;
-  const urls = getManifestUrls();
+  const urls = getManifestUrls(runtime);
   for (const url of urls) {
     try {
       const response = await fetchImpl(url, {
@@ -555,38 +563,29 @@ async function fetchLatestReleaseFromManifest(runtime) {
 async function fetchLatestRelease(runtime) {
   const state = runtime.state;
   if (state.releaseCache) return state.releaseCache;
-  let apiRelease = null;
   let apiError = null;
   let manifestRelease = null;
   let manifestError = null;
-  try {
-    apiRelease = await fetchLatestReleaseFromApi(runtime);
-  } catch (err) {
-    apiError = err;
-  }
   try {
     manifestRelease = await fetchLatestReleaseFromManifest(runtime);
   } catch (err) {
     manifestError = err;
   }
-
-  const manifestComparison = apiRelease && manifestRelease
-    ? compareReleaseTags(manifestRelease.tag, apiRelease.tag)
-    : null;
-  if (apiRelease && manifestRelease && manifestComparison !== null && manifestComparison >= 0) {
-    state.releaseCache = manifestRelease;
-  } else if (apiRelease) {
-    state.releaseCache = apiRelease;
-  } else if (manifestRelease) {
+  if (manifestRelease) {
     state.releaseCache = manifestRelease;
   } else {
-    const message = apiError && apiError.rateLimited
-      ? t('editor.systemUpdates.errors.releaseRateLimited')
-      : t('editor.systemUpdates.errors.releaseFetch');
-    const error = new Error(message);
-    error.apiError = apiError;
-    error.manifestError = manifestError;
-    throw error;
+    try {
+      state.releaseCache = await fetchLatestReleaseFromApi(runtime);
+    } catch (err) {
+      apiError = err;
+      const message = apiError && apiError.rateLimited
+        ? t('editor.systemUpdates.errors.releaseRateLimited')
+        : t('editor.systemUpdates.errors.releaseFetch');
+      const error = new Error(message);
+      error.apiError = apiError;
+      error.manifestError = manifestError;
+      throw error;
+    }
   }
 
   renderRelease(runtime);

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.62",
-  "tag": "v3.4.62",
+  "version": "3.4.63",
+  "tag": "v3.4.63",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.61 <3.4.62"
+      ">=3.4.62 <3.4.63"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.61 first."
+    "message": "Update to v3.4.62 first."
   }
 }

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { webcrypto } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
+import { buildConnectStatusUrl, CONNECT_SYSTEM_RELEASE_PATH } from '../assets/js/connect-status.js?connect-status-test';
 import {
   satisfiesSemverRange,
   setPressSystemManifestForTests
@@ -315,7 +316,7 @@ await run('hides stale release notes when no Press system package is attached', 
   }), 'Use `press-system-v3.3.37.zip`.');
 });
 
-await run('uses the static manifest artifact when the GitHub API tag matches', async () => {
+await run('uses the static manifest artifact without querying GitHub API when available', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>manifest</p>' });
   const digest = await sha256(buffer);
@@ -362,23 +363,25 @@ await run('uses the static manifest artifact when the GitHub API tag matches', a
 
   await analyzeArchive(buffer, 'press-system-v3.3.5.zip');
 
-  assert.equal(apiCalls, 1);
+  assert.equal(apiCalls, 0);
   assert.equal(manifestCalls, 1);
   delete globalThis.fetch;
 });
 
-await run('uses GitHub API metadata when the static manifest is stale', async () => {
+await run('prefers manifest metadata when the GitHub API advertises a newer release', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   const oldBuffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>old</p>' });
   const newBuffer = makeZip({ 'press-system-v3.3.6/index.html': '<!doctype html><p>new</p>' });
   const oldDigest = await sha256(oldBuffer);
   const newDigest = await sha256(newBuffer);
   const oldAssetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.5/press-system-v3.3.5.zip';
+  let apiCalls = 0;
   let oldAssetCalls = 0;
 
   globalThis.fetch = async (input) => {
     const url = String(input || '');
     if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      apiCalls += 1;
       return jsonResponse({
         name: 'v3.3.6',
         tag_name: 'v3.3.6',
@@ -416,14 +419,11 @@ await run('uses GitHub API metadata when the static manifest is stale', async ()
     };
   };
 
-  await analyzeArchive(newBuffer, 'press-system-v3.3.6.zip');
+  await stageLatestSystemUpdate();
+
+  assert.equal(apiCalls, 0);
+  assert.equal(oldAssetCalls, 1);
   assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path), ['index.html']);
-  assert.equal(oldAssetCalls, 0);
-  await assert.rejects(
-    () => stageLatestSystemUpdate(),
-    /download|下载|ダウンロード/i
-  );
-  assert.equal(oldAssetCalls, 0);
   delete globalThis.fetch;
 });
 
@@ -480,6 +480,106 @@ await run('uses newer fetchable manifest metadata when the GitHub API lags', asy
 
   assert.equal(newAssetCalls, 1);
   assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path), ['index.html']);
+  delete globalThis.fetch;
+});
+
+await run('prefers the Connect system-release cache before the raw GitHub manifest', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const buffer = makeZip({ 'press-system-v3.3.7/index.html': '<!doctype html><p>connect</p>' });
+  const digest = await sha256(buffer);
+  const connectManifestUrl = buildConnectStatusUrl(CONNECT_SYSTEM_RELEASE_PATH, { windowRef: globalThis.window });
+  const assetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.7/press-system-v3.3.7.zip';
+  let connectCalls = 0;
+  let rawManifestCalls = 0;
+  let assetCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      return jsonResponse({ message: 'rate limited' }, { ok: false, status: 429 });
+    }
+    if (url === connectManifestUrl) {
+      connectCalls += 1;
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.7',
+        tag: 'v3.3.7',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Connect manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.7',
+        asset: {
+          name: 'press-system-v3.3.7.zip',
+          url: assetUrl,
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }
+      });
+    }
+    if (url === 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json') {
+      rawManifestCalls += 1;
+      return jsonResponse({ message: 'raw should not be needed' }, { ok: false, status: 500 });
+    }
+    if (url === assetUrl) {
+      assetCalls += 1;
+      return arrayBufferResponse(buffer);
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await stageLatestSystemUpdate();
+
+  assert.equal(connectCalls, 1);
+  assert.equal(rawManifestCalls, 0);
+  assert.equal(assetCalls, 1);
+  assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path), ['index.html']);
+  delete globalThis.fetch;
+});
+
+await run('refuses automatic downloads from non-canonical Press release artifact URLs', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const assetUrl = 'https://raw.githubusercontent.com/Example/Press/release-artifacts/v3.3.7/press-system-v3.3.7.zip';
+  const connectManifestUrl = buildConnectStatusUrl(CONNECT_SYSTEM_RELEASE_PATH, { windowRef: globalThis.window });
+  let assetCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      return jsonResponse({ message: 'rate limited' }, { ok: false, status: 429 });
+    }
+    if (url === connectManifestUrl || url === 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json') {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.7',
+        tag: 'v3.3.7',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.7',
+        asset: {
+          name: 'press-system-v3.3.7.zip',
+          url: assetUrl,
+          size: 123,
+          digest: `sha256:${'a'.repeat(64)}`
+        }
+      });
+    }
+    if (url === assetUrl) {
+      assetCalls += 1;
+      return arrayBufferResponse(new ArrayBuffer(0));
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await assert.rejects(
+    () => stageLatestSystemUpdate(),
+    /download|下载|ダウンロード/i
+  );
+  assert.equal(assetCalls, 0);
   delete globalThis.fetch;
 });
 
@@ -615,7 +715,7 @@ await run('downloads the manifest asset and stages system files', async () => {
   await stageLatestSystemUpdate();
 
   const files = getSystemUpdateCommitFiles();
-  assert.equal(apiCalls, 1);
+  assert.equal(apiCalls, 0);
   assert.equal(assetCalls, 1);
   assert.deepEqual(files.map((file) => file.path), ['index.html']);
   assert.equal(files[0].kind, 'system');

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -3,6 +3,7 @@ import { webcrypto } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
 import { setPressSystemManifestForTests } from '../assets/js/press-version.js';
+import { buildConnectStatusUrl, CONNECT_PRODUCT_STATE_PATH } from '../assets/js/connect-status.js?connect-status-test';
 import { PRODUCT_STATE_URL } from '../assets/js/product-state.js?product-state-test';
 
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
@@ -536,7 +537,29 @@ await run('loads and caches the product state ledger', async () => {
   assert.equal((await loadThemeManagerProductState()).status, 'ok');
   assert.equal(seen.length, 0);
   assert.equal((await loadThemeManagerProductState({ force: true })).status, 'pending');
-  assert.deepEqual(seen, [PRODUCT_STATE_URL]);
+  assert.deepEqual(seen, [buildConnectStatusUrl(CONNECT_PRODUCT_STATE_PATH, { windowRef: globalThis.window })]);
+});
+
+await run('loads product state through the Connect read-through envelope before raw GitHub state', async () => {
+  const connectProductStateUrl = buildConnectStatusUrl(CONNECT_PRODUCT_STATE_PATH, { windowRef: globalThis.window });
+  const seen = [];
+  globalThis.fetch = async (input) => {
+    const url = String(input || '').split('?')[0];
+    seen.push(url);
+    if (url === connectProductStateUrl) {
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          productState: makeProductState({ status: 'ok' })
+        })
+      };
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+  const loaded = await loadThemeManagerProductState({ force: true });
+  assert.equal(loaded.status, 'ok');
+  assert.deepEqual(seen, [connectProductStateUrl]);
 });
 
 await run('keeps theme manager usable when product state is unavailable', async () => {


### PR DESCRIPTION
## Summary

- add browser Connect status URL resolution from explicit/local editor Connect settings
- make Theme Manager product-state loading prefer Connect `/api/product-state` and fall back to raw Press product-state
- make System Updates prefer Connect `/api/press/system-release`, keep raw/GitHub fallback, and only auto-download canonical `EkilyHQ/Press` raw system ZIPs
- bump Press system metadata to `v3.4.63`

## Validation

- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-pages-workflow.sh`
- `bash scripts/test-product-state-workflow.sh`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-composer-identity-grid.js`
- `git diff --check`

## Release / Security Notes

- This is a Press system-surface change and should publish `v3.4.63` after merge.
- Connect is preferred only as a cache/status path; raw GitHub/product-state fallbacks remain available.
- Automatic system update download remains pinned to canonical `https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/vX.Y.Z/press-system-vX.Y.Z.zip` URLs.

## Review Note

Local pre-PR subagent review was triggered twice for the cross-repo Phase 4 changes; both attempts timed out before returning final findings. The initial review's package-inclusion and trust-boundary findings were addressed before this PR.
