### PR TITLE
Add Press provider adapters

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -28,6 +28,7 @@ jobs:
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs
           node scripts/test-editor-app-kernel.mjs
+          node scripts/test-provider-adapters.js
           node --experimental-default-type=module scripts/test-theme-contracts.js
           node scripts/test-release-targets.js
           node scripts/test-release-intent.js

--- a/assets/js/product-state.js
+++ b/assets/js/product-state.js
@@ -1,6 +1,7 @@
 import { buildConnectStatusUrl, CONNECT_PRODUCT_STATE_PATH } from './connect-status.js';
+import { PRESS_GITHUB_PROVIDER } from './provider-adapters.js';
 
-export const PRODUCT_STATE_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/product-state.json';
+export const PRODUCT_STATE_URL = PRESS_GITHUB_PROVIDER.productStateUrl;
 
 const PRODUCT_STATE_TYPE = 'ekily-product-state';
 const STATUS_VALUES = new Set(['ok', 'pending', 'unknown', 'drift']);

--- a/assets/js/provider-adapters.js
+++ b/assets/js/provider-adapters.js
@@ -1,0 +1,145 @@
+export const GITHUB_PROVIDER_ID = 'github';
+
+const DEFAULT_OWNER = 'EkilyHQ';
+const DEFAULT_PRESS_REPOSITORY = `${DEFAULT_OWNER}/Press`;
+const DEFAULT_THEME_CATALOG_REPOSITORY = `${DEFAULT_OWNER}/Press-Theme-Catalog`;
+const DEFAULT_RELEASE_ARTIFACTS_REF = 'release-artifacts';
+const DEFAULT_CATALOG_REF = 'main';
+
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
+function trimOrigin(value, fallback) {
+  const raw = safeString(value || fallback).trim().replace(/\/+$/u, '');
+  try {
+    return new URL(raw).origin;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function normalizeRepository(value, fallback) {
+  const raw = safeString(value || fallback).trim();
+  const parts = raw.split('/').map((part) => part.trim()).filter(Boolean);
+  if (parts.length !== 2) throw new Error(`Invalid repository: ${raw || '(empty)'}`);
+  return `${parts[0]}/${parts[1]}`;
+}
+
+function repositoryParts(repository) {
+  const [owner, name] = normalizeRepository(repository).split('/');
+  return { owner, name };
+}
+
+function normalizePath(value) {
+  const clean = safeString(value).replace(/\\+/g, '/').replace(/^\/+|\/+$/g, '');
+  if (!clean || clean.includes('\0')) return '';
+  const parts = clean.split('/');
+  if (parts.some((part) => !part || part === '.' || part === '..')) return '';
+  return parts.join('/');
+}
+
+function encodePath(value) {
+  return normalizePath(value).split('/').map(encodeURIComponent).join('/');
+}
+
+function escapeRegExp(value) {
+  return safeString(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildRawUrl({ rawBaseUrl, repository, ref, path }) {
+  const { owner, name } = repositoryParts(repository);
+  const normalizedRef = normalizePath(ref);
+  const normalizedPath = normalizePath(path);
+  if (!normalizedRef || !normalizedPath) throw new Error('Raw provider URL requires a ref and path.');
+  return `${rawBaseUrl}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/${encodePath(normalizedRef)}/${encodePath(normalizedPath)}`;
+}
+
+function buildApiUrl({ apiBaseUrl, repository, path }) {
+  const { owner, name } = repositoryParts(repository);
+  const cleanPath = normalizePath(path);
+  if (!cleanPath) throw new Error('API provider URL requires a path.');
+  return `${apiBaseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/${encodePath(cleanPath)}`;
+}
+
+function buildWebUrl({ webBaseUrl, repository, path }) {
+  const { owner, name } = repositoryParts(repository);
+  const cleanPath = normalizePath(path);
+  return `${webBaseUrl}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${cleanPath ? `/${encodePath(cleanPath)}` : ''}`;
+}
+
+function createCanonicalSystemAssetMatcher({ rawBaseUrl, pressRepository, releaseArtifactsRef }) {
+  const { owner, name } = repositoryParts(pressRepository);
+  const rawOrigin = new URL(rawBaseUrl).origin;
+  const pattern = new RegExp(
+    `^/${escapeRegExp(owner)}/${escapeRegExp(name)}/${escapeRegExp(releaseArtifactsRef)}/(v\\d+\\.\\d+\\.\\d+)/press-system-\\1\\.zip$`,
+    'i'
+  );
+  return (value) => {
+    try {
+      const url = new URL(safeString(value).trim());
+      return url.origin === rawOrigin && pattern.test(url.pathname);
+    } catch (_) {
+      return false;
+    }
+  };
+}
+
+export function createGitHubPressProvider(options = {}) {
+  const rawBaseUrl = trimOrigin(options.rawBaseUrl, 'https://raw.githubusercontent.com');
+  const apiBaseUrl = trimOrigin(options.apiBaseUrl, 'https://api.github.com');
+  const webBaseUrl = trimOrigin(options.webBaseUrl, 'https://github.com');
+  const pressRepository = normalizeRepository(options.pressRepository, DEFAULT_PRESS_REPOSITORY);
+  const themeCatalogRepository = normalizeRepository(
+    options.themeCatalogRepository,
+    DEFAULT_THEME_CATALOG_REPOSITORY
+  );
+  const releaseArtifactsRef = normalizePath(options.releaseArtifactsRef || DEFAULT_RELEASE_ARTIFACTS_REF);
+  const themeCatalogRef = normalizePath(options.themeCatalogRef || DEFAULT_CATALOG_REF);
+  const buildPressArtifactUrl = (path) => buildRawUrl({
+    rawBaseUrl,
+    repository: pressRepository,
+    ref: releaseArtifactsRef,
+    path
+  });
+  const isCanonicalSystemUpdateAssetUrl = createCanonicalSystemAssetMatcher({
+    rawBaseUrl,
+    pressRepository,
+    releaseArtifactsRef
+  });
+
+  return Object.freeze({
+    id: GITHUB_PROVIDER_ID,
+    label: 'GitHub',
+    rawBaseUrl,
+    apiBaseUrl,
+    webBaseUrl,
+    pressRepository,
+    themeCatalogRepository,
+    releaseArtifactsRef,
+    themeCatalogRef,
+    systemReleaseUrl: buildPressArtifactUrl('system-release.json'),
+    productStateUrl: buildPressArtifactUrl('product-state.json'),
+    releaseIntentUrl: buildPressArtifactUrl('release-intent.json'),
+    latestReleaseApiUrl: buildApiUrl({
+      apiBaseUrl,
+      repository: pressRepository,
+      path: 'releases/latest'
+    }),
+    latestReleasePageUrl: buildWebUrl({
+      webBaseUrl,
+      repository: pressRepository,
+      path: 'releases/latest'
+    }),
+    themeCatalogUrl: buildRawUrl({
+      rawBaseUrl,
+      repository: themeCatalogRepository,
+      ref: themeCatalogRef,
+      path: 'catalog.json'
+    }),
+    buildPressArtifactUrl,
+    isCanonicalSystemUpdateAssetUrl
+  });
+}
+
+export const PRESS_GITHUB_PROVIDER = createGitHubPressProvider();

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -3,6 +3,7 @@ import { renderPressMath } from './math-render.js';
 import { setSafeHtml } from './safe-html.js';
 import { t } from './i18n.js';
 import { buildConnectStatusUrl, CONNECT_SYSTEM_RELEASE_PATH } from './connect-status.js';
+import { PRESS_GITHUB_PROVIDER } from './provider-adapters.js';
 import {
   isUpgradeAllowed,
   loadPressSystemManifest,
@@ -22,8 +23,8 @@ const TEXT_FILENAMES = new Set(['LICENSE', 'README', 'README.md', 'CHANGELOG', '
 
 export const SYSTEM_UPDATE_ASSET_NAME_PATTERN = /^press-system-v\d+\.\d+\.\d+\.zip$/i;
 
-const RELEASE_API_URL = 'https://api.github.com/repos/EkilyHQ/Press/releases/latest';
-const RELEASE_MANIFEST_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json';
+const RELEASE_API_URL = PRESS_GITHUB_PROVIDER.latestReleaseApiUrl;
+const RELEASE_MANIFEST_URL = PRESS_GITHUB_PROVIDER.systemReleaseUrl;
 
 function createSystemUpdateElements() {
   return {
@@ -331,8 +332,7 @@ export function selectSystemUpdateAsset(releaseData) {
 }
 
 function isFetchableSystemUpdateAssetUrl(url) {
-  return /^https:\/\/raw\.githubusercontent\.com\/EkilyHQ\/Press\/release-artifacts\/v\d+\.\d+\.\d+\/press-system-v\d+\.\d+\.\d+\.zip$/i
-    .test(String(url || '').trim());
+  return PRESS_GITHUB_PROVIDER.isCanonicalSystemUpdateAssetUrl(url);
 }
 
 function isObject(value) {
@@ -639,7 +639,7 @@ function updateDownloadLink(runtime) {
   const { elements, releaseCache } = runtime.state;
   const link = elements.downloadLink;
   if (!link) return;
-  let href = 'https://github.com/EkilyHQ/Press/releases/latest';
+  let href = PRESS_GITHUB_PROVIDER.latestReleasePageUrl;
   let label = t('editor.systemUpdates.openReleasePage');
   link.removeAttribute('download');
   if (releaseCache) {

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,6 +1,7 @@
 import { t } from './i18n.js';
 import { loadPressSystemManifest, satisfiesSemverRange } from './press-version.js';
 import { getProductStateThemeEntry, loadProductState } from './product-state.js';
+import { PRESS_GITHUB_PROVIDER } from './provider-adapters.js';
 import {
   PRESS_THEME_CONTRACT,
   getDefaultThemeStyles,
@@ -17,7 +18,7 @@ import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';
 const REQUIRED_CONTRACT_VERSION = PRESS_THEME_CONTRACT.contractVersion;
-export const OFFICIAL_THEME_CATALOG_URL = 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Catalog/main/catalog.json';
+export const OFFICIAL_THEME_CATALOG_URL = PRESS_GITHUB_PROVIDER.themeCatalogUrl;
 const THEME_SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 const THEME_RELEASE_ASSET_PATTERN = /^press-theme-[a-z0-9_-]+-v\d+\.\d+\.\d+\.zip$/i;
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = new Set(getThemeArchiveAllowedExtensions());

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.63",
-  "tag": "v3.4.63",
+  "version": "3.4.64",
+  "tag": "v3.4.64",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.62 <3.4.63"
+      ">=3.4.63 <3.4.64"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.62 first."
+    "message": "Update to v3.4.63 first."
   }
 }

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -41,6 +41,7 @@ for command in \
   'node scripts/test-product-state-ledger.js' \
   'node scripts/test-composer-app-services.js' \
   'node scripts/test-composer-service-registry.js' \
+  'node scripts/test-provider-adapters.js' \
   'bash scripts/test-pages-artifact.sh'
 do
   if ! grep -F "${command}" "${workflow}" >/dev/null; then

--- a/scripts/test-provider-adapters.js
+++ b/scripts/test-provider-adapters.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import {
+  GITHUB_PROVIDER_ID,
+  PRESS_GITHUB_PROVIDER,
+  createGitHubPressProvider
+} from '../assets/js/provider-adapters.js';
+
+assert.equal(PRESS_GITHUB_PROVIDER.id, GITHUB_PROVIDER_ID);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.systemReleaseUrl,
+  'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.productStateUrl,
+  'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/product-state.json'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.releaseIntentUrl,
+  'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/release-intent.json'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.latestReleaseApiUrl,
+  'https://api.github.com/repos/EkilyHQ/Press/releases/latest'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.latestReleasePageUrl,
+  'https://github.com/EkilyHQ/Press/releases/latest'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.themeCatalogUrl,
+  'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Catalog/main/catalog.json'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.buildPressArtifactUrl('v3.4.64/press-system-v3.4.64.zip'),
+  'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.64/press-system-v3.4.64.zip'
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.isCanonicalSystemUpdateAssetUrl(
+    'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.64/press-system-v3.4.64.zip'
+  ),
+  true
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.isCanonicalSystemUpdateAssetUrl(
+    'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.64/press-system-v3.4.63.zip'
+  ),
+  false
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.isCanonicalSystemUpdateAssetUrl(
+    'https://github.com/EkilyHQ/Press/releases/download/v3.4.64/press-system-v3.4.64.zip'
+  ),
+  false
+);
+assert.equal(
+  PRESS_GITHUB_PROVIDER.isCanonicalSystemUpdateAssetUrl(
+    'https://raw.githubusercontent.com/Other/Press/release-artifacts/v3.4.64/press-system-v3.4.64.zip'
+  ),
+  false
+);
+
+const custom = createGitHubPressProvider({
+  pressRepository: 'Example/Press',
+  themeCatalogRepository: 'Example/Theme-Catalog',
+  releaseArtifactsRef: 'published',
+  themeCatalogRef: 'stable',
+  rawBaseUrl: 'https://raw.example.test/',
+  apiBaseUrl: 'https://api.example.test/',
+  webBaseUrl: 'https://git.example.test/'
+});
+assert.equal(custom.systemReleaseUrl, 'https://raw.example.test/Example/Press/published/system-release.json');
+assert.equal(custom.latestReleaseApiUrl, 'https://api.example.test/repos/Example/Press/releases/latest');
+assert.equal(custom.latestReleasePageUrl, 'https://git.example.test/Example/Press/releases/latest');
+assert.equal(custom.themeCatalogUrl, 'https://raw.example.test/Example/Theme-Catalog/stable/catalog.json');
+assert.equal(
+  custom.isCanonicalSystemUpdateAssetUrl(
+    'https://raw.example.test/Example/Press/published/v1.2.3/press-system-v1.2.3.zip'
+  ),
+  true
+);
+assert.equal(Object.isFrozen(custom), true);
+
+console.log('ok - provider adapters');

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -73,6 +73,11 @@ if ! grep -qx "press-system-${version}/assets/js/system-updates.js" "${entries_f
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/provider-adapters.js" "${entries_file}"; then
+  echo "expected package to include provider adapter code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/press-system-surface.mjs" "${entries_file}"; then
   echo "expected package to include the shared Press system surface contract" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add a GitHub Press provider adapter for release-artifacts, Product State, official theme catalog, GitHub release API, and canonical system ZIP URL checks
- route System Updates, Product State, and Theme Manager through the adapter instead of scattered provider constants
- bump Press system runtime to v3.4.64 and add provider adapter coverage to Main Guard and system package checks

## Verification
- `node scripts/test-provider-adapters.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- `node scripts/test-product-state-ledger.js`
- `bash scripts/test-product-state-workflow.sh`
- `node scripts/test-press-system-surface.mjs`
- `node scripts/test-release-intent.js && node scripts/test-dispatch-system-release.js`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `git diff --check HEAD~1..HEAD`

## Release impact
- Press system release expected: `v3.4.64`.
- Connect/YAP/theme sync behavior is unchanged, but downstream sync should converge through the existing release-intent and lockfile path.
- This is an internal provider-boundary refactor; GitHub remains the first supported provider.