### PR TITLE
Add publish flow smoke guard

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -33,6 +33,7 @@ jobs:
           node scripts/test-press-system-surface.mjs
           node scripts/test-editor-app-kernel.mjs
           node scripts/test-provider-adapters.js
+          node scripts/test-publish-flow-smoke.js
           node --experimental-default-type=module scripts/test-theme-contracts.js
           node scripts/test-release-targets.js
           node scripts/test-release-intent.js

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -34,6 +34,7 @@ jobs:
           node scripts/test-composer-service-registry.js
           node scripts/test-press-system-surface.mjs
           node scripts/test-editor-app-kernel.mjs
+          node scripts/test-publish-flow-smoke.js
           node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-system-release-package.sh
           bash scripts/test-system-release-workflow.sh

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -46,6 +46,7 @@ for command in \
   'node scripts/test-composer-app-services.js' \
   'node scripts/test-composer-service-registry.js' \
   'node scripts/test-provider-adapters.js' \
+  'node scripts/test-publish-flow-smoke.js' \
   'bash scripts/test-pages-artifact.sh'
 do
   if ! grep -F "${command}" "${workflow}" >/dev/null; then

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+
+import { createComposerPublishFlow } from '../assets/js/composer-publish-flow.js';
+
+function okJson(payload) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(payload),
+    text: () => Promise.resolve(JSON.stringify(payload))
+  };
+}
+
+function textResponse(text) {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(String(text || '')),
+    arrayBuffer: () => Promise.resolve(Buffer.from(String(text || ''), 'utf8').buffer)
+  };
+}
+
+function notFound() {
+  return {
+    ok: false,
+    status: 404,
+    text: () => Promise.resolve('')
+  };
+}
+
+function createFlowHarness() {
+  const calls = [];
+  const requests = [];
+  const liveFiles = new Map([
+    ['post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n'],
+    ['wwwroot/post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n']
+  ]);
+  const files = [
+    {
+      path: 'wwwroot/post/smoke.md',
+      label: 'Smoke post',
+      content: '# Smoke\n\nUpdated from publish flow.\n'
+    },
+    {
+      path: 'wwwroot/post/old.md',
+      label: 'Removed post',
+      deleted: true
+    }
+  ];
+
+  const fetchImpl = async (url, options = {}) => {
+    const target = String(url || '');
+    requests.push({ url: target, options });
+
+    if (target === 'https://connect.example/api/press/publish') {
+      const body = JSON.parse(String(options.body || '{}'));
+      return okJson({ ok: true, id: 'connect-smoke', body });
+    }
+
+    if (target === 'https://api.github.com/graphql') {
+      const body = JSON.parse(String(options.body || '{}'));
+      if (String(body.query || '').includes('createCommitOnBranch')) {
+        return okJson({
+          data: {
+            createCommitOnBranch: {
+              commit: { oid: 'publish-smoke-commit' }
+            }
+          }
+        });
+      }
+      return okJson({
+        data: {
+          repository: {
+            ref: {
+              target: { oid: 'publish-smoke-head' }
+            }
+          }
+        }
+      });
+    }
+
+    const clean = target.split('?')[0].replace(/^\/+/, '');
+    if (liveFiles.has(clean)) return textResponse(liveFiles.get(clean));
+    return notFound();
+  };
+
+  const flow = createComposerPublishFlow({
+    windowRef: { location: { origin: 'https://docs.example' } },
+    documentRef: {},
+    fetchImpl,
+    t: (key, values = {}) => values && values.count ? `${key}:${values.count}` : key,
+    getActiveSiteRepoConfig: () => ({ owner: 'EkilyHQ', name: 'Press', branch: 'main' }),
+    getTrackedPublishContentRoot: () => 'wwwroot',
+    gatherCommitPayload: async (options = {}) => {
+      calls.push(['gather', options.showSeoStatus === true]);
+      return { files: files.map(file => ({ ...file })) };
+    },
+    applyLocalPostCommitState: committedFiles => calls.push(['postCommit', committedFiles.map(file => file.path)]),
+    setTimeoutRef: (handler, delay) => {
+      calls.push(['timer', delay]);
+      handler();
+      return calls.length;
+    },
+    getCachedConnectPublishGrant: () => ({
+      token: 'grant-token',
+      baseUrl: 'https://connect.example',
+      owner: 'EkilyHQ',
+      name: 'Press',
+      branch: 'main'
+    }),
+    setCachedConnectPublishGrant: grant => calls.push(['setGrant', !!grant]),
+    clearCachedConnectPublishGrant: () => calls.push(['clearGrant']),
+    clearCachedFineGrainedToken: () => calls.push(['clearPat']),
+    showSyncOverlay: overlay => calls.push(['overlay:show', overlay.status]),
+    hideSyncOverlay: () => calls.push(['overlay:hide']),
+    setSyncOverlayStatus: status => calls.push(['status', status]),
+    setSyncOverlayMessage: message => calls.push(['message', message]),
+    setSyncOverlayCancelHandler: (handler) => calls.push(['cancelHandler', typeof handler === 'function']),
+    showToast: (kind, message, options = {}) => calls.push(['toast', kind, message, !!options.action]),
+    describeSummaryEntry: entry => entry && entry.label || 'summary',
+    switchToPatFallbackAndFocusToken: () => calls.push(['fallback']),
+    setGitHubCommitInFlight: value => calls.push(['inFlight', !!value]),
+    consoleRef: { error: (...args) => calls.push(['console:error', args.length]) }
+  });
+
+  return {
+    calls,
+    flow,
+    requests
+  };
+}
+
+{
+  const harness = createFlowHarness();
+  await harness.flow.performConnectGithubCommit({ baseUrl: 'https://connect.example' }, [
+    { kind: 'site', label: 'site.yaml' }
+  ]);
+
+  const connectPost = harness.requests.find(request => request.url === 'https://connect.example/api/press/publish');
+  assert.ok(connectPost, 'Connect smoke should POST to the Connect publish endpoint');
+  assert.equal(connectPost.options.referrerPolicy, 'unsafe-url');
+  assert.equal(connectPost.options.headers.Authorization, 'Bearer grant-token');
+  const connectBody = JSON.parse(connectPost.options.body);
+  assert.deepEqual(connectBody.repository, { owner: 'EkilyHQ', name: 'Press', branch: 'main' });
+  assert.equal(connectBody.contentRoot, 'wwwroot');
+  assert.equal(connectBody.message.headline, 'chore: sync drafts via Press');
+  assert.deepEqual(
+    connectBody.files.map(file => ({ path: file.path, deleted: !!file.deleted, hasContent: Object.prototype.hasOwnProperty.call(file, 'content') })),
+    [
+      { path: 'wwwroot/post/smoke.md', deleted: false, hasContent: true },
+      { path: 'wwwroot/post/old.md', deleted: true, hasContent: false }
+    ],
+    'Connect smoke should serialize additions and deletions in one publish payload'
+  );
+  assert.deepEqual(harness.calls.filter(call => call[0] === 'gather'), [['gather', true]]);
+  assert.ok(harness.calls.some(call => call[0] === 'postCommit' && call[1].includes('wwwroot/post/smoke.md')));
+  assert.ok(harness.calls.some(call => call[0] === 'status' && String(call[1]).startsWith('Checking Smoke post')));
+  assert.ok(harness.calls.some(call => call[0] === 'status' && String(call[1]).startsWith('Checking Removed post')));
+  assert.deepEqual(harness.calls.at(-2), ['toast', 'success', 'editor.toasts.commitSuccess:2', false]);
+  assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
+}
+
+{
+  const harness = createFlowHarness();
+  await harness.flow.performDirectGithubCommit('pat-token', [
+    { kind: 'site', label: 'site.yaml' }
+  ]);
+
+  const graphqlPosts = harness.requests.filter(request => request.url === 'https://api.github.com/graphql');
+  assert.equal(graphqlPosts.length, 2, 'PAT smoke should fetch branch state and create one commit');
+  assert.equal(graphqlPosts[0].options.headers.Authorization, 'Bearer pat-token');
+  const mutationBody = JSON.parse(graphqlPosts[1].options.body);
+  const mutationInput = mutationBody.variables.input;
+  assert.deepEqual(mutationInput.branch, {
+    repositoryNameWithOwner: 'EkilyHQ/Press',
+    branchName: 'main'
+  });
+  assert.equal(mutationInput.message.headline, 'chore: sync drafts via Press');
+  assert.equal(mutationInput.expectedHeadOid, 'publish-smoke-head');
+  assert.deepEqual(
+    mutationInput.fileChanges.additions.map(file => file.path),
+    ['wwwroot/post/smoke.md'],
+    'PAT smoke should include text additions'
+  );
+  assert.deepEqual(
+    mutationInput.fileChanges.deletions,
+    [{ path: 'wwwroot/post/old.md' }],
+    'PAT smoke should include deletions'
+  );
+  assert.equal(
+    Buffer.from(mutationInput.fileChanges.additions[0].contents, 'base64').toString('utf8'),
+    '# Smoke\n\nUpdated from publish flow.\n'
+  );
+  assert.ok(harness.calls.some(call => call[0] === 'status' && call[1] === 'Creating commit...'));
+  assert.ok(harness.calls.some(call => call[0] === 'status' && call[1] === 'All files confirmed on site.'));
+  assert.deepEqual(harness.calls.at(-2), ['toast', 'success', 'editor.toasts.commitSuccess:2', false]);
+  assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
+}
+
+console.log('ok - publish flow smoke');

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -128,6 +128,11 @@ if ! grep -F 'node scripts/test-editor-app-kernel.mjs' "${workflow}" >/dev/null;
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-publish-flow-smoke.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must run the publish flow smoke before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node --experimental-default-type=module scripts/test-theme-contracts.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the shared Press theme contract surface before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add a publish flow smoke test that drives the real `createComposerPublishFlow()` path
- cover Connect and PAT publish payloads, including additions, deletions, repository targeting, commit metadata, and propagation checks
- wire the smoke into main guard and system release verification

## Verification
- `node --check scripts/test-publish-flow-smoke.js`
- `node scripts/test-publish-flow-smoke.js`
- `node scripts/test-composer-publish-flow.js`
- `node scripts/test-publish-commit-transports.js`
- `node scripts/test-composer-sync-commit-controller.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node scripts/test-composer-root-contract.js && node scripts/test-composer-root-boundaries.js && node scripts/test-composer-action-contract.js && node scripts/test-editor-effects-boundary.js && node scripts/test-composer-app-services.js && node scripts/test-composer-service-registry.js && node scripts/test-ui-components.js`
- `node scripts/sync-runtime-cache-keys.mjs --check && node scripts/test-press-system-surface.mjs && node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-system-release-package.sh && bash scripts/test-pages-artifact.sh && bash scripts/test-pages-workflow.sh && node scripts/test-product-state-ledger.js`
- pre-PR subagent review: no blockers

## Release impact
- Press system surface changes: no runtime surface change
- System version bump: none; remains `v3.4.111`
- Runtime/editor behavior change: no intended user-facing behavior change
- Starter/theme/Connect impact: no downstream runtime sync expected unless release workflow policy changes