### PR TITLE
Clarify composer root boundaries

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-composer-action-contract.js
+          node scripts/test-composer-root-boundaries.js
           node scripts/test-composer-app-services.js
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-composer-action-contract.js
+          node scripts/test-composer-root-boundaries.js
           node scripts/test-composer-app-services.js
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs

--- a/assets/js/composer-action-effects.js
+++ b/assets/js/composer-action-effects.js
@@ -1,0 +1,64 @@
+import { createComposerActionDispatcher } from './composer-action-dispatcher.js';
+
+export const COMPOSER_ACTION_EFFECT_SERVICES = Object.freeze([
+  'modeController',
+  'filePanelController',
+  'stateStore',
+  'yamlDraftController',
+  'diffUi',
+  'siteConfigController',
+  'unsyncedSummaryController',
+  'orderPreview',
+  'editorTree',
+  'systemThemeBridge',
+  'markdownDraftController',
+  'publishStateService'
+]);
+
+export function createComposerActionEffects(options = {}) {
+  const dispatch = createComposerActionDispatcher({
+    handlers: {
+      applyMode: ({ mode, options: actionOptions = {} }) => options.applyMode(mode, actionOptions),
+      selectComposerFile: ({ name, options: actionOptions = {} }) => options.selectComposerFile(name, actionOptions),
+      recomputeYamlDiff: ({ kind }) => options.recomputeYamlDiff(kind),
+      applyYamlDiffMarkers: ({ kind }) => options.applyYamlDiffMarkers(kind),
+      refreshFileDirtyBadges: () => options.refreshFileDirtyBadges(),
+      scheduleYamlAutoDraft: ({ kind, options: actionOptions = {} }) => {
+        if (!actionOptions.skipAutoSave) options.scheduleYamlAutoDraft(kind);
+      },
+      applySiteConfig: ({ kind }) => options.applySiteConfigForYamlChange(kind),
+      refreshUnsyncedSummary: ({ options: actionOptions = {} }) => options.refreshUnsyncedSummary(actionOptions),
+      refreshOrderPreview: ({ kind }) => options.refreshOrderPreviewForYamlChange(kind),
+      refreshEditorTree: (payload, context) => {
+        if (context && context.action && context.action.type === 'composer.yaml.changed') {
+          options.refreshEditorTree({
+            preserveStructure: options.shouldPreserveEditorStructureForMode(options.getCurrentMode())
+          });
+          return;
+        }
+        options.refreshEditorTree(payload && payload.options ? payload.options : {});
+      },
+      clearYamlDraftStorage: ({ kind }) => options.clearYamlDraftStorage(kind),
+      applyLocalPostCommitState: ({ files = [] }) => options.applyLocalPostCommitState(files)
+    },
+    availableServices: COMPOSER_ACTION_EFFECT_SERVICES
+  });
+
+  return {
+    dispatch,
+    assertReady: () => dispatch.assertReady(),
+    applyComposerFile: (name, actionOptions = {}) => dispatch.dispatch('composer.file.select', {
+      name,
+      options: { ...actionOptions, persist: false }
+    }),
+    applyLocalPostCommitState: (files = []) => dispatch.dispatch('publish.completed', { files }),
+    applyMode: (mode, actionOptions = {}) => dispatch.dispatch('composer.mode.apply', { mode, options: actionOptions }),
+    clearDraftStorage: (kind) => dispatch.dispatch('composer.yaml.draft.cleared', { kind }),
+    notifyComposerChange: (kind, actionOptions = {}) => dispatch.dispatch('composer.yaml.changed', { kind, options: actionOptions }),
+    refreshEditorContentTree: (actionOptions = {}) => dispatch.dispatch('editor.tree.refresh', { options: actionOptions }),
+    refreshMarkdownDraftState: (actionOptions = {}) => dispatch.dispatch('markdown.draft.changed', { options: actionOptions }),
+    refreshSystemThemeState: (actionOptions = {}) => dispatch.dispatch('composer.system-theme.changed', { options: actionOptions }),
+    selectComposerFile: (name, actionOptions = {}) => dispatch.dispatch('composer.file.select', { name, options: actionOptions }),
+    updateUnsyncedSummary: (actionOptions = {}) => dispatch.dispatch('composer.summary.refresh', { options: actionOptions })
+  };
+}

--- a/assets/js/composer-editor-tree-state.js
+++ b/assets/js/composer-editor-tree-state.js
@@ -1,0 +1,110 @@
+import { buildEditorContentTree } from './editor-content-tree.js';
+
+export function createComposerEditorTreeState(options = {}) {
+  const preferredLangs = Array.isArray(options.preferredLangs) ? options.preferredLangs : [];
+  const normalizeRelPath = typeof options.normalizeRelPath === 'function' ? options.normalizeRelPath : value => String(value || '').trim();
+  const treeText = typeof options.treeText === 'function' ? options.treeText : (_key, fallback) => fallback;
+  const getStateSlice = typeof options.getStateSlice === 'function' ? options.getStateSlice : () => null;
+  const readMarkdownDraftStore = typeof options.readMarkdownDraftStore === 'function' ? options.readMarkdownDraftStore : () => ({});
+  const collectDynamicMarkdownDraftStates = typeof options.collectDynamicMarkdownDraftStates === 'function' ? options.collectDynamicMarkdownDraftStates : () => new Map();
+  const getMarkdownSessionController = typeof options.getMarkdownSessionController === 'function' ? options.getMarkdownSessionController : () => null;
+  const getComposerDiff = typeof options.getComposerDiff === 'function' ? options.getComposerDiff : () => null;
+  const getRemoteBaseline = typeof options.getRemoteBaseline === 'function' ? options.getRemoteBaseline : () => null;
+  const recomputeDiff = typeof options.recomputeDiff === 'function' ? options.recomputeDiff : () => null;
+  const getComposerDraftMeta = typeof options.getComposerDraftMeta === 'function' ? options.getComposerDraftMeta : () => null;
+  const hasSystemUpdateEntries = typeof options.hasSystemUpdateEntries === 'function' ? options.hasSystemUpdateEntries : () => false;
+  const hasThemeEntries = typeof options.hasThemeEntries === 'function' ? options.hasThemeEntries : () => false;
+
+  function collectEditorDraftStatusMap() {
+    const map = new Map();
+    try {
+      const store = readMarkdownDraftStore();
+      Object.keys(store || {}).forEach((key) => {
+        const path = normalizeRelPath(key);
+        if (path && store[key] && store[key].content) map.set(path, 'saved');
+      });
+    } catch (_) {}
+    try {
+      collectDynamicMarkdownDraftStates().forEach((value, key) => {
+        if (key && value) map.set(key, value);
+      });
+    } catch (_) {}
+    return map;
+  }
+
+  function collectEditorFileStatusMap() {
+    const controller = getMarkdownSessionController();
+    return controller && typeof controller.collectFileStatusMap === 'function'
+      ? controller.collectFileStatusMap()
+      : new Map();
+  }
+
+  function collectEditorDiffStatusMap() {
+    const map = new Map();
+    const add = (id, value) => {
+      if (id && value) map.set(id, value);
+    };
+    const applyDiff = (source, diff) => {
+      if (!diff) return;
+      (diff.addedKeys || []).forEach(key => add(`${source}:${key}`, 'added'));
+      (diff.removedKeys || []).forEach(key => add(`${source}:${key}`, 'removed'));
+      Object.keys(diff.keys || {}).forEach((key) => {
+        const info = diff.keys[key] || {};
+        add(`${source}:${key}`, info.state || 'modified');
+        Object.keys(info.langs || {}).forEach((lang) => {
+          const detail = info.langs[lang] || {};
+          add(`${source}:${key}:${lang}`, detail.state || 'modified');
+        });
+      });
+    };
+    applyDiff('index', getComposerDiff('index'));
+    applyDiff('tabs', getComposerDiff('tabs'));
+    try {
+      const siteDiff = getComposerDiff('site') || recomputeDiff('site');
+      if (siteDiff && siteDiff.hasChanges) add('system:site-settings', 'modified');
+      else if (getComposerDraftMeta('site')) add('system:site-settings', 'saved');
+    } catch (_) {
+      try {
+        if (getComposerDraftMeta('site')) add('system:site-settings', 'saved');
+      } catch (__) {}
+    }
+    try {
+      if (hasSystemUpdateEntries()) add('system:updates', 'modified');
+    } catch (_) {}
+    try {
+      if (hasThemeEntries()) add('system:themes', 'modified');
+    } catch (_) {}
+    return map;
+  }
+
+  function buildCurrentEditorTree() {
+    return buildEditorContentTree({
+      index: getStateSlice('index') || { __order: [] },
+      tabs: getStateSlice('tabs') || { __order: [] }
+    }, {
+      preferredLangs,
+      welcomeLabel: treeText('welcome', 'Welcome'),
+      systemLabel: treeText('system', 'System'),
+      siteSettingsLabel: treeText('siteSettings', 'Site Settings'),
+      themesLabel: treeText('themes', 'Themes'),
+      updatesLabel: treeText('pressUpdates', 'Press Updates'),
+      syncLabel: treeText('sync', 'Publish'),
+      articlesLabel: treeText('articles', 'Articles'),
+      pagesLabel: treeText('pages', 'Pages'),
+      draftStates: collectEditorDraftStatusMap(),
+      diffStates: collectEditorDiffStatusMap(),
+      fileStates: collectEditorFileStatusMap(),
+      indexDiff: getComposerDiff('index') || null,
+      tabsDiff: getComposerDiff('tabs') || null,
+      indexBaseline: getRemoteBaseline('index') || null,
+      tabsBaseline: getRemoteBaseline('tabs') || null
+    });
+  }
+
+  return {
+    buildCurrentEditorTree,
+    collectEditorDiffStatusMap,
+    collectEditorDraftStatusMap,
+    collectEditorFileStatusMap
+  };
+}

--- a/assets/js/composer-markdown-workspace-facade.js
+++ b/assets/js/composer-markdown-workspace-facade.js
@@ -1,0 +1,71 @@
+export function createComposerMarkdownWorkspaceFacade(options = {}) {
+  const services = options.services || null;
+
+  function getMarkdownSessionController() {
+    return services.getMarkdownSessionController();
+  }
+
+  function getMarkdownActionsUi() {
+    return services.getMarkdownActionsUi();
+  }
+
+  function getMarkdownLoader() {
+    return services.getMarkdownLoader();
+  }
+
+  function getMarkdownDraftController() {
+    return services.getMarkdownDraftController();
+  }
+
+  function getMarkdownWorkspaceController() {
+    return services.getMarkdownWorkspaceController();
+  }
+
+  return {
+    getMarkdownActionsUi,
+    getMarkdownDraftController,
+    getMarkdownLoader,
+    getMarkdownSessionController,
+    getMarkdownWorkspaceController,
+    getPrimaryEditorApi: () => getMarkdownWorkspaceController().getPrimaryEditorApi(),
+    restorePrimaryEditorMarkdownView: (editorApi) => getMarkdownWorkspaceController().restorePrimaryEditorMarkdownView(editorApi),
+    ensurePrimaryEditorListener: () => getMarkdownWorkspaceController().ensurePrimaryEditorListener(),
+    ensurePrimaryEditorTabsMetadataListener: () => getMarkdownWorkspaceController().ensurePrimaryEditorTabsMetadataListener(),
+    getDynamicEditorTabs: () => getMarkdownWorkspaceController().getDynamicEditorTabs(),
+    getDynamicTabByMode: (mode) => getMarkdownWorkspaceController().getDynamicTabByMode(mode),
+    isDynamicMode: (mode) => getMarkdownWorkspaceController().isDynamicMode(mode),
+    getFirstDynamicModeId: () => getMarkdownWorkspaceController().getFirstDynamicModeId(),
+    getActiveDynamicTab: () => getMarkdownWorkspaceController().getActiveDynamicTab(),
+    activateDynamicMode: (mode) => getMarkdownWorkspaceController().activateDynamicMode(mode),
+    clearActiveDynamicMode: (mode = null) => getMarkdownWorkspaceController().clearActiveDynamicMode(mode),
+    persistDynamicEditorState: () => getMarkdownWorkspaceController().persistDynamicEditorState(),
+    restoreDynamicEditorState: () => getMarkdownWorkspaceController().restoreDynamicEditorState(),
+    setTabLoadingState: (tab, isLoading) => getMarkdownWorkspaceController().setTabLoadingState(tab, isLoading),
+    detachPrimaryEditorListeners: () => getMarkdownWorkspaceController().detachPrimaryEditorListeners(),
+    updateMarkdownActionsForTab: (tab) => getMarkdownWorkspaceController().updateMarkdownActionsForTab(tab),
+    getMarkdownPushButton: () => getMarkdownWorkspaceController().getMarkdownPushButton(),
+    getMarkdownDiscardButton: () => getMarkdownWorkspaceController().getMarkdownDiscardButton(),
+    getMarkdownSaveButton: () => getMarkdownWorkspaceController().getMarkdownSaveButton(),
+    setMarkdownPushButton: (button) => getMarkdownWorkspaceController().setMarkdownPushButton(button),
+    setMarkdownDiscardButton: (button) => getMarkdownWorkspaceController().setMarkdownDiscardButton(button),
+    setMarkdownSaveButton: (button) => getMarkdownWorkspaceController().setMarkdownSaveButton(button),
+    setMarkdownProtectionButton: (button) => getMarkdownWorkspaceController().setMarkdownProtectionButton(button),
+    getMarkdownPushLabel: (kind) => getMarkdownWorkspaceController().getMarkdownPushLabel(kind),
+    getMarkdownDiscardLabel: () => getMarkdownWorkspaceController().getMarkdownDiscardLabel(),
+    getMarkdownDiscardBusyLabel: () => getMarkdownWorkspaceController().getMarkdownDiscardBusyLabel(),
+    getMarkdownSaveLabel: () => getMarkdownWorkspaceController().getMarkdownSaveLabel(),
+    getMarkdownSaveBusyLabel: () => getMarkdownWorkspaceController().getMarkdownSaveBusyLabel(),
+    getMarkdownSaveTooltip: (kind) => getMarkdownWorkspaceController().getMarkdownSaveTooltip(kind),
+    updateMarkdownPushButton: (tab) => getMarkdownWorkspaceController().updateMarkdownPushButton(tab),
+    updateMarkdownDiscardButton: (tab) => getMarkdownWorkspaceController().updateMarkdownDiscardButton(tab),
+    updateMarkdownSaveButton: (tab) => getMarkdownWorkspaceController().updateMarkdownSaveButton(tab),
+    updateMarkdownProtectionButton: (tab) => getMarkdownWorkspaceController().updateMarkdownProtectionButton(tab),
+    pushEditorCurrentFileInfo: (tab) => getMarkdownWorkspaceController().pushEditorCurrentFileInfo(tab),
+    setDynamicTabStatus: (tab, status) => getMarkdownWorkspaceController().setDynamicTabStatus(tab, status),
+    closeDynamicTab: (modeId, closeOptions = {}) => getMarkdownWorkspaceController().closeDynamicTab(modeId, closeOptions),
+    getOrCreateDynamicMode: (path, createOptions = {}) => getMarkdownWorkspaceController().getOrCreateDynamicMode(path, createOptions),
+    loadDynamicTabContent: (tab) => getMarkdownWorkspaceController().loadDynamicTabContent(tab),
+    openMarkdownInEditor: (path, openOptions = {}) => getMarkdownWorkspaceController().openMarkdownInEditor(path, openOptions),
+    findDynamicTabByPath: (path) => getMarkdownWorkspaceController().findDynamicTabByPath(path)
+  };
+}

--- a/assets/js/composer-yaml-serialization.js
+++ b/assets/js/composer-yaml-serialization.js
@@ -1,0 +1,118 @@
+function quoteYamlScalar(value) {
+  const str = String(value ?? '');
+  return '"' + str
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/\"/g, '\\"') + '"';
+}
+
+export function createComposerYamlSerialization(options = {}) {
+  const preferredLangOrder = Array.isArray(options.preferredLangOrder) ? options.preferredLangOrder : [];
+  const normalizeLangCode = typeof options.normalizeLangCode === 'function' ? options.normalizeLangCode : value => String(value || '').trim().toLowerCase();
+  const getLanguageLabel = typeof options.getLanguageLabel === 'function' ? options.getLanguageLabel : () => '';
+  const isIndexMetadataObject = typeof options.isIndexMetadataObject === 'function' ? options.isIndexMetadataObject : value => !!value && typeof value === 'object' && !Array.isArray(value);
+  const writeYamlValue = typeof options.writeYamlValue === 'function' ? options.writeYamlValue : () => {};
+
+  function sortLangKeys(obj) {
+    const keys = Object.keys(obj || {});
+    return keys.sort((a, b) => {
+      const ia = preferredLangOrder.indexOf(normalizeLangCode(a));
+      const ib = preferredLangOrder.indexOf(normalizeLangCode(b));
+      if (ia !== -1 || ib !== -1) return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+      return a.localeCompare(b);
+    });
+  }
+
+  function displayLangName(code) {
+    const normalized = normalizeLangCode(code);
+    if (!normalized) return '';
+    try {
+      const label = getLanguageLabel(normalized);
+      if (label && String(label).trim()) return String(label).trim();
+    } catch (_) {}
+    return normalized.toUpperCase();
+  }
+
+  function langFlag(code) {
+    const c = normalizeLangCode(code);
+    if (c === 'en') return '🇺🇸';
+    if (c === 'chs') return '🇨🇳';
+    if (c === 'cht-tw') return '🇹🇼';
+    if (c === 'cht-hk') return '🇭🇰';
+    if (c === 'ja') return '🇯🇵';
+    return '';
+  }
+
+  function toIndexYaml(data) {
+    const lines = [
+      '# yaml-language-server: $schema=../assets/schema/index.json',
+      ''
+    ];
+    const keys = data.__order && Array.isArray(data.__order) ? data.__order.slice() : Object.keys(data).filter(k => k !== '__order');
+    keys.forEach(key => {
+      const entry = data[key];
+      if (!entry || typeof entry !== 'object') return;
+      lines.push(`${key}:`);
+      const langs = sortLangKeys(entry);
+      langs.forEach(lang => {
+        const v = entry[lang];
+        if (Array.isArray(v)) {
+          const hasMetadata = v.some(item => isIndexMetadataObject(item));
+          if (hasMetadata) {
+            lines.push(`  ${lang}:`);
+            writeYamlValue(lines, 2, v);
+          } else if (v.length <= 1) {
+            const one = v[0] ?? '';
+            lines.push(`  ${lang}: ${one ? one : '""'}`);
+          } else {
+            lines.push(`  ${lang}:`);
+            v.forEach(p => lines.push(`    - ${p}`));
+          }
+        } else if (typeof v === 'string') {
+          lines.push(`  ${lang}: ${v}`);
+        } else if (isIndexMetadataObject(v)) {
+          lines.push(`  ${lang}:`);
+          writeYamlValue(lines, 2, v);
+        }
+      });
+    });
+    return lines.join('\n') + '\n';
+  }
+
+  function toTabsYaml(data) {
+    const lines = [
+      '# yaml-language-server: $schema=../assets/schema/tabs.json',
+      ''
+    ];
+    const keys = data.__order && Array.isArray(data.__order) ? data.__order.slice() : Object.keys(data).filter(k => k !== '__order');
+    keys.forEach(tab => {
+      const entry = data[tab];
+      if (!entry || typeof entry !== 'object') return;
+      lines.push(`${tab}:`);
+      const langs = sortLangKeys(entry);
+      langs.forEach(lang => {
+        const v = entry[lang];
+        if (v && typeof v === 'object') {
+          const title = v.title ?? '';
+          const loc = v.location ?? '';
+          lines.push(`  ${lang}:`);
+          lines.push(`    title: ${quoteYamlScalar(title)}`);
+          lines.push(`    location: ${loc ? loc : '""'}`);
+        }
+      });
+      lines.push('');
+    });
+    while (lines.length && lines[lines.length - 1] === '') lines.pop();
+    return lines.join('\n') + '\n';
+  }
+
+  return {
+    displayLangName,
+    langFlag,
+    sortLangKeys,
+    toIndexYaml,
+    toTabsYaml
+  };
+}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -333,7 +333,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     getMarkdownDraftController,
     getMarkdownLoader,
     getMarkdownSessionController,
-    getMarkdownWorkspaceController,
     getPrimaryEditorApi,
     restorePrimaryEditorMarkdownView,
     ensurePrimaryEditorListener,
@@ -369,8 +368,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     updateMarkdownProtectionButton,
     pushEditorCurrentFileInfo,
     setDynamicTabStatus,
-    closeDynamicTab,
-    getOrCreateDynamicMode,
     loadDynamicTabContent,
     openMarkdownInEditor,
     findDynamicTabByPath

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -6,7 +6,7 @@ import {
 } from './yaml.js';
 import { escapeHtml } from './utils.js';
 import { t, getAvailableLangs, getLanguageLabel } from './i18n.js';
-import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js';
+import { findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js';
 import {
   decryptMarkdownDocument,
   encryptMarkdownDocument,
@@ -47,7 +47,10 @@ import {
 } from './composer-runtime.js';
 import { createComposerServiceRegistry } from './composer-service-registry.js';
 import { createComposerServiceLifecycle } from './composer-app-services.js';
-import { createComposerActionDispatcher } from './composer-action-dispatcher.js';
+import { createComposerActionEffects } from './composer-action-effects.js';
+import { createComposerMarkdownWorkspaceFacade } from './composer-markdown-workspace-facade.js';
+import { createComposerYamlSerialization } from './composer-yaml-serialization.js';
+import { createComposerEditorTreeState } from './composer-editor-tree-state.js';
 import { createComposerFilePanelController } from './composer-file-panel-controller.js';
 import { createComposerPublishService } from './composer-publish-service.js';
 import { createComposerNotificationController } from './composer-notifications.js';
@@ -209,6 +212,20 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   const tComposerDiff = (suffix, params) => t(`editor.composer.diff.${suffix}`, params);
   const tComposerLang = (suffix, params) => t(`editor.composer.languages.${suffix}`, params);
   const tComposerEntryRow = (suffix, params) => t(`editor.composer.entryRow.${suffix}`, params);
+  const composerYamlSerialization = createComposerYamlSerialization({
+    preferredLangOrder: PREFERRED_LANG_ORDER,
+    normalizeLangCode,
+    getLanguageLabel,
+    isIndexMetadataObject,
+    writeYamlValue
+  });
+  const {
+    displayLangName,
+    langFlag,
+    sortLangKeys,
+    toIndexYaml,
+    toTabsYaml
+  } = composerYamlSerialization;
 
   // --- Persisted UI state keys ---
   const LS_KEYS = {
@@ -308,6 +325,56 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     storageKey: MARKDOWN_DRAFT_STORAGE_KEY,
     scopeKey: scopedEditorStorageKey
   });
+  const composerServices = createComposerServiceRegistry();
+  const composerServiceLifecycle = createComposerServiceLifecycle(composerServices);
+  const markdownWorkspace = createComposerMarkdownWorkspaceFacade({ services: composerServices });
+  const {
+    getMarkdownActionsUi,
+    getMarkdownDraftController,
+    getMarkdownLoader,
+    getMarkdownSessionController,
+    getMarkdownWorkspaceController,
+    getPrimaryEditorApi,
+    restorePrimaryEditorMarkdownView,
+    ensurePrimaryEditorListener,
+    ensurePrimaryEditorTabsMetadataListener,
+    getDynamicEditorTabs,
+    getDynamicTabByMode,
+    isDynamicMode,
+    getFirstDynamicModeId,
+    getActiveDynamicTab,
+    activateDynamicMode,
+    clearActiveDynamicMode,
+    persistDynamicEditorState,
+    restoreDynamicEditorState,
+    setTabLoadingState,
+    detachPrimaryEditorListeners,
+    updateMarkdownActionsForTab,
+    getMarkdownPushButton,
+    getMarkdownDiscardButton,
+    getMarkdownSaveButton,
+    setMarkdownPushButton,
+    setMarkdownDiscardButton,
+    setMarkdownSaveButton,
+    setMarkdownProtectionButton,
+    getMarkdownPushLabel,
+    getMarkdownDiscardLabel,
+    getMarkdownDiscardBusyLabel,
+    getMarkdownSaveLabel,
+    getMarkdownSaveBusyLabel,
+    getMarkdownSaveTooltip,
+    updateMarkdownPushButton,
+    updateMarkdownDiscardButton,
+    updateMarkdownSaveButton,
+    updateMarkdownProtectionButton,
+    pushEditorCurrentFileInfo,
+    setDynamicTabStatus,
+    closeDynamicTab,
+    getOrCreateDynamicMode,
+    loadDynamicTabContent,
+    openMarkdownInEditor,
+    findDynamicTabByPath
+  } = markdownWorkspace;
   const markdownAssetManager = createComposerMarkdownAssetManager({
     t,
     normalizeRelPath,
@@ -353,10 +420,8 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     getStateSlice,
     setStateSlice,
     notifyComposerChange,
-    updateUnsyncedSummary: () => composerActions.dispatch('composer.system-theme.changed', {
-      options: { preserveStructure: true }
-    }),
-    refreshEditorContentTree: (options) => composerActions.dispatch('editor.tree.refresh', { options })
+    updateUnsyncedSummary: () => composerActions.refreshSystemThemeState({ preserveStructure: true }),
+    refreshEditorContentTree: (options) => composerActions.refreshEditorContentTree(options)
   });
   const composerPublishStateService = createComposerPublishStateService({
     safeString,
@@ -427,8 +492,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     updateUnsyncedSummary,
     registerExternalStagingProviders: (registry) => composerSystemThemeBridge.registerStagingProviders(registry)
   });
-  const composerServices = createComposerServiceRegistry();
-  const composerServiceLifecycle = createComposerServiceLifecycle(composerServices);
   const editorSessionStateStore = createEditorSessionStateStore({
     storage: editorRuntime.storage,
     scopeKey: scopedEditorStorageKey,
@@ -460,9 +523,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     updateMarkdownPushButton,
     updateComposerMarkdownDraftIndicators,
     refreshEditorContentTree: () => {},
-    updateUnsyncedSummary: () => composerActions.dispatch('markdown.draft.changed', {
-      options: { preserveStructure: true }
-    }),
+    updateUnsyncedSummary: () => composerActions.refreshMarkdownDraftState({ preserveStructure: true }),
     showToast,
     t,
     consoleRef: composerLogger,
@@ -1015,10 +1076,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     };
   }
 
-  function getMarkdownDraftController() {
-    return composerServices.getMarkdownDraftController();
-  }
-
   function readMarkdownDraftStore() {
     return getMarkdownDraftController().readDraftStore();
   }
@@ -1263,11 +1320,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function updateUnsyncedSummary(options = {}) {
-    return composerActions.dispatch('composer.summary.refresh', { options });
-  }
-
-  function findDynamicTabByPath(path) {
-    return getMarkdownWorkspaceController().findDynamicTabByPath(path);
+    return composerActions.updateUnsyncedSummary(options);
   }
 
   async function gatherCommitPayload(options = {}) {
@@ -1282,7 +1335,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function applyLocalPostCommitState(files = []) {
-    return composerActions.dispatch('publish.completed', { files });
+    return composerActions.applyLocalPostCommitState(files);
   }
 
   function rawApplyLocalPostCommitState(files = []) {
@@ -1580,110 +1633,30 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     handleRefresh: handleComposerRefresh
   } = composerYamlActions;
 
-  const composerActions = createComposerActionDispatcher({
-    handlers: {
-      applyMode: ({ mode, options = {} }) => rawApplyMode(mode, options),
-      selectComposerFile: ({ name, options = {} }) => rawSelectComposerFile(name, options),
-      recomputeYamlDiff: ({ kind }) => rawRecomputeYamlDiff(kind),
-      applyYamlDiffMarkers: ({ kind }) => rawApplyYamlDiffMarkers(kind),
-      refreshFileDirtyBadges: () => refreshFileDirtyBadges(),
-      scheduleYamlAutoDraft: ({ kind, options = {} }) => {
-        if (!options.skipAutoSave) rawScheduleYamlAutoDraft(kind);
-      },
-      applySiteConfig: ({ kind }) => rawApplySiteConfigForYamlChange(kind),
-      refreshUnsyncedSummary: ({ options = {} }) => rawUpdateUnsyncedSummary(options),
-      refreshOrderPreview: ({ kind }) => rawRefreshOrderPreviewForYamlChange(kind),
-      refreshEditorTree: (payload, context) => {
-        if (context && context.action && context.action.type === 'composer.yaml.changed') {
-          rawRefreshEditorContentTree({
-            preserveStructure: shouldPreserveEditorStructureForMode(getCurrentComposerMode())
-          });
-          return;
-        }
-        rawRefreshEditorContentTree(payload && payload.options ? payload.options : {});
-      },
-      clearYamlDraftStorage: ({ kind }) => rawClearDraftStorage(kind),
-      applyLocalPostCommitState: ({ files = [] }) => rawApplyLocalPostCommitState(files)
-    },
-    availableServices: [
-      'modeController',
-      'filePanelController',
-      'stateStore',
-      'yamlDraftController',
-      'diffUi',
-      'siteConfigController',
-      'unsyncedSummaryController',
-      'orderPreview',
-      'editorTree',
-      'systemThemeBridge',
-      'markdownDraftController',
-      'publishStateService'
-    ]
+  const composerActions = createComposerActionEffects({
+    applyMode: rawApplyMode,
+    selectComposerFile: rawSelectComposerFile,
+    recomputeYamlDiff: rawRecomputeYamlDiff,
+    applyYamlDiffMarkers: rawApplyYamlDiffMarkers,
+    refreshFileDirtyBadges,
+    scheduleYamlAutoDraft: rawScheduleYamlAutoDraft,
+    applySiteConfigForYamlChange: rawApplySiteConfigForYamlChange,
+    refreshUnsyncedSummary: rawUpdateUnsyncedSummary,
+    refreshOrderPreviewForYamlChange: rawRefreshOrderPreviewForYamlChange,
+    refreshEditorTree: rawRefreshEditorContentTree,
+    clearYamlDraftStorage: rawClearDraftStorage,
+    applyLocalPostCommitState: rawApplyLocalPostCommitState,
+    getCurrentMode: getCurrentComposerMode,
+    shouldPreserveEditorStructureForMode
   });
 
   function clearDraftStorage(kind) {
-    return composerActions.dispatch('composer.yaml.draft.cleared', { kind });
+    return composerActions.clearDraftStorage(kind);
   }
 
   function notifyComposerChange(kind, options = {}) {
-    return composerActions.dispatch('composer.yaml.changed', { kind, options });
+    return composerActions.notifyComposerChange(kind, options);
   }
-
-  function getMarkdownSessionController() {
-    return composerServices.getMarkdownSessionController();
-  }
-
-  function getMarkdownActionsUi() {
-    return composerServices.getMarkdownActionsUi();
-  }
-
-  function getMarkdownLoader() {
-    return composerServices.getMarkdownLoader();
-  }
-
-  function getMarkdownWorkspaceController() {
-    return composerServices.getMarkdownWorkspaceController();
-  }
-
-  function getPrimaryEditorApi() { return getMarkdownWorkspaceController().getPrimaryEditorApi(); }
-  function restorePrimaryEditorMarkdownView(editorApi) { getMarkdownWorkspaceController().restorePrimaryEditorMarkdownView(editorApi); }
-  function ensurePrimaryEditorListener() { getMarkdownWorkspaceController().ensurePrimaryEditorListener(); }
-  function ensurePrimaryEditorTabsMetadataListener() { getMarkdownWorkspaceController().ensurePrimaryEditorTabsMetadataListener(); }
-  function getDynamicEditorTabs() { return getMarkdownWorkspaceController().getDynamicEditorTabs(); }
-  function getDynamicTabByMode(mode) { return getMarkdownWorkspaceController().getDynamicTabByMode(mode); }
-  function isDynamicMode(mode) { return getMarkdownWorkspaceController().isDynamicMode(mode); }
-  function getFirstDynamicModeId() { return getMarkdownWorkspaceController().getFirstDynamicModeId(); }
-  function getActiveDynamicTab() { return getMarkdownWorkspaceController().getActiveDynamicTab(); }
-  function activateDynamicMode(mode) { return getMarkdownWorkspaceController().activateDynamicMode(mode); }
-  function clearActiveDynamicMode(mode = null) { getMarkdownWorkspaceController().clearActiveDynamicMode(mode); }
-  function persistDynamicEditorState() { return getMarkdownWorkspaceController().persistDynamicEditorState(); }
-  function restoreDynamicEditorState() { return getMarkdownWorkspaceController().restoreDynamicEditorState(); }
-  function setTabLoadingState(tab, isLoading) { getMarkdownWorkspaceController().setTabLoadingState(tab, isLoading); }
-  function detachPrimaryEditorListeners() { getMarkdownWorkspaceController().detachPrimaryEditorListeners(); }
-  function updateMarkdownActionsForTab(tab) { getMarkdownWorkspaceController().updateMarkdownActionsForTab(tab); }
-  function getMarkdownPushButton() { return getMarkdownWorkspaceController().getMarkdownPushButton(); }
-  function getMarkdownDiscardButton() { return getMarkdownWorkspaceController().getMarkdownDiscardButton(); }
-  function getMarkdownSaveButton() { return getMarkdownWorkspaceController().getMarkdownSaveButton(); }
-  function setMarkdownPushButton(button) { getMarkdownWorkspaceController().setMarkdownPushButton(button); }
-  function setMarkdownDiscardButton(button) { getMarkdownWorkspaceController().setMarkdownDiscardButton(button); }
-  function setMarkdownSaveButton(button) { getMarkdownWorkspaceController().setMarkdownSaveButton(button); }
-  function setMarkdownProtectionButton(button) { getMarkdownWorkspaceController().setMarkdownProtectionButton(button); }
-  function getMarkdownPushLabel(kind) { return getMarkdownWorkspaceController().getMarkdownPushLabel(kind); }
-  function getMarkdownDiscardLabel() { return getMarkdownWorkspaceController().getMarkdownDiscardLabel(); }
-  function getMarkdownDiscardBusyLabel() { return getMarkdownWorkspaceController().getMarkdownDiscardBusyLabel(); }
-  function getMarkdownSaveLabel() { return getMarkdownWorkspaceController().getMarkdownSaveLabel(); }
-  function getMarkdownSaveBusyLabel() { return getMarkdownWorkspaceController().getMarkdownSaveBusyLabel(); }
-  function getMarkdownSaveTooltip(kind) { return getMarkdownWorkspaceController().getMarkdownSaveTooltip(kind); }
-  function updateMarkdownPushButton(tab) { getMarkdownWorkspaceController().updateMarkdownPushButton(tab); }
-  function updateMarkdownDiscardButton(tab) { getMarkdownWorkspaceController().updateMarkdownDiscardButton(tab); }
-  function updateMarkdownSaveButton(tab) { getMarkdownWorkspaceController().updateMarkdownSaveButton(tab); }
-  function updateMarkdownProtectionButton(tab) { getMarkdownWorkspaceController().updateMarkdownProtectionButton(tab); }
-  function pushEditorCurrentFileInfo(tab) { getMarkdownWorkspaceController().pushEditorCurrentFileInfo(tab); }
-  function setDynamicTabStatus(tab, status) { return getMarkdownWorkspaceController().setDynamicTabStatus(tab, status); }
-  async function closeDynamicTab(modeId, options = {}) { return getMarkdownWorkspaceController().closeDynamicTab(modeId, options); }
-  function getOrCreateDynamicMode(path, options = {}) { return getMarkdownWorkspaceController().getOrCreateDynamicMode(path, options); }
-  async function loadDynamicTabContent(tab) { return getMarkdownWorkspaceController().loadDynamicTabContent(tab); }
-  function openMarkdownInEditor(path, options = {}) { return getMarkdownWorkspaceController().openMarkdownInEditor(path, options); }
 
   function getTrackedPublishContentRoot() {
     return composerPublishStateService.getTrackedPublishContentRoot();
@@ -1694,7 +1667,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function applyMode(mode, options = {}) {
-    return composerActions.dispatch('composer.mode.apply', { mode, options });
+    return composerActions.applyMode(mode, options);
   }
 
   function getInitialComposerFile() {
@@ -1709,10 +1682,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function applyComposerFile(name, options = {}) {
-    return composerActions.dispatch('composer.file.select', {
-      name,
-      options: { ...options, persist: false }
-    });
+    return composerActions.applyComposerFile(name, options);
   }
 
   // Apply initial state as early as possible to avoid flash on reload
@@ -1727,112 +1697,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     return editorRuntime.writeClipboardText(text);
   }
 
-  function sortLangKeys(obj) {
-    const keys = Object.keys(obj || {});
-    return keys.sort((a, b) => {
-      const ia = PREFERRED_LANG_ORDER.indexOf(normalizeLangCode(a));
-      const ib = PREFERRED_LANG_ORDER.indexOf(normalizeLangCode(b));
-      if (ia !== -1 || ib !== -1) return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
-      return a.localeCompare(b);
-    });
-  }
-
-  // Localized display names for languages in UI menus
-  function displayLangName(code) {
-    const normalized = normalizeLangCode(code);
-    if (!normalized) return '';
-    try {
-      const label = getLanguageLabel(normalized);
-      if (label && String(label).trim()) return String(label).trim();
-    } catch (_) {}
-    return normalized.toUpperCase();
-  }
-
-  function langFlag(code) {
-    const c = normalizeLangCode(code);
-    if (c === 'en') return '🇺🇸';
-    if (c === 'chs') return '🇨🇳';
-    if (c === 'cht-tw') return '🇹🇼';
-    if (c === 'cht-hk') return '🇭🇰';
-    if (c === 'ja') return '🇯🇵';
-    return '';
-  }
-
-  function q(s) {
-    // Double-quoted YAML scalar with basic escapes
-    const str = String(s ?? '');
-    return '"' + str
-      .replace(/\\/g, '\\\\')
-      .replace(/\n/g, '\\n')
-      .replace(/\r/g, '\\r')
-      .replace(/\t/g, '\\t')
-      .replace(/\"/g, '\\"') + '"';
-  }
-
-  function toIndexYaml(data) {
-    const lines = [
-      '# yaml-language-server: $schema=../assets/schema/index.json',
-      ''
-    ];
-    const keys = data.__order && Array.isArray(data.__order) ? data.__order.slice() : Object.keys(data).filter(k => k !== '__order');
-    keys.forEach(key => {
-      const entry = data[key];
-      if (!entry || typeof entry !== 'object') return;
-      lines.push(`${key}:`);
-      const langs = sortLangKeys(entry);
-      langs.forEach(lang => {
-        const v = entry[lang];
-        if (Array.isArray(v)) {
-          const hasMetadata = v.some(item => isIndexMetadataObject(item));
-          if (hasMetadata) {
-            lines.push(`  ${lang}:`);
-            writeYamlValue(lines, 2, v);
-          } else if (v.length <= 1) {
-            const one = v[0] ?? '';
-            lines.push(`  ${lang}: ${one ? one : '""'}`);
-          } else {
-            lines.push(`  ${lang}:`);
-            v.forEach(p => lines.push(`    - ${p}`));
-          }
-        } else if (typeof v === 'string') {
-          lines.push(`  ${lang}: ${v}`);
-        } else if (isIndexMetadataObject(v)) {
-          lines.push(`  ${lang}:`);
-          writeYamlValue(lines, 2, v);
-        }
-      });
-    });
-    return lines.join('\n') + '\n';
-  }
-
-  function toTabsYaml(data) {
-    const lines = [
-      '# yaml-language-server: $schema=../assets/schema/tabs.json',
-      ''
-    ];
-    const keys = data.__order && Array.isArray(data.__order) ? data.__order.slice() : Object.keys(data).filter(k => k !== '__order');
-    keys.forEach(tab => {
-      const entry = data[tab];
-      if (!entry || typeof entry !== 'object') return;
-      lines.push(`${tab}:`);
-      const langs = sortLangKeys(entry);
-      langs.forEach(lang => {
-        const v = entry[lang];
-        if (v && typeof v === 'object') {
-          const title = v.title ?? '';
-          const loc = v.location ?? '';
-          lines.push(`  ${lang}:`);
-          lines.push(`    title: ${q(title)}`);
-          lines.push(`    location: ${loc ? loc : '""'}`);
-        }
-      });
-      lines.push('');
-    });
-    // Remove extra trailing blank line
-    while (lines.length && lines[lines.length - 1] === '') lines.pop();
-    return lines.join('\n') + '\n';
-  }
-
   function treeText(key, fallback, params) {
     const fullKey = `editor.tree.${key}`;
     const value = t(fullKey, params);
@@ -1844,6 +1708,25 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     const value = t(fullKey, params);
     return value && value !== fullKey ? value : fallback;
   }
+
+  const composerEditorTreeState = createComposerEditorTreeState({
+    preferredLangs: PREFERRED_LANG_ORDER,
+    normalizeRelPath,
+    treeText,
+    getStateSlice,
+    readMarkdownDraftStore,
+    collectDynamicMarkdownDraftStates,
+    getMarkdownSessionController,
+    getComposerDiff: (kind) => composerStateStore.getDiff(kind),
+    getRemoteBaseline: (kind) => composerStateStore.getRemoteBaseline(kind),
+    recomputeDiff,
+    getComposerDraftMeta,
+    hasSystemUpdateEntries: () => composerSystemThemeBridge.hasSystemUpdateEntries(),
+    hasThemeEntries: () => composerSystemThemeBridge.hasThemeEntries()
+  });
+  const {
+    buildCurrentEditorTree
+  } = composerEditorTreeState;
 
   const editorFileTreeUi = createEditorFileTreeUi({
     documentRef: composerDocument,
@@ -1900,89 +1783,6 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     restoreDeletedEditorTreeNode: (node) => restoreDeletedEditorTreeNode(node)
   });
 
-  function collectEditorDraftStatusMap() {
-    const map = new Map();
-    try {
-      const store = readMarkdownDraftStore();
-      Object.keys(store || {}).forEach((key) => {
-        const path = normalizeRelPath(key);
-        if (path && store[key] && store[key].content) map.set(path, 'saved');
-      });
-    } catch (_) {}
-    try {
-      collectDynamicMarkdownDraftStates().forEach((value, key) => {
-        if (key && value) map.set(key, value);
-      });
-    } catch (_) {}
-    return map;
-  }
-
-  function collectEditorFileStatusMap() {
-    return getMarkdownSessionController().collectFileStatusMap();
-  }
-
-  function collectEditorDiffStatusMap() {
-    const map = new Map();
-    const add = (id, value) => {
-      if (id && value) map.set(id, value);
-    };
-    const applyDiff = (source, diff) => {
-      if (!diff) return;
-      (diff.addedKeys || []).forEach(key => add(`${source}:${key}`, 'added'));
-      (diff.removedKeys || []).forEach(key => add(`${source}:${key}`, 'removed'));
-      Object.keys(diff.keys || {}).forEach((key) => {
-        const info = diff.keys[key] || {};
-        add(`${source}:${key}`, info.state || 'modified');
-        Object.keys(info.langs || {}).forEach((lang) => {
-          const detail = info.langs[lang] || {};
-          add(`${source}:${key}:${lang}`, detail.state || 'modified');
-        });
-      });
-    };
-    applyDiff('index', composerStateStore.getDiff('index'));
-    applyDiff('tabs', composerStateStore.getDiff('tabs'));
-    try {
-      const siteDiff = composerStateStore.getDiff('site') || recomputeDiff('site');
-      if (siteDiff && siteDiff.hasChanges) add('system:site-settings', 'modified');
-      else if (getComposerDraftMeta('site')) add('system:site-settings', 'saved');
-    } catch (_) {
-      try {
-        if (getComposerDraftMeta('site')) add('system:site-settings', 'saved');
-      } catch (__) {}
-    }
-    try {
-      if (composerSystemThemeBridge.hasSystemUpdateEntries()) add('system:updates', 'modified');
-    } catch (_) {}
-    try {
-      if (composerSystemThemeBridge.hasThemeEntries()) add('system:themes', 'modified');
-    } catch (_) {}
-    return map;
-  }
-
-  function buildCurrentEditorTree() {
-    return buildEditorContentTree({
-      index: getStateSlice('index') || { __order: [] },
-      tabs: getStateSlice('tabs') || { __order: [] }
-    }, {
-      preferredLangs: PREFERRED_LANG_ORDER,
-      welcomeLabel: treeText('welcome', 'Welcome'),
-      systemLabel: treeText('system', 'System'),
-      siteSettingsLabel: treeText('siteSettings', 'Site Settings'),
-      themesLabel: treeText('themes', 'Themes'),
-      updatesLabel: treeText('pressUpdates', 'Press Updates'),
-      syncLabel: treeText('sync', 'Publish'),
-      articlesLabel: treeText('articles', 'Articles'),
-      pagesLabel: treeText('pages', 'Pages'),
-      draftStates: collectEditorDraftStatusMap(),
-      diffStates: collectEditorDiffStatusMap(),
-      fileStates: collectEditorFileStatusMap(),
-      indexDiff: composerStateStore.getDiff('index') || null,
-      tabsDiff: composerStateStore.getDiff('tabs') || null,
-      indexBaseline: composerStateStore.getRemoteBaseline('index') || null,
-      tabsBaseline: composerStateStore.getRemoteBaseline('tabs') || null
-    });
-  }
-
   function getActiveEditorTreeNode() {
     return editorContentTreeController.getActiveNode();
   }
@@ -2024,7 +1824,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   }
 
   function refreshEditorContentTree(options = {}) {
-    return composerActions.dispatch('editor.tree.refresh', { options });
+    return composerActions.refreshEditorContentTree(options);
   }
 
   function handleEditorTreeSelection(nodeId) {
@@ -2136,7 +1936,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
           applyMode,
           initSystemThemeBridge: () => composerSystemThemeBridge.init(),
           setComposerFile: (name, options = {}) => {
-            composerActions.dispatch('composer.file.select', { name, options });
+            composerActions.selectComposerFile(name, options);
           },
           getInitialComposerFile,
           getActiveComposerFile,

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.108",
-  "tag": "v3.4.108",
+  "version": "3.4.109",
+  "tag": "v3.4.109",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.107 <3.4.108"
+      ">=3.4.108 <3.4.109"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.107 first."
+    "message": "Update to v3.4.108 first."
   }
 }

--- a/scripts/test-composer-action-contract.js
+++ b/scripts/test-composer-action-contract.js
@@ -9,9 +9,14 @@ import {
   validateComposerActionPlan
 } from '../assets/js/composer-action-contract.js';
 import { createComposerActionDispatcher } from '../assets/js/composer-action-dispatcher.js';
+import {
+  COMPOSER_ACTION_EFFECT_SERVICES,
+  createComposerActionEffects
+} from '../assets/js/composer-action-effects.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const composerSource = readFileSync(resolve(here, '../assets/js/composer.js'), 'utf8');
+const composerActionEffectsSource = readFileSync(resolve(here, '../assets/js/composer-action-effects.js'), 'utf8');
 
 assert.deepEqual(
   validateComposerActionPlan(),
@@ -151,34 +156,110 @@ assert.deepEqual(
   );
 }
 
+{
+  const calls = [];
+  const actionEffects = createComposerActionEffects({
+    applyMode: (mode, options = {}) => calls.push(['applyMode', mode, options]),
+    selectComposerFile: (name, options = {}) => calls.push(['selectComposerFile', name, options]),
+    recomputeYamlDiff: (kind) => calls.push(['recomputeYamlDiff', kind]),
+    applyYamlDiffMarkers: (kind) => calls.push(['applyYamlDiffMarkers', kind]),
+    refreshFileDirtyBadges: () => calls.push(['refreshFileDirtyBadges']),
+    scheduleYamlAutoDraft: (kind) => calls.push(['scheduleYamlAutoDraft', kind]),
+    applySiteConfigForYamlChange: (kind) => calls.push(['applySiteConfigForYamlChange', kind]),
+    refreshUnsyncedSummary: (options = {}) => calls.push(['refreshUnsyncedSummary', options]),
+    refreshOrderPreviewForYamlChange: (kind) => calls.push(['refreshOrderPreviewForYamlChange', kind]),
+    refreshEditorTree: (options = {}) => calls.push(['refreshEditorTree', options]),
+    clearYamlDraftStorage: (kind) => calls.push(['clearYamlDraftStorage', kind]),
+    applyLocalPostCommitState: (files = []) => calls.push(['applyLocalPostCommitState', files]),
+    getCurrentMode: () => 'editor',
+    shouldPreserveEditorStructureForMode: (mode) => mode === 'editor'
+  });
+  assert.equal(actionEffects.assertReady(), true);
+  assert.deepEqual(COMPOSER_ACTION_EFFECT_SERVICES, [
+    'modeController',
+    'filePanelController',
+    'stateStore',
+    'yamlDraftController',
+    'diffUi',
+    'siteConfigController',
+    'unsyncedSummaryController',
+    'orderPreview',
+    'editorTree',
+    'systemThemeBridge',
+    'markdownDraftController',
+    'publishStateService'
+  ]);
+
+  actionEffects.notifyComposerChange('site', { skipAutoSave: true });
+  assert.deepEqual(
+    calls.map(call => call[0]),
+    [
+      'recomputeYamlDiff',
+      'applyYamlDiffMarkers',
+      'refreshFileDirtyBadges',
+      'applySiteConfigForYamlChange',
+      'refreshUnsyncedSummary',
+      'refreshOrderPreviewForYamlChange',
+      'refreshEditorTree'
+    ],
+    'action effects should preserve the YAML change order while honoring skipAutoSave'
+  );
+  assert.deepEqual(calls.at(-1), ['refreshEditorTree', { preserveStructure: true }]);
+  calls.length = 0;
+
+  actionEffects.applyComposerFile('tabs', { immediate: true });
+  assert.deepEqual(calls, [['selectComposerFile', 'tabs', { immediate: true, persist: false }]]);
+  calls.length = 0;
+
+  actionEffects.selectComposerFile('index', { force: true });
+  assert.deepEqual(calls, [['selectComposerFile', 'index', { force: true }]]);
+  calls.length = 0;
+
+  actionEffects.clearDraftStorage('site');
+  assert.deepEqual(calls, [
+    ['clearYamlDraftStorage', 'site'],
+    ['refreshUnsyncedSummary', {}]
+  ]);
+}
+
 assert.match(
-  composerSource,
+  composerActionEffectsSource,
   /import \{ createComposerActionDispatcher \} from '\.\/composer-action-dispatcher\.js';/,
-  'composer should construct the action dispatcher'
+  'action effects boundary should construct the action dispatcher'
 );
 assert.match(
   composerSource,
-  /function notifyComposerChange\(kind, options = \{\}\) \{\s*return composerActions\.dispatch\('composer\.yaml\.changed'/,
+  /import \{ createComposerActionEffects \} from '\.\/composer-action-effects\.js';/,
+  'composer should import the action effects boundary'
+);
+assert.doesNotMatch(
+  composerSource,
+  /createComposerActionDispatcher|composerActions\.dispatch\('/,
+  'composer root should not construct the dispatcher or dispatch action strings directly'
+);
+assert.match(
+  composerSource,
+  /function notifyComposerChange\(kind, options = \{\}\) \{\s*return composerActions\.notifyComposerChange\(kind, options\);/,
   'YAML changes should dispatch the explicit action contract'
 );
 assert.match(
   composerSource,
-  /function applyMode\(mode, options = \{\}\) \{\s*return composerActions\.dispatch\('composer\.mode\.apply'/,
+  /function applyMode\(mode, options = \{\}\) \{\s*return composerActions\.applyMode\(mode, options\);/,
   'mode changes should dispatch the explicit action contract'
 );
 assert.match(
   composerSource,
-  /function applyLocalPostCommitState\(files = \[\]\) \{\s*return composerActions\.dispatch\('publish\.completed'/,
+  /function applyLocalPostCommitState\(files = \[\]\) \{\s*return composerActions\.applyLocalPostCommitState\(files\);/,
   'publish completion should dispatch the explicit action contract'
 );
 assert.match(
   composerSource,
-  /function updateUnsyncedSummary\(options = \{\}\) \{\s*return composerActions\.dispatch\('composer\.summary\.refresh'/,
+  /function updateUnsyncedSummary\(options = \{\}\) \{\s*return composerActions\.updateUnsyncedSummary\(options\);/,
   'summary refresh should dispatch the explicit action contract'
 );
 assert.match(
   composerSource,
-  /function refreshEditorContentTree\(options = \{\}\) \{\s*return composerActions\.dispatch\('editor\.tree\.refresh'/,
+  /function refreshEditorContentTree\(options = \{\}\) \{\s*return composerActions\.refreshEditorContentTree\(options\);/,
   'editor tree refresh should dispatch the explicit action contract'
 );
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -67,6 +67,7 @@ const composerBootstrapPath = resolve(here, '../assets/js/composer-bootstrap.js'
 const composerRuntimePath = resolve(here, '../assets/js/composer-runtime.js');
 const composerServiceRegistryPath = resolve(here, '../assets/js/composer-service-registry.js');
 const composerAppServicesPath = resolve(here, '../assets/js/composer-app-services.js');
+const composerEditorTreeStatePath = resolve(here, '../assets/js/composer-editor-tree-state.js');
 const composerFilePanelControllerPath = resolve(here, '../assets/js/composer-file-panel-controller.js');
 const composerEditorDetailPanelControllerPath = resolve(here, '../assets/js/composer-editor-detail-panel-controller.js');
 const composerUiMotionPath = resolve(here, '../assets/js/composer-ui-motion.js');
@@ -232,6 +233,7 @@ const composerBootstrapSource = readFileSync(composerBootstrapPath, 'utf8');
 const composerRuntimeSource = readFileSync(composerRuntimePath, 'utf8');
 const composerServiceRegistrySource = readFileSync(composerServiceRegistryPath, 'utf8');
 const composerAppServicesSource = readFileSync(composerAppServicesPath, 'utf8');
+const composerEditorTreeStateSource = readFileSync(composerEditorTreeStatePath, 'utf8');
 const composerFilePanelControllerSource = readFileSync(composerFilePanelControllerPath, 'utf8');
 const composerEditorDetailPanelControllerSource = readFileSync(composerEditorDetailPanelControllerPath, 'utf8');
 const composerUiMotionSource = readFileSync(composerUiMotionPath, 'utf8');
@@ -1900,7 +1902,7 @@ assert.match(
 
 assert.match(
   source,
-  /function rawApplyMode\(mode, options = \{\}\) \{\s*composerServices\.applyMode\(mode, options\);\s*\}[\s\S]*function applyMode\(mode, options = \{\}\) \{\s*return composerActions\.dispatch\('composer\.mode\.apply', \{ mode, options \}\);[\s\S]*\}/,
+  /function rawApplyMode\(mode, options = \{\}\) \{\s*composerServices\.applyMode\(mode, options\);\s*\}[\s\S]*function applyMode\(mode, options = \{\}\) \{\s*return composerActions\.applyMode\(mode, options\);[\s\S]*\}/,
   'composer applyMode should delegate through the explicit action contract into the service registry'
 );
 
@@ -1936,7 +1938,7 @@ assert.match(
 
 assert.match(
   source,
-  /function collectUnsyncedMarkdownEntries\(\) \{\s*return getUnsyncedSummaryController\(\)\.collectUnsyncedMarkdownEntries\(\);\s*\}[\s\S]*function computeUnsyncedSummary\(\) \{\s*return getUnsyncedSummaryController\(\)\.computeUnsyncedSummary\(\);\s*\}[\s\S]*function updateModeDirtyIndicators\(summaryEntries\) \{\s*getUnsyncedSummaryController\(\)\.updateModeDirtyIndicators\(summaryEntries\);\s*\}[\s\S]*function rawUpdateUnsyncedSummary\(options = \{\}\) \{\s*return getUnsyncedSummaryController\(\)\.updateUnsyncedSummary\(options\);\s*\}[\s\S]*function updateUnsyncedSummary\(options = \{\}\) \{\s*return composerActions\.dispatch\('composer\.summary\.refresh', \{ options \}\);[\s\S]*\}/,
+  /function collectUnsyncedMarkdownEntries\(\) \{\s*return getUnsyncedSummaryController\(\)\.collectUnsyncedMarkdownEntries\(\);\s*\}[\s\S]*function computeUnsyncedSummary\(\) \{\s*return getUnsyncedSummaryController\(\)\.computeUnsyncedSummary\(\);\s*\}[\s\S]*function updateModeDirtyIndicators\(summaryEntries\) \{\s*getUnsyncedSummaryController\(\)\.updateModeDirtyIndicators\(summaryEntries\);\s*\}[\s\S]*function rawUpdateUnsyncedSummary\(options = \{\}\) \{\s*return getUnsyncedSummaryController\(\)\.updateUnsyncedSummary\(options\);\s*\}[\s\S]*function updateUnsyncedSummary\(options = \{\}\) \{\s*return composerActions\.updateUnsyncedSummary\(options\);[\s\S]*\}/,
   'composer unsynced summary helpers should route public refreshes through the action contract and keep raw updates on the extracted controller'
 );
 
@@ -2912,7 +2914,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /const composerSystemThemeBridge = createComposerSystemThemeBridge\(\{[\s\S]*consoleRef: composerLogger,[\s\S]*getStateSlice,[\s\S]*setStateSlice,[\s\S]*notifyComposerChange,[\s\S]*updateUnsyncedSummary: \(\) => composerActions\.dispatch\('composer\.system-theme\.changed'[\s\S]*refreshEditorContentTree: \(options\) => composerActions\.dispatch\('editor\.tree\.refresh'[\s\S]*\}\);[\s\S]*registerExternalStagingProviders: \(registry\) => composerSystemThemeBridge\.registerStagingProviders\(registry\)[\s\S]*composerSystemThemeBridge\.hasSystemUpdateEntries\(\)[\s\S]*composerSystemThemeBridge\.hasThemeEntries\(\)[\s\S]*initSystemThemeBridge: \(\) => composerSystemThemeBridge\.init\(\)/,
+  /const composerSystemThemeBridge = createComposerSystemThemeBridge\(\{[\s\S]*consoleRef: composerLogger,[\s\S]*getStateSlice,[\s\S]*setStateSlice,[\s\S]*notifyComposerChange,[\s\S]*updateUnsyncedSummary: \(\) => composerActions\.refreshSystemThemeState\(\{ preserveStructure: true \}\)[\s\S]*refreshEditorContentTree: \(options\) => composerActions\.refreshEditorContentTree\(options\)[\s\S]*\}\);[\s\S]*registerExternalStagingProviders: \(registry\) => composerSystemThemeBridge\.registerStagingProviders\(registry\)[\s\S]*composerSystemThemeBridge\.hasSystemUpdateEntries\(\)[\s\S]*composerSystemThemeBridge\.hasThemeEntries\(\)[\s\S]*initSystemThemeBridge: \(\) => composerSystemThemeBridge\.init\(\)/,
   'composer should delegate system/theme staging, status, and initialization through explicit action callbacks'
 );
 
@@ -2942,7 +2944,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /const composerPublishStateService = createComposerPublishStateService\(\{[\s\S]*getStateSlice,[\s\S]*getRemoteBaseline: \(\) => composerStateStore\.getRemoteBaseline\(\),[\s\S]*fetchContent: \(url, options\) => editorRuntime\.fetchContent\(url, options\),[\s\S]*getLocationOrigin: \(\) => editorRuntime\.getLocationOrigin\(\),[\s\S]*getDocumentLang: \(\) => editorRuntime\.getDocumentLang\(\),[\s\S]*consoleRef: composerLogger,[\s\S]*setRemoteBaselineSlice: \(kind, value\) => composerStateStore\.setRemoteBaseline\(kind, value\),[\s\S]*applyComposerEffectiveSiteConfig: \(site\) => applyComposerEffectiveSiteConfig\(site\),[\s\S]*registerExternalStagingProviders: \(registry\) => composerSystemThemeBridge\.registerStagingProviders\(registry\)[\s\S]*\}\);[\s\S]*function gatherCommitPayload\(options = \{\}\) \{[\s\S]*composerPublishStateService\.gatherCommitPayload\(\{[\s\S]*setStatus: setSyncOverlayStatus[\s\S]*function applyLocalPostCommitState\(files = \[\]\) \{[\s\S]*composerActions\.dispatch\('publish\.completed'[\s\S]*function rawApplyLocalPostCommitState\(files = \[\]\) \{[\s\S]*composerPublishStateService\.applyLocalPostCommitState\(files\);[\s\S]*function getTrackedPublishContentRoot\(\) \{[\s\S]*composerPublishStateService\.getTrackedPublishContentRoot\(\);/,
+  /const composerPublishStateService = createComposerPublishStateService\(\{[\s\S]*getStateSlice,[\s\S]*getRemoteBaseline: \(\) => composerStateStore\.getRemoteBaseline\(\),[\s\S]*fetchContent: \(url, options\) => editorRuntime\.fetchContent\(url, options\),[\s\S]*getLocationOrigin: \(\) => editorRuntime\.getLocationOrigin\(\),[\s\S]*getDocumentLang: \(\) => editorRuntime\.getDocumentLang\(\),[\s\S]*consoleRef: composerLogger,[\s\S]*setRemoteBaselineSlice: \(kind, value\) => composerStateStore\.setRemoteBaseline\(kind, value\),[\s\S]*applyComposerEffectiveSiteConfig: \(site\) => applyComposerEffectiveSiteConfig\(site\),[\s\S]*registerExternalStagingProviders: \(registry\) => composerSystemThemeBridge\.registerStagingProviders\(registry\)[\s\S]*\}\);[\s\S]*function gatherCommitPayload\(options = \{\}\) \{[\s\S]*composerPublishStateService\.gatherCommitPayload\(\{[\s\S]*setStatus: setSyncOverlayStatus[\s\S]*function applyLocalPostCommitState\(files = \[\]\) \{[\s\S]*composerActions\.applyLocalPostCommitState\(files\);[\s\S]*function rawApplyLocalPostCommitState\(files = \[\]\) \{[\s\S]*composerPublishStateService\.applyLocalPostCommitState\(files\);[\s\S]*function getTrackedPublishContentRoot\(\) \{[\s\S]*composerPublishStateService\.getTrackedPublishContentRoot\(\);/,
   'composer should reduce publish persistence to explicit app-service and action-contract callbacks'
 );
 
@@ -3736,8 +3738,8 @@ assert.match(
 
 assert.match(
   source,
-  /function restorePrimaryEditorMarkdownView\(editorApi\) \{ getMarkdownWorkspaceController\(\)\.restorePrimaryEditorMarkdownView\(editorApi\); \}/,
-  'composer should route markdown view restoration through the workspace controller'
+  /const markdownWorkspace = createComposerMarkdownWorkspaceFacade\(\{ services: composerServices \}\);[\s\S]*restorePrimaryEditorMarkdownView,[\s\S]*= markdownWorkspace;/,
+  'composer should route markdown view restoration through the workspace facade'
 );
 
 assert.match(
@@ -5690,7 +5692,7 @@ assert.match(
 );
 
 assert.match(
-  source,
+  composerEditorTreeStateSource,
   /themesLabel: treeText\('themes', 'Themes'\),[\s\S]*syncLabel: treeText\('sync', 'Publish'\),/,
   'System tree should expose the Themes and Publish leaves'
 );
@@ -6822,8 +6824,14 @@ assert.match(
 
 assert.match(
   source,
-  /import \{ buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree \} from '\.\/editor-content-tree\.js';/,
-  'composer should use the shared editor content tree model'
+  /import \{ findEditorContentTreeNode, flattenEditorContentTree \} from '\.\/editor-content-tree\.js';/,
+  'composer should use the shared editor content tree navigation helpers'
+);
+
+assert.match(
+  composerEditorTreeStateSource,
+  /import \{ buildEditorContentTree \} from '\.\/editor-content-tree\.js';/,
+  'composer editor tree state should own shared tree construction'
 );
 
 assert.match(

--- a/scripts/test-composer-root-boundaries.js
+++ b/scripts/test-composer-root-boundaries.js
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findEditorContentTreeNode } from '../assets/js/editor-content-tree.js';
+import { createComposerEditorTreeState } from '../assets/js/composer-editor-tree-state.js';
+import { createComposerMarkdownWorkspaceFacade } from '../assets/js/composer-markdown-workspace-facade.js';
+import { createComposerYamlSerialization } from '../assets/js/composer-yaml-serialization.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const composerSource = readFileSync(resolve(here, '../assets/js/composer.js'), 'utf8');
+const actionEffectsSource = readFileSync(resolve(here, '../assets/js/composer-action-effects.js'), 'utf8');
+const markdownWorkspaceFacadeSource = readFileSync(resolve(here, '../assets/js/composer-markdown-workspace-facade.js'), 'utf8');
+const yamlSerializationSource = readFileSync(resolve(here, '../assets/js/composer-yaml-serialization.js'), 'utf8');
+const editorTreeStateSource = readFileSync(resolve(here, '../assets/js/composer-editor-tree-state.js'), 'utf8');
+
+assert.match(composerSource, /from '\.\/composer-action-effects\.js'/);
+assert.match(composerSource, /from '\.\/composer-markdown-workspace-facade\.js'/);
+assert.match(composerSource, /from '\.\/composer-yaml-serialization\.js'/);
+assert.match(composerSource, /from '\.\/composer-editor-tree-state\.js'/);
+assert.doesNotMatch(composerSource, /createComposerActionDispatcher|composerActions\.dispatch\('/);
+assert.doesNotMatch(composerSource, /import \{ buildEditorContentTree/);
+[
+  'sortLangKeys',
+  'toIndexYaml',
+  'toTabsYaml',
+  'collectEditorDraftStatusMap',
+  'collectEditorFileStatusMap',
+  'collectEditorDiffStatusMap',
+  'findDynamicTabByPath',
+  'getPrimaryEditorApi'
+].forEach((name) => {
+  assert.doesNotMatch(
+    composerSource,
+    new RegExp(`function ${name}\\b`),
+    `composer root should not own ${name}`
+  );
+});
+
+assert.match(actionEffectsSource, /createComposerActionDispatcher/);
+assert.match(actionEffectsSource, /COMPOSER_ACTION_EFFECT_SERVICES/);
+assert.match(actionEffectsSource, /notifyComposerChange: \(kind, actionOptions = \{\}\) => dispatch\.dispatch\('composer\.yaml\.changed'/);
+assert.match(markdownWorkspaceFacadeSource, /getMarkdownWorkspaceController\(\)\.openMarkdownInEditor/);
+assert.match(yamlSerializationSource, /function toIndexYaml\(data\)/);
+assert.match(editorTreeStateSource, /function collectEditorDiffStatusMap\(\)/);
+
+{
+  const serializer = createComposerYamlSerialization({
+    preferredLangOrder: ['en', 'chs', 'ja'],
+    normalizeLangCode: value => String(value || '').trim().toLowerCase(),
+    getLanguageLabel: code => ({ en: 'English', chs: 'Chinese' })[code] || '',
+    isIndexMetadataObject: value => !!value && typeof value === 'object' && !Array.isArray(value),
+    writeYamlValue: (lines, indent, value) => {
+      const prefix = '  '.repeat(indent);
+      lines.push(`${prefix}location: ${value.location || ''}`);
+    }
+  });
+  assert.deepEqual(serializer.sortLangKeys({ ja: true, chs: true, en: true, de: true }), ['en', 'chs', 'ja', 'de']);
+  assert.equal(serializer.displayLangName('en'), 'English');
+  assert.equal(serializer.displayLangName('ja'), 'JA');
+  assert.notEqual(serializer.langFlag('en'), '');
+  assert.match(
+    serializer.toIndexYaml({
+      __order: ['post'],
+      post: {
+        chs: ['wwwroot/post/chs.md'],
+        en: ['wwwroot/post/en.md']
+      }
+    }),
+    /post:\n  en: wwwroot\/post\/en\.md\n  chs: wwwroot\/post\/chs\.md\n/
+  );
+  assert.match(
+    serializer.toTabsYaml({
+      __order: ['about'],
+      about: {
+        en: { title: 'About "Us"', location: 'wwwroot/about.md' }
+      }
+    }),
+    /about:\n  en:\n    title: "About \\"Us\\""\n    location: wwwroot\/about\.md\n/
+  );
+}
+
+{
+  const workspaceCalls = [];
+  const workspaceController = {
+    getPrimaryEditorApi: () => ({ id: 'primary' }),
+    restorePrimaryEditorMarkdownView: editorApi => workspaceCalls.push(['restore', editorApi.id]),
+    ensurePrimaryEditorListener: () => workspaceCalls.push(['ensurePrimary']),
+    ensurePrimaryEditorTabsMetadataListener: () => workspaceCalls.push(['ensureTabsMetadata']),
+    getDynamicEditorTabs: () => [{ mode: 'markdown:one' }],
+    getDynamicTabByMode: mode => ({ mode }),
+    isDynamicMode: mode => String(mode).startsWith('markdown:'),
+    getFirstDynamicModeId: () => 'markdown:one',
+    getActiveDynamicTab: () => ({ mode: 'markdown:one' }),
+    activateDynamicMode: mode => workspaceCalls.push(['activate', mode]),
+    clearActiveDynamicMode: mode => workspaceCalls.push(['clear', mode]),
+    persistDynamicEditorState: () => 'persisted',
+    restoreDynamicEditorState: () => 'restored',
+    setTabLoadingState: (tab, isLoading) => workspaceCalls.push(['loading', tab.mode, isLoading]),
+    detachPrimaryEditorListeners: () => workspaceCalls.push(['detach']),
+    updateMarkdownActionsForTab: tab => workspaceCalls.push(['actions', tab.mode]),
+    getMarkdownPushButton: () => 'push',
+    getMarkdownDiscardButton: () => 'discard',
+    getMarkdownSaveButton: () => 'save',
+    setMarkdownPushButton: button => workspaceCalls.push(['setPush', button]),
+    setMarkdownDiscardButton: button => workspaceCalls.push(['setDiscard', button]),
+    setMarkdownSaveButton: button => workspaceCalls.push(['setSave', button]),
+    setMarkdownProtectionButton: button => workspaceCalls.push(['setProtection', button]),
+    getMarkdownPushLabel: kind => `push:${kind}`,
+    getMarkdownDiscardLabel: () => 'discard label',
+    getMarkdownDiscardBusyLabel: () => 'discard busy',
+    getMarkdownSaveLabel: () => 'save label',
+    getMarkdownSaveBusyLabel: () => 'save busy',
+    getMarkdownSaveTooltip: kind => `save:${kind}`,
+    updateMarkdownPushButton: tab => workspaceCalls.push(['updatePush', tab.mode]),
+    updateMarkdownDiscardButton: tab => workspaceCalls.push(['updateDiscard', tab.mode]),
+    updateMarkdownSaveButton: tab => workspaceCalls.push(['updateSave', tab.mode]),
+    updateMarkdownProtectionButton: tab => workspaceCalls.push(['updateProtection', tab.mode]),
+    pushEditorCurrentFileInfo: tab => workspaceCalls.push(['fileInfo', tab.mode]),
+    setDynamicTabStatus: (tab, status) => `${tab.mode}:${status}`,
+    closeDynamicTab: (modeId, options = {}) => ({ modeId, options }),
+    getOrCreateDynamicMode: path => `markdown:${path}`,
+    loadDynamicTabContent: tab => `loaded:${tab.mode}`,
+    openMarkdownInEditor: path => `opened:${path}`,
+    findDynamicTabByPath: path => ({ path })
+  };
+  const services = {
+    getMarkdownSessionController: () => ({ id: 'session' }),
+    getMarkdownActionsUi: () => ({ id: 'actions' }),
+    getMarkdownLoader: () => ({ id: 'loader' }),
+    getMarkdownDraftController: () => ({ id: 'draft' }),
+    getMarkdownWorkspaceController: () => workspaceController
+  };
+  const facade = createComposerMarkdownWorkspaceFacade({ services });
+  assert.deepEqual(facade.getPrimaryEditorApi(), { id: 'primary' });
+  assert.equal(facade.getMarkdownDraftController().id, 'draft');
+  assert.equal(facade.setDynamicTabStatus({ mode: 'markdown:one' }, 'dirty'), 'markdown:one:dirty');
+  assert.equal(facade.openMarkdownInEditor('wwwroot/post/a.md'), 'opened:wwwroot/post/a.md');
+  assert.deepEqual(facade.findDynamicTabByPath('wwwroot/post/a.md'), { path: 'wwwroot/post/a.md' });
+}
+
+{
+  const treeState = createComposerEditorTreeState({
+    preferredLangs: ['en', 'chs'],
+    normalizeRelPath: value => String(value || '').replace(/^\.\//, ''),
+    treeText: (_key, fallback) => fallback,
+    getStateSlice: kind => ({
+      index: {
+        __order: ['post'],
+        post: { en: ['wwwroot/post/a.md'] }
+      },
+      tabs: {
+        __order: ['about'],
+        about: { en: { title: 'About', location: 'wwwroot/about.md' } }
+      }
+    })[kind],
+    readMarkdownDraftStore: () => ({
+      './wwwroot/post/a.md': { content: '# Draft' },
+      './wwwroot/post/empty.md': { content: '' }
+    }),
+    collectDynamicMarkdownDraftStates: () => new Map([['wwwroot/about.md', 'unsaved']]),
+    getMarkdownSessionController: () => ({
+      collectFileStatusMap: () => new Map([['wwwroot/post/a.md', 'checking']])
+    }),
+    getComposerDiff: kind => ({
+      index: { keys: { post: { state: 'modified', langs: { en: { state: 'modified' } } } } },
+      tabs: { addedKeys: ['about'] },
+      site: { hasChanges: true }
+    })[kind] || null,
+    getRemoteBaseline: () => null,
+    getComposerDraftMeta: kind => (kind === 'site' ? { savedAt: 1 } : null),
+    hasSystemUpdateEntries: () => true,
+    hasThemeEntries: () => true
+  });
+
+  assert.deepEqual(
+    [...treeState.collectEditorDraftStatusMap().entries()],
+    [
+      ['wwwroot/post/a.md', 'saved'],
+      ['wwwroot/about.md', 'unsaved']
+    ]
+  );
+  assert.deepEqual([...treeState.collectEditorFileStatusMap().entries()], [['wwwroot/post/a.md', 'checking']]);
+  const diffEntries = treeState.collectEditorDiffStatusMap();
+  assert.equal(diffEntries.get('index:post'), 'modified');
+  assert.equal(diffEntries.get('index:post:en'), 'modified');
+  assert.equal(diffEntries.get('tabs:about'), 'added');
+  assert.equal(diffEntries.get('system:site-settings'), 'modified');
+  assert.equal(diffEntries.get('system:updates'), 'modified');
+  assert.equal(diffEntries.get('system:themes'), 'modified');
+
+  const tree = treeState.buildCurrentEditorTree();
+  assert.deepEqual(tree.map(node => node.id), ['welcome', 'system', 'articles', 'pages']);
+  assert.equal(findEditorContentTreeNode(tree, 'index:post:en:0').draftState, 'saved');
+  assert.equal(findEditorContentTreeNode(tree, 'index:post:en:0').fileState, 'checking');
+  assert.equal(findEditorContentTreeNode(tree, 'system:themes').diffState, 'modified');
+}
+
+console.log('ok - composer root boundaries');

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -40,6 +40,7 @@ for command in \
   'node scripts/test-dispatch-system-release.js' \
   'node scripts/test-product-state-ledger.js' \
   'node scripts/test-composer-action-contract.js' \
+  'node scripts/test-composer-root-boundaries.js' \
   'node scripts/test-composer-app-services.js' \
   'node scripts/test-composer-service-registry.js' \
   'node scripts/test-provider-adapters.js' \

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -238,6 +238,26 @@ if ! grep -qx "press-system-${version}/assets/js/composer-markdown-assets.js" "$
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/composer-action-effects.js" "${entries_file}"; then
+  echo "expected package to include composer action effects boundary code" >&2
+  exit 1
+fi
+
+if ! grep -qx "press-system-${version}/assets/js/composer-markdown-workspace-facade.js" "${entries_file}"; then
+  echo "expected package to include composer Markdown workspace facade code" >&2
+  exit 1
+fi
+
+if ! grep -qx "press-system-${version}/assets/js/composer-yaml-serialization.js" "${entries_file}"; then
+  echo "expected package to include composer YAML serialization boundary code" >&2
+  exit 1
+fi
+
+if ! grep -qx "press-system-${version}/assets/js/composer-editor-tree-state.js" "${entries_file}"; then
+  echo "expected package to include composer editor tree state boundary code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/composer-editor-shell.js" "${entries_file}"; then
   echo "expected package to include composer editor shell code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -98,6 +98,11 @@ if ! grep -F 'node scripts/test-composer-action-contract.js' "${workflow}" >/dev
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-composer-root-boundaries.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify composer root boundaries before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node scripts/test-composer-service-registry.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the composer service registry before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary
- move composer action dispatch effects, Markdown workspace proxy calls, YAML serialization, and editor-tree status aggregation out of `composer.js`
- keep `composer.js` as the composition root while routing public callbacks through named action-effect methods instead of direct action strings
- bump Press system runtime to v3.4.109 and add package/workflow coverage for the new runtime modules

## Verification
- `node --check assets/js/composer.js assets/js/composer-action-effects.js assets/js/composer-markdown-workspace-facade.js assets/js/composer-yaml-serialization.js assets/js/composer-editor-tree-state.js scripts/test-composer-root-boundaries.js`
- `node scripts/test-composer-action-contract.js`
- `node scripts/test-composer-root-boundaries.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-composer-app-services.js && node scripts/test-composer-service-registry.js && node scripts/test-composer-bootstrap.js && node scripts/test-composer-file-panel-controller.js`
- `node scripts/test-composer-yaml-drafts.js && node scripts/test-composer-yaml-actions.js && node scripts/test-composer-remote-sync.js && node scripts/test-composer-publish-state-service.js`
- `node scripts/test-composer-markdown-drafts.js && node scripts/test-composer-system-theme-bridge.js && node scripts/test-composer-markdown-workspace.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `node scripts/test-ui-components.js`
- `node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `bash scripts/test-main-guard.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node scripts/test-press-system-surface.mjs`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- `bash scripts/test-pages-workflow.sh`
- `node scripts/test-release-targets.js && node scripts/test-release-intent.js && node scripts/test-dispatch-system-release.js && node scripts/test-product-state-ledger.js && node scripts/test-product-state-dashboard.js`
- `bash scripts/test-system-release-package.sh`
- Browser smoke: loaded `http://127.0.0.1:8001/index_editor.html`, verified editor tree and System/Themes nodes were present with no console errors

## Release impact
- Press system release surface changes; `assets/press-system.json` is bumped to v3.4.109.
- New runtime modules are included in the system release package boundary.
- No starter content, theme contract, Connect API, or GitHub App permission changes.

## Review
- Local pre-PR subagent review found no blockers.
