### PR TITLE
Add editor effects boundary

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -27,6 +27,7 @@ jobs:
           node scripts/test-composer-action-contract.js
           node scripts/test-composer-root-contract.js
           node scripts/test-composer-root-boundaries.js
+          node scripts/test-editor-effects-boundary.js
           node scripts/test-composer-app-services.js
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -29,6 +29,7 @@ jobs:
           node scripts/test-composer-action-contract.js
           node scripts/test-composer-root-contract.js
           node scripts/test-composer-root-boundaries.js
+          node scripts/test-editor-effects-boundary.js
           node scripts/test-composer-app-services.js
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs

--- a/assets/js/composer-bootstrap.js
+++ b/assets/js/composer-bootstrap.js
@@ -1,26 +1,7 @@
 import { createEditorAppKernel } from './editor-app-kernel.js';
+import { createDomEffects } from './editor-effects.js';
 
 function noop() {}
-
-function getElement(documentRef, id) {
-  try {
-    return documentRef && typeof documentRef.getElementById === 'function'
-      ? documentRef.getElementById(id)
-      : null;
-  } catch (_) {
-    return null;
-  }
-}
-
-function queryAll(documentRef, selector) {
-  try {
-    return documentRef && typeof documentRef.querySelectorAll === 'function'
-      ? Array.from(documentRef.querySelectorAll(selector))
-      : [];
-  } catch (_) {
-    return [];
-  }
-}
 
 function setToolbarBusyState(button, busy, text, setButtonLabel = noop) {
   if (!button) return;
@@ -61,10 +42,11 @@ export function bindComposerMarkdownToolbar({
   updateMarkdownSaveButton = noop,
   updateMarkdownDiscardButton = noop
 } = {}) {
-  const pushBtn = getElement(documentRef, 'btnPushMarkdown');
+  const effects = createDomEffects({ documentRef });
+  const pushBtn = effects.getElementById('btnPushMarkdown');
   if (pushBtn) {
     setMarkdownPushButton(pushBtn);
-    pushBtn.addEventListener('click', async (event) => {
+    effects.on(pushBtn, 'click', async (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       const active = getActiveDynamicTab();
       if (!active) {
@@ -86,30 +68,30 @@ export function bindComposerMarkdownToolbar({
     updateMarkdownPushButton(getActiveDynamicTab());
   }
 
-  const saveBtn = getElement(documentRef, 'btnSaveMarkdown');
+  const saveBtn = effects.getElementById('btnSaveMarkdown');
   if (saveBtn) {
     setMarkdownSaveButton(saveBtn);
-    saveBtn.addEventListener('click', (event) => {
+    effects.on(saveBtn, 'click', (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       manualSaveActiveMarkdown(saveBtn);
     });
     updateMarkdownSaveButton(getActiveDynamicTab());
   }
 
-  const protectBtn = getElement(documentRef, 'btnProtectMarkdown');
+  const protectBtn = effects.getElementById('btnProtectMarkdown');
   if (protectBtn) {
     setMarkdownProtectionButton(protectBtn);
-    protectBtn.addEventListener('click', (event) => {
+    effects.on(protectBtn, 'click', (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       handleMarkdownProtectionButton(protectBtn);
     });
     updateMarkdownProtectionButton(getActiveDynamicTab());
   }
 
-  const discardBtn = getElement(documentRef, 'btnDiscardMarkdown');
+  const discardBtn = effects.getElementById('btnDiscardMarkdown');
   if (discardBtn) {
     setMarkdownDiscardButton(discardBtn);
-    discardBtn.addEventListener('click', (event) => {
+    effects.on(discardBtn, 'click', (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       discardMarkdownLocalChanges(null, discardBtn);
     });
@@ -138,14 +120,15 @@ export function bindComposerWorkspaceUi({
   openComposerDiffModal = noop,
   bindVerifySetup = noop
 } = {}) {
+  const effects = createDomEffects({ documentRef });
   mountEditorSystemPanels();
   initEditorOverlay();
   initEditorRailResize();
   initMobileEditorRail();
   bindEditorStatePersistenceListeners();
 
-  queryAll(documentRef, '.mode-tab').forEach((btn) => {
-    btn.addEventListener('click', (event) => {
+  effects.querySelectorAll('.mode-tab').forEach((btn) => {
+    effects.on(btn, 'click', (event) => {
       const mode = btn.dataset && btn.dataset.mode;
       if (mode === 'composer' || mode === 'themes' || mode === 'updates' || mode === 'sync') {
         if (event && typeof event.preventDefault === 'function') event.preventDefault();
@@ -157,17 +140,17 @@ export function bindComposerWorkspaceUi({
   });
   initSystemThemeBridge();
 
-  queryAll(documentRef, 'a.vt-btn[data-cfile]').forEach((link) => {
-    link.addEventListener('click', (event) => {
+  effects.querySelectorAll('a.vt-btn[data-cfile]').forEach((link) => {
+    effects.on(link, 'click', (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       setComposerFile(link.dataset && link.dataset.cfile);
     });
   });
   setComposerFile(getInitialComposerFile(), { immediate: true });
 
-  const btnAddItem = getElement(documentRef, 'btnAddItem');
+  const btnAddItem = effects.getElementById('btnAddItem');
   if (btnAddItem) {
-    btnAddItem.addEventListener('click', (event) => {
+    effects.on(btnAddItem, 'click', (event) => {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       const kind = getActiveComposerFile();
       const anchor = event && event.currentTarget ? event.currentTarget : btnAddItem;
@@ -179,15 +162,15 @@ export function bindComposerWorkspaceUi({
     });
   }
 
-  const btnDiscard = getElement(documentRef, 'btnDiscard');
-  if (btnDiscard) btnDiscard.addEventListener('click', () => handleComposerDiscard(btnDiscard));
+  const btnDiscard = effects.getElementById('btnDiscard');
+  if (btnDiscard) effects.on(btnDiscard, 'click', () => handleComposerDiscard(btnDiscard));
 
-  const btnRefresh = getElement(documentRef, 'btnRefresh');
-  if (btnRefresh) btnRefresh.addEventListener('click', () => handleComposerRefresh(btnRefresh));
+  const btnRefresh = effects.getElementById('btnRefresh');
+  if (btnRefresh) effects.on(btnRefresh, 'click', () => handleComposerRefresh(btnRefresh));
 
-  const btnReview = getElement(documentRef, 'btnReview');
+  const btnReview = effects.getElementById('btnReview');
   if (btnReview) {
-    btnReview.addEventListener('click', () => {
+    effects.on(btnReview, 'click', () => {
       const datasetKind = btnReview.dataset && btnReview.dataset.kind;
       const preferred = datasetKind === 'tabs' ? 'tabs' : datasetKind === 'index' ? 'index' : null;
       if (preferred) {
@@ -286,6 +269,7 @@ export function assembleComposerWorkspace({
   persistDynamicEditorState,
   setTimeoutRef = null
 } = {}) {
+  const effects = createDomEffects({ documentRef });
   const scheduleTimer = (handler, delay) => {
     if (typeof setTimeoutRef !== 'function') return false;
     try {
@@ -320,9 +304,9 @@ export function assembleComposerWorkspace({
   }
 
   bindWorkspaceUi(state);
-  buildIndexUI(getElement(documentRef, 'composerIndex'), state);
-  buildTabsUI(getElement(documentRef, 'composerTabs'), state);
-  buildSiteUI(getElement(documentRef, 'composerSite'), state);
+  buildIndexUI(effects.getElementById('composerIndex'), state);
+  buildTabsUI(effects.getElementById('composerTabs'), state);
+  buildSiteUI(effects.getElementById('composerSite'), state);
 
   notifyComposerChange('index', { skipAutoSave: true });
   notifyComposerChange('tabs', { skipAutoSave: true });

--- a/assets/js/editor-app-runtime.js
+++ b/assets/js/editor-app-runtime.js
@@ -1,3 +1,9 @@
+import {
+  createEventEffects,
+  createStorageEffects,
+  resolveStorageEffect
+} from './editor-effects.js';
+
 function noop() {}
 
 function normalizeKind(kind, allowedKinds, defaultKind) {
@@ -67,83 +73,6 @@ export function createEditorStateStore({
       const diff = diffCache[normalize(kind)];
       return !!(diff && diff.hasChanges);
     }
-  };
-}
-
-function createRuntimeStorage(storage) {
-  return {
-    get native() {
-      return storage || null;
-    },
-    getItem(key) {
-      try {
-        return storage && typeof storage.getItem === 'function'
-          ? storage.getItem(key)
-          : null;
-      } catch (_) {
-        return null;
-      }
-    },
-    setItem(key, value) {
-      try {
-        if (!storage || typeof storage.setItem !== 'function') return false;
-        storage.setItem(key, String(value));
-        return true;
-      } catch (_) {
-        return false;
-      }
-    },
-    removeItem(key) {
-      try {
-        if (!storage || typeof storage.removeItem !== 'function') return false;
-        storage.removeItem(key);
-        return true;
-      } catch (_) {
-        return false;
-      }
-    }
-  };
-}
-
-function createRuntimeEvents({ documentRef, windowRef } = {}) {
-  function createRuntimeEvent(type, detail, eventOptions = {}) {
-    const CustomEventCtor = windowRef && typeof windowRef.CustomEvent === 'function'
-      ? windowRef.CustomEvent
-      : null;
-    if (CustomEventCtor) return new CustomEventCtor(type, { ...eventOptions, detail });
-    return { type, detail };
-  }
-
-  function on(target, type, handler, options) {
-    try {
-      if (!target || typeof target.addEventListener !== 'function') return noop;
-      target.addEventListener(type, handler, options);
-      return () => {
-        try {
-          if (typeof target.removeEventListener === 'function') {
-            target.removeEventListener(type, handler, options);
-          }
-        } catch (_) {}
-      };
-    } catch (_) {
-      return noop;
-    }
-  }
-
-  function emit(target, type, detail, eventOptions) {
-    try {
-      if (!target || typeof target.dispatchEvent !== 'function') return false;
-      return target.dispatchEvent(createRuntimeEvent(type, detail, eventOptions));
-    } catch (_) {
-      return false;
-    }
-  }
-
-  return {
-    onDocument: (type, handler, options) => on(documentRef, type, handler, options),
-    onWindow: (type, handler, options) => on(windowRef, type, handler, options),
-    emitDocument: (type, detail, options) => emit(documentRef, type, detail, options),
-    emitWindow: (type, detail, options) => emit(windowRef, type, detail, options)
   };
 }
 
@@ -673,25 +602,17 @@ function createRuntimeBrowser({ documentRef, windowRef } = {}) {
   };
 }
 
-function resolveWindowStorage(windowRef) {
-  try {
-    return windowRef && windowRef.localStorage ? windowRef.localStorage : null;
-  } catch (_) {
-    return null;
-  }
-}
-
 export function createEditorAppRuntime({
   windowRef = null,
   documentRef = null,
   storage = undefined
 } = {}) {
-  const runtimeStorage = storage === undefined ? resolveWindowStorage(windowRef) : storage;
+  const runtimeStorage = storage === undefined ? resolveStorageEffect(windowRef, 'localStorage') : storage;
   return {
     windowRef,
     documentRef,
-    storage: createRuntimeStorage(runtimeStorage),
-    events: createRuntimeEvents({ documentRef, windowRef }),
+    storage: createStorageEffects(runtimeStorage),
+    events: createEventEffects({ documentRef, windowRef }),
     browser: createRuntimeBrowser({ documentRef, windowRef }),
     globals: createRuntimeGlobals(windowRef),
     createStateStore: createEditorStateStore

--- a/assets/js/editor-effects.js
+++ b/assets/js/editor-effects.js
@@ -1,0 +1,121 @@
+function noop() {}
+
+export function bindEventEffect(target, type, handler, options) {
+  try {
+    if (!target || typeof target.addEventListener !== 'function') return noop;
+    target.addEventListener(type, handler, options);
+    return () => {
+      try {
+        if (typeof target.removeEventListener === 'function') {
+          target.removeEventListener(type, handler, options);
+        }
+      } catch (_) {}
+    };
+  } catch (_) {
+    return noop;
+  }
+}
+
+export function createStorageEffects(storage) {
+  return {
+    get native() {
+      return storage || null;
+    },
+    getItem(key) {
+      try {
+        return storage && typeof storage.getItem === 'function'
+          ? storage.getItem(key)
+          : null;
+      } catch (_) {
+        return null;
+      }
+    },
+    setItem(key, value) {
+      try {
+        if (!storage || typeof storage.setItem !== 'function') return false;
+        storage.setItem(key, String(value));
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
+    removeItem(key) {
+      try {
+        if (!storage || typeof storage.removeItem !== 'function') return false;
+        storage.removeItem(key);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    }
+  };
+}
+
+export function resolveStorageEffect(windowRef, name = 'localStorage') {
+  try {
+    return windowRef && windowRef[name] ? windowRef[name] : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function createEventEffects({ documentRef = null, windowRef = null } = {}) {
+  function createCustomEvent(type, detail, eventOptions = {}) {
+    const CustomEventCtor = windowRef && typeof windowRef.CustomEvent === 'function'
+      ? windowRef.CustomEvent
+      : null;
+    if (CustomEventCtor) return new CustomEventCtor(type, { ...eventOptions, detail });
+    return { type, detail };
+  }
+
+  function emit(target, type, detail, eventOptions) {
+    try {
+      if (!target || typeof target.dispatchEvent !== 'function') return false;
+      return target.dispatchEvent(createCustomEvent(type, detail, eventOptions));
+    } catch (_) {
+      return false;
+    }
+  }
+
+  return {
+    on: bindEventEffect,
+    onDocument: (type, handler, options) => bindEventEffect(documentRef, type, handler, options),
+    onWindow: (type, handler, options) => bindEventEffect(windowRef, type, handler, options),
+    emit,
+    emitDocument: (type, detail, options) => emit(documentRef, type, detail, options),
+    emitWindow: (type, detail, options) => emit(windowRef, type, detail, options)
+  };
+}
+
+export function createDomEffects({ documentRef = null } = {}) {
+  return {
+    on: bindEventEffect,
+    getElementById(id) {
+      try {
+        return documentRef && typeof documentRef.getElementById === 'function'
+          ? documentRef.getElementById(id)
+          : null;
+      } catch (_) {
+        return null;
+      }
+    },
+    querySelector(selector) {
+      try {
+        return documentRef && typeof documentRef.querySelector === 'function'
+          ? documentRef.querySelector(selector)
+          : null;
+      } catch (_) {
+        return null;
+      }
+    },
+    querySelectorAll(selector) {
+      try {
+        return documentRef && typeof documentRef.querySelectorAll === 'function'
+          ? Array.from(documentRef.querySelectorAll(selector))
+          : [];
+      } catch (_) {
+        return [];
+      }
+    }
+  };
+}

--- a/assets/js/publish/settings-store.js
+++ b/assets/js/publish/settings-store.js
@@ -1,3 +1,8 @@
+import {
+  createStorageEffects,
+  resolveStorageEffect
+} from '../editor-effects.js';
+
 export const GITHUB_PAT_STORAGE_KEY = 'press_fg_pat_cache';
 export const CONNECT_PUBLISH_GRANT_STORAGE_KEY = 'press_connect_publish_grant_cache';
 export const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';
@@ -43,14 +48,14 @@ export function createPublishSettingsStore(options = {}) {
   let cachedConnectPublishGrantMemory = null;
   let cachedConnectPublishSettingsMemory = null;
 
-  const session = () => windowRef && windowRef.sessionStorage ? windowRef.sessionStorage : null;
-  const local = () => windowRef && windowRef.localStorage ? windowRef.localStorage : null;
+  const session = () => createStorageEffects(resolveStorageEffect(windowRef, 'sessionStorage'));
+  const local = () => createStorageEffects(resolveStorageEffect(windowRef, 'localStorage'));
   const scopedKey = (key) => scopeKey(key);
 
   function getCachedFineGrainedToken() {
     try {
       const storage = session();
-      const value = storage ? storage.getItem(scopedKey(GITHUB_PAT_STORAGE_KEY)) : '';
+      const value = storage.getItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
       if (typeof value === 'string' && value) {
         cachedFineGrainedTokenMemory = value;
         return value;
@@ -66,7 +71,6 @@ export function createPublishSettingsStore(options = {}) {
     cachedFineGrainedTokenMemory = trimmed;
     try {
       const storage = session();
-      if (!storage) return;
       if (trimmed) storage.setItem(scopedKey(GITHUB_PAT_STORAGE_KEY), trimmed);
       else storage.removeItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
     } catch (_) {
@@ -78,7 +82,7 @@ export function createPublishSettingsStore(options = {}) {
     cachedFineGrainedTokenMemory = '';
     try {
       const storage = session();
-      if (storage) storage.removeItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
+      storage.removeItem(scopedKey(GITHUB_PAT_STORAGE_KEY));
     } catch (_) {
       /* ignore */
     }
@@ -95,24 +99,22 @@ export function createPublishSettingsStore(options = {}) {
     };
     try {
       const storage = local();
-      if (storage) {
-        const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
-        if (modeRaw === 'connect' || modeRaw === 'pat') {
-          settings.mode = modeRaw;
-          settings.enabled = modeRaw === 'connect';
-        } else {
-          const enabledRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
-          if (enabledRaw === '0') {
-            settings.mode = 'pat';
-            settings.enabled = false;
-          } else if (enabledRaw === '1') {
-            settings.mode = 'connect';
-            settings.enabled = true;
-          }
+      const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
+      if (modeRaw === 'connect' || modeRaw === 'pat') {
+        settings.mode = modeRaw;
+        settings.enabled = modeRaw === 'connect';
+      } else {
+        const enabledRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+        if (enabledRaw === '0') {
+          settings.mode = 'pat';
+          settings.enabled = false;
+        } else if (enabledRaw === '1') {
+          settings.mode = 'connect';
+          settings.enabled = true;
         }
-        const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
-        if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
       }
+      const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
+      if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
     } catch (_) {
       /* ignore unavailable storage */
     }
@@ -137,11 +139,9 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishSettingsMemory = { ...settings };
     try {
       const storage = local();
-      if (storage) {
-        storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
-        storage.setItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY), settings.enabled ? '1' : '0');
-        storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
-      }
+      storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
+      storage.setItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY), settings.enabled ? '1' : '0');
+      storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
     } catch (_) {
       /* ignore storage errors */
     }
@@ -155,7 +155,7 @@ export function createPublishSettingsStore(options = {}) {
     }
     try {
       const storage = session();
-      const raw = storage ? storage.getItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY)) : '';
+      const raw = storage.getItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
       if (!raw) return null;
       const parsed = JSON.parse(raw);
       if (isUsableConnectPublishGrant(parsed)) {
@@ -172,7 +172,6 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishGrantMemory = grant && typeof grant === 'object' ? { ...grant } : null;
     try {
       const storage = session();
-      if (!storage) return;
       if (cachedConnectPublishGrantMemory) {
         storage.setItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY), JSON.stringify(cachedConnectPublishGrantMemory));
       } else {
@@ -187,7 +186,7 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishGrantMemory = null;
     try {
       const storage = session();
-      if (storage) storage.removeItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
+      storage.removeItem(scopedKey(CONNECT_PUBLISH_GRANT_STORAGE_KEY));
     } catch (_) {
       /* ignore */
     }

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -1,4 +1,5 @@
 import { CONNECT_PUBLISH_MESSAGE_TYPE } from '../settings-store.js';
+import { createEventEffects } from '../../editor-effects.js';
 
 function resolveAmbientValue(name) {
   try {
@@ -151,6 +152,7 @@ export function requestConnectPublishGrant({
 } = {}) {
   windowRef = resolveWindow(windowRef);
   documentRef = resolveDocument(documentRef, windowRef);
+  const eventEffects = createEventEffects({ documentRef, windowRef });
   const startUrl = new URL('/github/press/start', connect.baseUrl);
   startUrl.searchParams.set('origin', windowRef && windowRef.location ? windowRef.location.origin || '' : '');
   startUrl.searchParams.set('owner', repo.owner);
@@ -184,10 +186,9 @@ export function requestConnectPublishGrant({
   return new Promise((resolve, reject) => {
     let timer = 0;
     let closeTimer = 0;
+    let unbindMessage = null;
     const cleanup = () => {
-      if (windowRef && typeof windowRef.removeEventListener === 'function') {
-        windowRef.removeEventListener('message', onMessage);
-      }
+      if (typeof unbindMessage === 'function') unbindMessage();
       if (timer && windowRef && typeof windowRef.clearTimeout === 'function') windowRef.clearTimeout(timer);
       if (closeTimer && windowRef && typeof windowRef.clearInterval === 'function') windowRef.clearInterval(closeTimer);
     };
@@ -210,13 +211,12 @@ export function requestConnectPublishGrant({
       if (typeof setCachedGrant === 'function') setCachedGrant(grant);
       resolve(grant);
     };
-    if (windowRef && typeof windowRef.addEventListener === 'function') {
-      windowRef.addEventListener('message', onMessage);
-    } else {
+    if (!windowRef || typeof windowRef.addEventListener !== 'function') {
       cleanup();
       reject(new Error(translate('editor.composer.github.modal.connectAuthorizationFailed')));
       return;
     }
+    unbindMessage = eventEffects.onWindow('message', onMessage);
     if (typeof windowRef.setInterval === 'function') {
       closeTimer = windowRef.setInterval(() => {
         try {

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,4 +1,5 @@
 import { t } from './i18n.js';
+import { createDomEffects } from './editor-effects.js';
 import { createThemeInstallService } from './theme-install-service.js';
 import {
   getThemeManagerOfficialCatalogStatus as getOfficialCatalogStatusForRuntime,
@@ -168,39 +169,34 @@ function initThemeManagerWithRuntime(runtime, options = {}) {
   const state = runtime.state;
   const { elements, optionsRef } = state;
   const documentRef = runtime.getDocument();
+  const effects = createDomEffects({ documentRef });
   if (options && typeof options.onStateChange === 'function') state.listeners.add(options.onStateChange);
   if (options && typeof options.getCurrentThemePack === 'function') optionsRef.getCurrentThemePack = options.getCurrentThemePack;
   if (options && typeof options.setSiteThemePack === 'function') optionsRef.setSiteThemePack = options.setSiteThemePack;
   if (state.initialized) return;
   state.initialized = true;
 
-  if (documentRef && typeof documentRef.getElementById === 'function') {
-    elements.root = documentRef.getElementById('mode-themes');
-    elements.status = documentRef.getElementById('themeManagerStatus');
-    elements.tabs = typeof documentRef.querySelectorAll === 'function'
-      ? Array.from(documentRef.querySelectorAll('[data-theme-manager-view]'))
-      : [];
-    elements.views = typeof documentRef.querySelectorAll === 'function'
-      ? Array.from(documentRef.querySelectorAll('[data-theme-manager-panel]'))
-      : [];
-    elements.installedList = documentRef.getElementById('themeManagerInstalledList');
-    elements.availableList = documentRef.getElementById('themeManagerAvailableList');
-    elements.pendingSection = documentRef.getElementById('themeManagerPendingSection');
-    elements.pendingList = documentRef.getElementById('themeManagerFileList');
-    elements.fileInput = documentRef.getElementById('themeImportFileInput');
-    elements.headerImportButton = documentRef.getElementById('btnThemeImport');
-    elements.inlineImportButton = documentRef.getElementById('btnThemeImportInline');
-    elements.refreshCatalogButton = documentRef.getElementById('btnThemeRefreshCatalog');
-    elements.clearButton = documentRef.getElementById('btnThemeClearStaged');
-  }
+  elements.root = effects.getElementById('mode-themes');
+  elements.status = effects.getElementById('themeManagerStatus');
+  elements.tabs = effects.querySelectorAll('[data-theme-manager-view]');
+  elements.views = effects.querySelectorAll('[data-theme-manager-panel]');
+  elements.installedList = effects.getElementById('themeManagerInstalledList');
+  elements.availableList = effects.getElementById('themeManagerAvailableList');
+  elements.pendingSection = effects.getElementById('themeManagerPendingSection');
+  elements.pendingList = effects.getElementById('themeManagerFileList');
+  elements.fileInput = effects.getElementById('themeImportFileInput');
+  elements.headerImportButton = effects.getElementById('btnThemeImport');
+  elements.inlineImportButton = effects.getElementById('btnThemeImportInline');
+  elements.refreshCatalogButton = effects.getElementById('btnThemeRefreshCatalog');
+  elements.clearButton = effects.getElementById('btnThemeClearStaged');
 
   elements.tabs.forEach((button) => {
-    button.addEventListener('click', () => setActiveThemeManagerView(runtime, button.dataset.themeManagerView));
+    effects.on(button, 'click', () => setActiveThemeManagerView(runtime, button.dataset.themeManagerView));
   });
-  if (elements.headerImportButton) elements.headerImportButton.addEventListener('click', () => openImportPicker(runtime));
-  if (elements.inlineImportButton) elements.inlineImportButton.addEventListener('click', () => openImportPicker(runtime));
+  if (elements.headerImportButton) effects.on(elements.headerImportButton, 'click', () => openImportPicker(runtime));
+  if (elements.inlineImportButton) effects.on(elements.inlineImportButton, 'click', () => openImportPicker(runtime));
   if (elements.fileInput) {
-    elements.fileInput.addEventListener('change', (event) => {
+    effects.on(elements.fileInput, 'change', (event) => {
       const input = event && event.target ? event.target : elements.fileInput;
       const file = input && input.files && input.files[0] ? input.files[0] : null;
       if (input) input.value = '';
@@ -208,7 +204,7 @@ function initThemeManagerWithRuntime(runtime, options = {}) {
     });
   }
   if (elements.refreshCatalogButton) {
-    elements.refreshCatalogButton.addEventListener('click', async () => {
+    effects.on(elements.refreshCatalogButton, 'click', async () => {
       if (runtime.state.busy) return;
       setBusy(runtime, true);
       try {
@@ -228,7 +224,7 @@ function initThemeManagerWithRuntime(runtime, options = {}) {
     });
   }
   if (elements.clearButton) {
-    elements.clearButton.addEventListener('click', () => clearThemeManagerStateWithRuntime(runtime, { keepStatus: false }));
+    effects.on(elements.clearButton, 'click', () => clearThemeManagerStateWithRuntime(runtime, { keepStatus: false }));
   }
 
   setActiveThemeManagerView(runtime, 'installed');

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.110",
-  "tag": "v3.4.110",
+  "version": "3.4.111",
+  "tag": "v3.4.111",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.109 <3.4.110"
+      ">=3.4.110 <3.4.111"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.109 first."
+    "message": "Update to v3.4.110 first."
   }
 }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3666,7 +3666,7 @@ assert.match(
 
 assert.match(
   composerBootstrapSource,
-  /const restoredDrafts = loadDraftSnapshotsIntoState\(state\);[\s\S]*applyInferredRepoConfig\([\s\S]*inferRepoConfigFromGitHubPagesUrl\(getLocation\(\)\)[\s\S]*applyEffectiveSiteConfig\(state\.site\);[\s\S]*buildSiteUI\(getElement\(documentRef, 'composerSite'\), state\);[\s\S]*notifyComposerChange\('site', inferredSiteRepoApplied \? \{\} : \{ skipAutoSave: true \}\);/,
+  /const restoredDrafts = loadDraftSnapshotsIntoState\(state\);[\s\S]*applyInferredRepoConfig\([\s\S]*inferRepoConfigFromGitHubPagesUrl\(getLocation\(\)\)[\s\S]*applyEffectiveSiteConfig\(state\.site\);[\s\S]*buildSiteUI\(effects\.getElementById\('composerSite'\), state\);[\s\S]*notifyComposerChange\('site', inferredSiteRepoApplied \? \{\} : \{ skipAutoSave: true \}\);/,
   'composer should mark inferred site repo changes dirty while preserving normal initialization behavior'
 );
 

--- a/scripts/test-editor-effects-boundary.js
+++ b/scripts/test-editor-effects-boundary.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  bindEventEffect,
+  createDomEffects,
+  createEventEffects,
+  createStorageEffects,
+  resolveStorageEffect
+} from '../assets/js/editor-effects.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (path) => readFileSync(resolve(here, '..', path), 'utf8');
+
+function createTarget() {
+  const listeners = [];
+  return {
+    listeners,
+    addEventListener(type, handler, options) {
+      listeners.push({ type, handler, options });
+    },
+    removeEventListener(type, handler, options) {
+      listeners.push({ type: `remove:${type}`, handler, options });
+    }
+  };
+}
+
+{
+  const target = createTarget();
+  const handler = () => {};
+  const options = { capture: true };
+  const unbind = bindEventEffect(target, 'click', handler, options);
+  assert.equal(typeof unbind, 'function');
+  assert.deepEqual(target.listeners[0], { type: 'click', handler, options });
+  unbind();
+  assert.deepEqual(target.listeners[1], { type: 'remove:click', handler, options });
+  assert.equal(typeof bindEventEffect(null, 'click', handler), 'function');
+  assert.equal(typeof bindEventEffect({ addEventListener: () => { throw new Error('blocked'); } }, 'click', handler), 'function');
+}
+
+{
+  const storage = new Map();
+  const effects = createStorageEffects({
+    getItem: key => storage.get(key) || null,
+    setItem: (key, value) => storage.set(key, value),
+    removeItem: key => storage.delete(key)
+  });
+  assert.equal(effects.getItem('missing'), null);
+  assert.equal(effects.setItem('token', 42), true);
+  assert.equal(effects.getItem('token'), '42');
+  assert.equal(effects.removeItem('token'), true);
+  assert.equal(effects.getItem('token'), null);
+
+  const throwing = createStorageEffects({
+    getItem: () => { throw new Error('unavailable'); },
+    setItem: () => { throw new Error('unavailable'); },
+    removeItem: () => { throw new Error('unavailable'); }
+  });
+  assert.equal(throwing.getItem('x'), null);
+  assert.equal(throwing.setItem('x', 'y'), false);
+  assert.equal(throwing.removeItem('x'), false);
+}
+
+{
+  const storage = { getItem: () => 'ok' };
+  assert.equal(resolveStorageEffect({ localStorage: storage }, 'localStorage'), storage);
+  const blockedWindow = {};
+  Object.defineProperty(blockedWindow, 'localStorage', {
+    get() {
+      throw new Error('blocked');
+    }
+  });
+  assert.equal(resolveStorageEffect(blockedWindow, 'localStorage'), null);
+}
+
+{
+  const elements = new Map([
+    ['btn', { id: 'btn' }]
+  ]);
+  const documentRef = {
+    getElementById: id => elements.get(id) || null,
+    querySelector: selector => selector === '.known' ? { selector } : null,
+    querySelectorAll: selector => selector === '.items' ? [{ id: 'a' }, { id: 'b' }] : []
+  };
+  const effects = createDomEffects({ documentRef });
+  assert.deepEqual(effects.getElementById('btn'), { id: 'btn' });
+  assert.deepEqual(effects.querySelector('.known'), { selector: '.known' });
+  assert.deepEqual(effects.querySelectorAll('.items'), [{ id: 'a' }, { id: 'b' }]);
+}
+
+{
+  class FakeCustomEvent {
+    constructor(type, options = {}) {
+      this.type = type;
+      this.detail = options.detail;
+      this.bubbles = !!options.bubbles;
+    }
+  }
+  const events = [];
+  const documentRef = {
+    dispatchEvent(event) {
+      events.push(event);
+      return true;
+    }
+  };
+  const effects = createEventEffects({ documentRef, windowRef: { CustomEvent: FakeCustomEvent } });
+  assert.equal(effects.emitDocument('press:test', { ok: true }, { bubbles: true }), true);
+  assert.equal(events[0].type, 'press:test');
+  assert.deepEqual(events[0].detail, { ok: true });
+  assert.equal(events[0].bubbles, true);
+}
+
+const editorEffects = read('assets/js/editor-effects.js');
+const editorRuntime = read('assets/js/editor-app-runtime.js');
+const composerBootstrap = read('assets/js/composer-bootstrap.js');
+const themeManager = read('assets/js/theme-manager.js');
+const publishSettingsStore = read('assets/js/publish/settings-store.js');
+const connectTransport = read('assets/js/publish/transports/connect-transport.js');
+
+assert.match(editorEffects, /export function bindEventEffect/, 'effects boundary should own listener binding');
+assert.match(editorEffects, /export function createStorageEffects/, 'effects boundary should own safe storage access');
+assert.match(editorRuntime, /from '\.\/editor-effects\.js'/, 'editor runtime should compose shared effects');
+assert.doesNotMatch(editorRuntime, /function createRuntimeStorage|function createRuntimeEvents|function resolveWindowStorage/);
+
+assert.match(composerBootstrap, /from '\.\/editor-effects\.js'/, 'composer bootstrap should use shared DOM effects');
+assert.doesNotMatch(composerBootstrap, /\.addEventListener\(/, 'composer bootstrap should not bind raw DOM listeners directly');
+
+assert.match(themeManager, /from '\.\/editor-effects\.js'/, 'Theme Manager init should use shared DOM effects');
+assert.doesNotMatch(themeManager, /\.addEventListener\(/, 'Theme Manager root should not bind raw DOM listeners directly');
+
+assert.match(publishSettingsStore, /from '\.\.\/editor-effects\.js'/, 'publish settings should use shared storage effects');
+assert.doesNotMatch(
+  publishSettingsStore,
+  /windowRef\.(?:localStorage|sessionStorage)/,
+  'publish settings should not touch browser storage directly'
+);
+
+assert.match(connectTransport, /from '\.\.\/\.\.\/editor-effects\.js'/, 'Connect transport should use shared event effects');
+assert.match(connectTransport, /eventEffects\.onWindow\('message', onMessage\)/);
+assert.doesNotMatch(
+  connectTransport,
+  /windowRef\.(?:addEventListener|removeEventListener)\('message'/,
+  'Connect popup listener should be routed through shared event effects'
+);
+
+console.log('ok - editor effects boundary');

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -42,6 +42,7 @@ for command in \
   'node scripts/test-composer-action-contract.js' \
   'node scripts/test-composer-root-contract.js' \
   'node scripts/test-composer-root-boundaries.js' \
+  'node scripts/test-editor-effects-boundary.js' \
   'node scripts/test-composer-app-services.js' \
   'node scripts/test-composer-service-registry.js' \
   'node scripts/test-provider-adapters.js' \

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -308,6 +308,11 @@ if ! grep -qx "press-system-${version}/assets/js/editor-app-runtime.js" "${entri
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/editor-effects.js" "${entries_file}"; then
+  echo "expected package to include shared editor effects boundary code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/editor-boot-runtime.js" "${entries_file}"; then
   echo "expected package to include editor boot runtime boundary code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -108,6 +108,11 @@ if ! grep -F 'node scripts/test-composer-root-boundaries.js' "${workflow}" >/dev
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-editor-effects-boundary.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the shared editor effects boundary before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node scripts/test-composer-service-registry.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the composer service registry before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add `editor-effects.js` for shared listener, DOM query, event emission, and safe storage access effects
- route editor runtime, composer bootstrap, Theme Manager init, publish settings storage, and Connect popup message handling through the shared effects boundary
- add focused boundary tests, wire them into main guard/system release checks, include the new runtime module in package assertions, and bump the system marker to `v3.4.111`

## Verification
- `node --check assets/js/editor-effects.js && node --check assets/js/editor-app-runtime.js && node --check assets/js/composer-bootstrap.js && node --check assets/js/theme-manager.js && node --check assets/js/publish/settings-store.js && node --check assets/js/publish/transports/connect-transport.js && node --check scripts/test-editor-effects-boundary.js`
- `node scripts/test-editor-effects-boundary.js`
- `node scripts/test-composer-bootstrap.js`
- `node scripts/test-theme-manager.js`
- `node scripts/test-publish-commit-transports.js`
- `node scripts/test-editor-app-runtime.js && node scripts/test-editor-main-runtime.js && node scripts/test-composer-identity-grid.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-composer-root-contract.js && node scripts/test-composer-root-boundaries.js && node scripts/test-composer-action-contract.js && node scripts/test-composer-app-services.js && node scripts/test-composer-service-registry.js`
- `bash scripts/test-main-guard.sh && bash scripts/test-system-release-workflow.sh && node scripts/sync-runtime-cache-keys.mjs --check && node scripts/test-press-system-surface.mjs`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-pages-artifact.sh && bash scripts/test-pages-workflow.sh && node scripts/test-product-state-ledger.js`
- `bash scripts/test-system-release-package.sh`
- `node --experimental-default-type=module scripts/test-theme-contracts.js && node --experimental-default-type=module scripts/test-editor-blocks-roundtrip.js && bash scripts/test-frontmatter-roundtrip.sh`
- local in-app Browser smoke: `index_editor.html?smoke=editor-effects-boundary`, Publish open, Theme Manager available tab switch, no warning/error console logs
- pre-PR subagent review: no blockers

## Release impact
- Press system surface changes: yes, adds `assets/js/editor-effects.js`
- System version bump: `3.4.110` -> `3.4.111`
- Runtime/editor behavior change: no intended user-facing behavior change
- Starter/theme/Connect impact: downstream runtime sync expected; Connect server contract unchanged