### PR TITLE
Record publish receipts in editor flow

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -34,6 +34,7 @@ jobs:
           node scripts/test-editor-app-kernel.mjs
           node scripts/test-provider-adapters.js
           node scripts/test-provider-boundary.js
+          node scripts/test-publish-receipt.js
           node scripts/test-publish-flow-smoke.js
           node --experimental-default-type=module scripts/test-theme-contracts.js
           node scripts/test-release-targets.js

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -36,6 +36,7 @@ jobs:
           node scripts/test-editor-app-kernel.mjs
           node scripts/test-provider-adapters.js
           node scripts/test-provider-boundary.js
+          node scripts/test-publish-receipt.js
           node scripts/test-publish-flow-smoke.js
           node --experimental-default-type=module scripts/test-theme-contracts.js
           bash scripts/test-system-release-package.sh

--- a/assets/js/composer-publish-flow.js
+++ b/assets/js/composer-publish-flow.js
@@ -1,11 +1,31 @@
 import { ensurePublishGrant, publishCommit as publishStagedCommit } from './publish/commit-service.js';
 import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js';
+import {
+  createPublishReceipt,
+  createPublishReceiptStore,
+  PUBLISH_STATES,
+  transitionPublishReceipt
+} from './publish/publish-receipt.js';
 
 function resolveAmbientFunction(name) {
   try {
     const scope = typeof globalThis === 'object' ? globalThis : null;
     const value = scope ? scope[name] : null;
     return typeof value === 'function' ? value.bind(scope) : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function resolveReceiptStorage(windowRef) {
+  try {
+    if (windowRef && windowRef.localStorage) return windowRef.localStorage;
+  } catch (_) {
+    return null;
+  }
+  try {
+    const scope = typeof globalThis === 'object' ? globalThis : null;
+    return scope && scope.localStorage ? scope.localStorage : null;
   } catch (_) {
     return null;
   }
@@ -34,6 +54,10 @@ export function createComposerPublishFlow({
   describeSummaryEntry = (entry) => entry && (entry.label || entry.path || entry.kind) || '',
   switchToPatFallbackAndFocusToken = () => {},
   setGitHubCommitInFlight = () => {},
+  publishReceiptStore = null,
+  onPublishReceipt = () => {},
+  createPublishRunId = null,
+  now = null,
   consoleRef = null
 } = {}) {
   const fetchRef = typeof fetchImpl === 'function'
@@ -47,6 +71,15 @@ export function createComposerPublishFlow({
     if (timerRef) timerRef(resolve, timeout);
     else resolve();
   });
+  const receiptStore = publishReceiptStore || createPublishReceiptStore({
+    storage: resolveReceiptStorage(windowRef)
+  });
+
+  function savePublishReceipt(receipt) {
+    if (!receipt) return;
+    if (receiptStore && typeof receiptStore.save === 'function') receiptStore.save(receipt);
+    if (typeof onPublishReceipt === 'function') onPublishReceipt(receipt);
+  }
 
   async function waitForRemotePropagation(files = []) {
     return waitForPublishedFiles(files, {
@@ -74,6 +107,18 @@ export function createComposerPublishFlow({
     });
 
     let connectFallbackActionAvailable = false;
+    let publishReceipt = null;
+    const setPublishReceiptState = (state, patch = {}) => {
+      if (!publishReceipt) return;
+      publishReceipt = transitionPublishReceipt(publishReceipt, state, patch, { now });
+      savePublishReceipt(publishReceipt);
+    };
+    const handlePublishStatus = (message) => {
+      setSyncOverlayStatus(message);
+    };
+    const handlePublishState = (state) => {
+      setPublishReceiptState(state);
+    };
     try {
       const { files } = await gatherCommitPayload({ showSeoStatus: true });
       if (!files.length) {
@@ -83,42 +128,69 @@ export function createComposerPublishFlow({
       }
 
       const headline = `chore: sync ${files.length === 1 ? 'draft' : 'drafts'} via Press`;
+      const repo = { owner, name, branch };
+      const contentRoot = getTrackedPublishContentRoot();
+      publishReceipt = createPublishReceipt({
+        repo,
+        transport,
+        contentRoot,
+        headline,
+        files,
+        now,
+        runId: typeof createPublishRunId === 'function'
+          ? createPublishRunId({ repo, transport, headline, files })
+          : null
+      });
+      savePublishReceipt(publishReceipt);
+      let publishResult = null;
       if (transport && transport.type === 'connect') {
         connectFallbackActionAvailable = true;
-        await publishStagedCommit({
+        publishResult = await publishStagedCommit({
           transport,
-          repo: { owner, name, branch },
+          repo,
           headline,
           files,
-          contentRoot: getTrackedPublishContentRoot(),
+          contentRoot,
           getCachedGrant: getCachedConnectPublishGrant,
           setCachedGrant: setCachedConnectPublishGrant,
           windowRef,
           documentRef,
           fetchImpl: fetchRef,
           translate: t,
-          onStatus: setSyncOverlayStatus
+          onStatus: handlePublishStatus,
+          onPublishState: handlePublishState
         });
         connectFallbackActionAvailable = false;
       } else {
-        await publishStagedCommit({
+        publishResult = await publishStagedCommit({
           transport,
-          repo: { owner, name, branch },
+          repo,
           headline,
           files,
           fetchImpl: fetchRef,
           translate: t,
-          onStatus: setSyncOverlayStatus
+          onStatus: handlePublishStatus,
+          onPublishState: handlePublishState
         });
       }
 
+      setPublishReceiptState(PUBLISH_STATES.COMMITTED, { publishResult });
+      setPublishReceiptState(PUBLISH_STATES.APPLYING_LOCAL_STATE);
       setSyncOverlayStatus('Updating editor state…');
       applyLocalPostCommitState(files);
 
       const fileCount = files.length;
       const summaryLabel = fileCount === 1 ? describeSummaryEntry(summaryEntries[0] || files[0]) : `${fileCount} files`;
-      setSyncOverlayMessage(`Commit pushed for ${summaryLabel}. Waiting for the site to update… This can take a few minutes. If you stop waiting, the commit stays on GitHub but the live site might not show the changes yet.`);
+      setPublishReceiptState(PUBLISH_STATES.OBSERVING_PROPAGATION);
+      setSyncOverlayMessage(`Commit accepted for ${summaryLabel}. Press recorded a local publish receipt and is checking the live site… This can take a few minutes. If you stop waiting, the commit stays on GitHub but the live site might not show the changes yet.`);
       const propagationResult = await waitForRemotePropagation(files);
+      setPublishReceiptState(propagationResult && propagationResult.canceled
+        ? PUBLISH_STATES.CANCELED
+        : propagationResult && propagationResult.timedOut
+          ? PUBLISH_STATES.TIMED_OUT
+          : PUBLISH_STATES.OBSERVED, {
+        propagation: propagationResult
+      });
 
       hideSyncOverlay();
       if (propagationResult && propagationResult.canceled) {
@@ -128,7 +200,9 @@ export function createComposerPublishFlow({
       } else {
         showToast('success', t('editor.toasts.commitSuccess', { count: fileCount }));
       }
+      return publishReceipt;
     } catch (err) {
+      setPublishReceiptState(PUBLISH_STATES.FAILED, { error: err });
       hideSyncOverlay();
       let message = err && err.message ? err.message : t('editor.toasts.githubCommitFailed');
       if (err && err.status === 401) {
@@ -154,6 +228,7 @@ export function createComposerPublishFlow({
         };
       }
       showToast('error', message, toastOptions);
+      return publishReceipt;
     } finally {
       setGitHubCommitInFlight(false);
     }

--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -23,6 +23,38 @@ export async function ensurePublishGrant({
   });
 }
 
+function emitPublishState(onPublishState, state) {
+  if (typeof onPublishState === 'function') onPublishState(state);
+}
+
+function normalizeConnectPublishResult(payload) {
+  const source = payload && typeof payload === 'object' ? payload : {};
+  const out = {
+    ok: source.ok !== false,
+    provider: 'connect',
+    transport: 'connect'
+  };
+  if (source.id) out.id = String(source.id);
+  if (source.requestId) out.requestId = String(source.requestId);
+  const commit = source.commit && typeof source.commit === 'object' ? source.commit : null;
+  const oid = (commit && (commit.oid || commit.sha || commit.id)) || source.commitSha || source.commitId;
+  if (oid) out.commit = { oid: String(oid) };
+  if ((commit && commit.url) || source.commitUrl) {
+    out.commit = { ...(out.commit || {}), url: String((commit && commit.url) || source.commitUrl) };
+  }
+  return out;
+}
+
+function normalizePatPublishResult(payload) {
+  const source = payload && typeof payload === 'object' ? payload : {};
+  return {
+    ...source,
+    ok: source.ok !== false,
+    provider: source.provider || 'github',
+    transport: source.transport || 'pat'
+  };
+}
+
 export async function publishCommit({
   transport,
   repo,
@@ -35,7 +67,8 @@ export async function publishCommit({
   documentRef = null,
   fetchImpl = null,
   translate = (key) => key,
-  onStatus
+  onStatus,
+  onPublishState
 } = {}) {
   const owner = repo && repo.owner ? String(repo.owner) : '';
   const name = repo && repo.name ? String(repo.name) : '';
@@ -45,6 +78,7 @@ export async function publishCommit({
   }
 
   if (transport && transport.type === 'connect') {
+    emitPublishState(onPublishState, 'authorizing');
     if (typeof onStatus === 'function') onStatus(translate('editor.composer.github.modal.connectAuthorizing'));
     const grant = await ensurePublishGrant({
       connect: transport.connect,
@@ -55,8 +89,9 @@ export async function publishCommit({
       documentRef,
       translate
     });
+    emitPublishState(onPublishState, 'committing');
     if (typeof onStatus === 'function') onStatus(translate('editor.composer.github.modal.connectPublishing'));
-    return createConnectPublishCommit({
+    const payload = await createConnectPublishCommit({
       connect: transport.connect,
       repo: { owner, name, branch },
       headline,
@@ -66,10 +101,12 @@ export async function publishCommit({
       fetchImpl,
       translate
     });
+    return normalizeConnectPublishResult(payload);
   }
 
+  emitPublishState(onPublishState, 'committing');
   const { createFineGrainedTokenCommit } = await import('./transports/github-pat-transport.js');
-  return createFineGrainedTokenCommit(transport && transport.token, {
+  const payload = await createFineGrainedTokenCommit(transport && transport.token, {
     owner,
     name,
     branch,
@@ -78,4 +115,5 @@ export async function publishCommit({
     fetchImpl,
     onStatus
   });
+  return normalizePatPublishResult(payload);
 }

--- a/assets/js/publish/publish-receipt.js
+++ b/assets/js/publish/publish-receipt.js
@@ -1,0 +1,275 @@
+export const PUBLISH_RECEIPT_TYPE = 'press-publish-receipt';
+export const PUBLISH_RECEIPT_SCHEMA_VERSION = 1;
+export const PUBLISH_RECEIPT_LATEST_STORAGE_KEY = 'press.publish.latestReceipt.v1';
+export const PUBLISH_RECEIPT_LIST_STORAGE_KEY = 'press.publish.receipts.v1';
+
+export const PUBLISH_STATES = Object.freeze({
+  PREPARING: 'preparing',
+  AUTHORIZING: 'authorizing',
+  COMMITTING: 'committing',
+  COMMITTED: 'committed',
+  APPLYING_LOCAL_STATE: 'applyingLocalState',
+  OBSERVING_PROPAGATION: 'observingPropagation',
+  OBSERVED: 'observed',
+  TIMED_OUT: 'timedOut',
+  CANCELED: 'canceled',
+  FAILED: 'failed'
+});
+
+const TERMINAL_STATES = new Set([
+  PUBLISH_STATES.OBSERVED,
+  PUBLISH_STATES.TIMED_OUT,
+  PUBLISH_STATES.CANCELED,
+  PUBLISH_STATES.FAILED
+]);
+
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
+function isoNow(now) {
+  try {
+    const value = typeof now === 'function' ? now() : now;
+    if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString();
+    if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+    const text = safeString(value).trim();
+    if (text) {
+      const date = new Date(text);
+      if (!Number.isNaN(date.getTime())) return date.toISOString();
+    }
+  } catch (_) {}
+  return new Date().toISOString();
+}
+
+function createDefaultRunId(at) {
+  const stamp = safeString(at).replace(/[^0-9A-Za-z]/g, '').slice(0, 17) || 'publish';
+  let suffix = '';
+  try {
+    const cryptoRef = typeof globalThis === 'object' ? globalThis.crypto : null;
+    if (cryptoRef && typeof cryptoRef.randomUUID === 'function') {
+      suffix = cryptoRef.randomUUID().replace(/-/g, '').slice(0, 10);
+    }
+  } catch (_) {}
+  if (!suffix) {
+    suffix = Math.random().toString(36).slice(2, 12);
+  }
+  return `pub-${stamp}-${suffix}`;
+}
+
+function normalizeRepository(repo = {}) {
+  const source = repo && typeof repo === 'object' ? repo : {};
+  return {
+    owner: safeString(source.owner).trim(),
+    name: safeString(source.name).trim(),
+    branch: safeString(source.branch || 'main').trim() || 'main'
+  };
+}
+
+function normalizeTransport(transport = {}) {
+  const source = transport && typeof transport === 'object' ? transport : {};
+  const type = source.type === 'connect' ? 'connect' : 'pat';
+  const out = { type };
+  if (type === 'connect' && source.connect && source.connect.baseUrl) {
+    try {
+      out.connectBaseUrl = new URL(String(source.connect.baseUrl)).origin;
+    } catch (_) {
+      out.connectBaseUrl = safeString(source.connect.baseUrl).trim().split(/[?#]/)[0].replace(/\/+$/, '');
+    }
+  }
+  return out;
+}
+
+function normalizeContentRoot(value) {
+  const clean = safeString(value || 'wwwroot').replace(/\\+/g, '/').replace(/^\/+|\/+$/g, '');
+  return clean || 'wwwroot';
+}
+
+function summarizeFile(file = {}) {
+  const source = file && typeof file === 'object' ? file : {};
+  const out = {
+    path: safeString(source.path).replace(/\\+/g, '/').replace(/^\/+/, ''),
+    deleted: !!source.deleted
+  };
+  if (source.kind) out.kind = safeString(source.kind);
+  if (source.label) out.label = safeString(source.label);
+  if (source.binary) out.binary = true;
+  if (source.mime) out.mime = safeString(source.mime);
+  if (source.assetRelativePath) out.assetRelativePath = safeString(source.assetRelativePath).replace(/\\+/g, '/').replace(/^\/+/, '');
+  if (source.markdownPath) out.markdownPath = safeString(source.markdownPath).replace(/\\+/g, '/').replace(/^\/+/, '');
+  return out;
+}
+
+function normalizeCommitInfo(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const commit = source.commit && typeof source.commit === 'object' ? source.commit : null;
+  const oid = safeString(
+    commit && (commit.oid || commit.sha || commit.id)
+      || source.oid
+      || source.sha
+      || source.commitSha
+      || source.commitId
+  ).trim();
+  if (!oid) return null;
+  const out = { oid };
+  if ((commit && commit.url) || source.commitUrl) out.url = safeString((commit && commit.url) || source.commitUrl).trim();
+  return out;
+}
+
+function normalizePublishResult(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const out = {};
+  if (source.provider) out.provider = safeString(source.provider);
+  if (source.transport) out.transport = safeString(source.transport);
+  if (source.id || source.requestId) out.id = safeString(source.id || source.requestId);
+  if (source.branchName) out.branchName = safeString(source.branchName);
+  if (source.expectedHeadOid) out.expectedHeadOid = safeString(source.expectedHeadOid);
+  return Object.keys(out).length ? out : null;
+}
+
+function normalizePropagation(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  return {
+    canceled: !!source.canceled,
+    timedOut: !!source.timedOut,
+    observed: !source.canceled && !source.timedOut
+  };
+}
+
+export function classifyPublishError(err) {
+  const status = err && Number.isFinite(Number(err.status)) ? Number(err.status) : null;
+  let kind = 'unknown';
+  if (status === 401) kind = 'authentication';
+  else if (status === 403) kind = 'permission';
+  else if (status && status >= 500) kind = 'upstream';
+  else if (err && err.cause) kind = 'network';
+  else if (err && err.name === 'AbortError') kind = 'canceled';
+  return {
+    kind,
+    status,
+    message: err && err.message ? String(err.message) : 'Publish failed.'
+  };
+}
+
+export function createPublishReceipt({
+  repo,
+  transport,
+  contentRoot,
+  headline,
+  files,
+  now,
+  runId
+} = {}) {
+  const startedAt = isoNow(now);
+  const fileSummaries = (Array.isArray(files) ? files : []).map(summarizeFile).filter(file => file.path);
+  const id = safeString(runId).trim() || createDefaultRunId(startedAt);
+  return {
+    schemaVersion: PUBLISH_RECEIPT_SCHEMA_VERSION,
+    type: PUBLISH_RECEIPT_TYPE,
+    runId: id,
+    state: PUBLISH_STATES.PREPARING,
+    startedAt,
+    updatedAt: startedAt,
+    finishedAt: null,
+    repository: normalizeRepository(repo),
+    transport: normalizeTransport(transport),
+    contentRoot: normalizeContentRoot(contentRoot),
+    headline: safeString(headline).trim(),
+    fileCount: fileSummaries.length,
+    files: fileSummaries,
+    commit: null,
+    publish: null,
+    propagation: null,
+    error: null,
+    history: [
+      { state: PUBLISH_STATES.PREPARING, at: startedAt }
+    ]
+  };
+}
+
+export function transitionPublishReceipt(receipt, state, patch = {}, options = {}) {
+  if (!receipt || typeof receipt !== 'object') return null;
+  const nextState = safeString(state).trim() || receipt.state || PUBLISH_STATES.PREPARING;
+  const at = isoNow(options.now);
+  const next = {
+    ...receipt,
+    state: nextState,
+    updatedAt: at,
+    history: Array.isArray(receipt.history) ? receipt.history.slice() : []
+  };
+  next.history.push({ state: nextState, at });
+  if (TERMINAL_STATES.has(nextState)) next.finishedAt = at;
+
+  if (patch.publishResult) {
+    const commit = normalizeCommitInfo(patch.publishResult);
+    const publish = normalizePublishResult(patch.publishResult);
+    if (commit) next.commit = commit;
+    if (publish) next.publish = publish;
+  }
+  if (patch.commit) {
+    const commit = normalizeCommitInfo(patch.commit);
+    if (commit) next.commit = commit;
+  }
+  if (patch.propagation) next.propagation = normalizePropagation(patch.propagation);
+  if (patch.error) next.error = classifyPublishError(patch.error);
+  return next;
+}
+
+function parseReceiptList(text) {
+  try {
+    const value = JSON.parse(String(text || '[]'));
+    return Array.isArray(value) ? value : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+export function createPublishReceiptStore({
+  storage = null,
+  latestKey = PUBLISH_RECEIPT_LATEST_STORAGE_KEY,
+  listKey = PUBLISH_RECEIPT_LIST_STORAGE_KEY,
+  limit = 10
+} = {}) {
+  function getItem(key) {
+    try {
+      return storage && typeof storage.getItem === 'function' ? storage.getItem(key) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function setItem(key, value) {
+    try {
+      if (!storage || typeof storage.setItem !== 'function') return false;
+      storage.setItem(key, String(value));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function save(receipt) {
+    if (!receipt || typeof receipt !== 'object') return false;
+    const serialized = JSON.stringify(receipt);
+    const latestSaved = setItem(latestKey, serialized);
+    const existing = parseReceiptList(getItem(listKey)).filter(item => item && item.runId !== receipt.runId);
+    existing.unshift(receipt);
+    const bounded = existing.slice(0, Math.max(1, Number(limit) || 10));
+    const listSaved = setItem(listKey, JSON.stringify(bounded));
+    return latestSaved || listSaved;
+  }
+
+  function loadLatest() {
+    try {
+      const value = JSON.parse(String(getItem(latestKey) || 'null'));
+      return value && value.type === PUBLISH_RECEIPT_TYPE ? value : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function list() {
+    return parseReceiptList(getItem(listKey)).filter(item => item && item.type === PUBLISH_RECEIPT_TYPE);
+  }
+
+  return { save, loadLatest, list };
+}

--- a/assets/js/publish/transports/github-pat-transport.js
+++ b/assets/js/publish/transports/github-pat-transport.js
@@ -169,5 +169,14 @@ export async function createFineGrainedTokenCommit(token, { owner, name, branch,
   };
 
   reportStatus('Creating commit...');
-  await githubGraphqlRequest(token, commitMutation, { input: mutationInput }, fetchImpl, provider);
+  const commitData = await githubGraphqlRequest(token, commitMutation, { input: mutationInput }, fetchImpl, provider);
+  const createdCommit = commitData && commitData.createCommitOnBranch && commitData.createCommitOnBranch.commit;
+  return {
+    ok: true,
+    provider: 'github',
+    transport: 'pat',
+    branchName,
+    expectedHeadOid,
+    commit: createdCommit && createdCommit.oid ? { oid: createdCommit.oid } : null
+  };
 }

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.112",
-  "tag": "v3.4.112",
+  "version": "3.4.113",
+  "tag": "v3.4.113",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.111 <3.4.112"
+      ">=3.4.112 <3.4.113"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.111 first."
+    "message": "Update to v3.4.112 first."
   }
 }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -5878,8 +5878,8 @@ assert.doesNotMatch(
 
 assert.match(
   composerPublishFlowSource,
-  /publishStagedCommit\(\{[\s\S]*transport,[\s\S]*repo: \{ owner, name, branch \},[\s\S]*fetchImpl: fetchRef,[\s\S]*onStatus: setSyncOverlayStatus[\s\S]*\}\);[\s\S]*publishStagedCommit\(\{[\s\S]*transport,[\s\S]*repo: \{ owner, name, branch \},[\s\S]*fetchImpl: fetchRef,[\s\S]*onStatus: setSyncOverlayStatus/,
-  'composer publish flow should pass runtime fetch into both Connect and PAT commit transports'
+  /publishResult = await publishStagedCommit\(\{[\s\S]*transport,[\s\S]*repo,[\s\S]*fetchImpl: fetchRef,[\s\S]*onStatus: handlePublishStatus,[\s\S]*onPublishState: handlePublishState[\s\S]*\}\);[\s\S]*publishResult = await publishStagedCommit\(\{[\s\S]*transport,[\s\S]*repo,[\s\S]*fetchImpl: fetchRef,[\s\S]*onStatus: handlePublishStatus,[\s\S]*onPublishState: handlePublishState/,
+  'composer publish flow should pass runtime fetch and publish-state callbacks into both Connect and PAT commit transports'
 );
 
 assert.doesNotMatch(
@@ -7573,7 +7573,7 @@ assert.match(
 
 assert.match(
   composerPublishFlowSource,
-  /let connectFallbackActionAvailable = false;[\s\S]*const \{ files \} = await gatherCommitPayload\(\{ showSeoStatus: true \}\);[\s\S]*connectFallbackActionAvailable = true;[\s\S]*await publishStagedCommit\(\{[\s\S]*transport,[\s\S]*getCachedGrant: getCachedConnectPublishGrant[\s\S]*connectFallbackActionAvailable = false;[\s\S]*if \(transport && transport\.type === 'connect' && connectFallbackActionAvailable\) \{[\s\S]*toastOptions\.action = \{[\s\S]*connectFallback[\s\S]*switchToPatFallbackAndFocusToken\(\);[\s\S]*showToast\('error', message, toastOptions\);/,
+  /let connectFallbackActionAvailable = false;[\s\S]*const \{ files \} = await gatherCommitPayload\(\{ showSeoStatus: true \}\);[\s\S]*connectFallbackActionAvailable = true;[\s\S]*publishResult = await publishStagedCommit\(\{[\s\S]*transport,[\s\S]*getCachedGrant: getCachedConnectPublishGrant[\s\S]*connectFallbackActionAvailable = false;[\s\S]*if \(transport && transport\.type === 'connect' && connectFallbackActionAvailable\) \{[\s\S]*toastOptions\.action = \{[\s\S]*connectFallback[\s\S]*switchToPatFallbackAndFocusToken\(\);[\s\S]*showToast\('error', message, toastOptions\);/,
   'Only Connect authorization and publish failures should expose a toast action that switches to PAT fallback'
 );
 

--- a/scripts/test-composer-publish-flow.js
+++ b/scripts/test-composer-publish-flow.js
@@ -16,6 +16,17 @@ function installAmbientGlobal(name, value) {
 }
 
 {
+  const windowRef = {};
+  Object.defineProperty(windowRef, 'localStorage', {
+    configurable: true,
+    get() {
+      throw new Error('localStorage unavailable');
+    }
+  });
+  assert.doesNotThrow(() => createComposerPublishFlow({ windowRef }));
+}
+
+{
   const urls = [];
   const delays = [];
   let now = 5000;

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -47,6 +47,7 @@ for command in \
   'node scripts/test-composer-service-registry.js' \
   'node scripts/test-provider-adapters.js' \
   'node scripts/test-provider-boundary.js' \
+  'node scripts/test-publish-receipt.js' \
   'node scripts/test-publish-flow-smoke.js' \
   'bash scripts/test-pages-artifact.sh'
 do

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -236,13 +236,21 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   const restores = ['fetch', 'window', 'document', 'btoa'].map((name) => installAmbientTrap(name, ambientCalls));
   const requests = [];
   try {
-    await createFineGrainedTokenCommit('pat-token', {
+    const result = await createFineGrainedTokenCommit('pat-token', {
       owner: 'EkilyHQ',
       name: 'Press',
       branch: 'main',
       headline: 'Sync draft',
       files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
       fetchImpl: createGithubFetchRecorder(requests)
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      provider: 'github',
+      transport: 'pat',
+      branchName: 'main',
+      expectedHeadOid: 'abc123',
+      commit: { oid: 'def456' }
     });
   } finally {
     restores.reverse().forEach((restore) => restore());
@@ -258,7 +266,7 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   const provider = createGitHubSiteRepositoryProvider({
     apiBaseUrl: 'https://api.git.example.test'
   });
-  await createFineGrainedTokenCommit('pat-token', {
+  const result = await createFineGrainedTokenCommit('pat-token', {
     owner: 'EkilyHQ',
     name: 'Press',
     branch: 'refs/heads/feature/provider',
@@ -267,6 +275,8 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
     fetchImpl: createGithubFetchRecorder(requests),
     siteRepositoryProvider: provider
   });
+  assert.equal(result.branchName, 'feature/provider');
+  assert.equal(result.commit.oid, 'def456');
   assert.equal(requests.length, 2);
   assert.equal(requests[0].url, 'https://api.git.example.test/graphql');
   assert.equal(requests[0].body.variables.ref, 'refs/heads/feature/provider');
@@ -306,19 +316,25 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   const ambientCalls = [];
   const restores = ['fetch', 'window', 'document', 'btoa'].map((name) => installAmbientTrap(name, ambientCalls));
   const patRequests = [];
+  const states = [];
   try {
-    await publishCommit({
+    const result = await publishCommit({
       transport: { type: 'pat', token: 'pat-token' },
       repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
       headline: 'Sync draft',
       files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
-      fetchImpl: createGithubFetchRecorder(patRequests)
+      fetchImpl: createGithubFetchRecorder(patRequests),
+      onPublishState: state => states.push(state)
     });
+    assert.equal(result.provider, 'github');
+    assert.equal(result.transport, 'pat');
+    assert.equal(result.commit.oid, 'def456');
   } finally {
     restores.reverse().forEach((restore) => restore());
   }
   assert.equal(patRequests.length, 2);
   assert.equal(patRequests[1].body.variables.input.fileChanges.additions[0].contents, expectedBase64);
+  assert.deepEqual(states, ['committing']);
   assert.deepEqual(ambientCalls, [], 'publish commit service should pass injected fetch into the PAT transport');
 }
 
@@ -326,8 +342,9 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   const ambientCalls = [];
   const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
   const requests = [];
+  const states = [];
   try {
-    await publishCommit({
+    const result = await publishCommit({
       transport: { type: 'connect', connect: { baseUrl: 'https://connect.example' } },
       repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
       headline: 'Sync draft',
@@ -342,13 +359,22 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
       }),
       fetchImpl(url, options) {
         requests.push({ url, options });
-        return Promise.resolve(okJson({ ok: true, id: 'published' }));
-      }
+        return Promise.resolve(okJson({ ok: true, id: 'published', commit: { oid: 'connect-commit' } }));
+      },
+      onPublishState: state => states.push(state)
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      provider: 'connect',
+      transport: 'connect',
+      id: 'published',
+      commit: { oid: 'connect-commit' }
     });
   } finally {
     restores.reverse().forEach((restore) => restore());
   }
   assert.equal(requests.length, 1);
   assert.equal(requests[0].url, 'https://connect.example/api/press/publish');
+  assert.deepEqual(states, ['authorizing', 'committing']);
   assert.deepEqual(ambientCalls, [], 'publish commit service should pass injected fetch into the Connect transport');
 }

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 
 import { createComposerPublishFlow } from '../assets/js/composer-publish-flow.js';
+import {
+  PUBLISH_RECEIPT_LATEST_STORAGE_KEY,
+  PUBLISH_STATES
+} from '../assets/js/publish/publish-receipt.js';
 
 function okJson(payload) {
   return {
@@ -28,9 +32,23 @@ function notFound() {
   };
 }
 
+function createMemoryStorage() {
+  const data = new Map();
+  return {
+    getItem(key) {
+      return data.has(key) ? data.get(key) : null;
+    },
+    setItem(key, value) {
+      data.set(key, String(value));
+    }
+  };
+}
+
 function createFlowHarness() {
   const calls = [];
   const requests = [];
+  const receipts = [];
+  const receiptStorage = createMemoryStorage();
   const liveFiles = new Map([
     ['post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n'],
     ['wwwroot/post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n']
@@ -54,7 +72,7 @@ function createFlowHarness() {
 
     if (target === 'https://connect.example/api/press/publish') {
       const body = JSON.parse(String(options.body || '{}'));
-      return okJson({ ok: true, id: 'connect-smoke', body });
+      return okJson({ ok: true, id: 'connect-smoke', commit: { oid: 'connect-smoke-commit' }, body });
     }
 
     if (target === 'https://api.github.com/graphql') {
@@ -85,7 +103,10 @@ function createFlowHarness() {
   };
 
   const flow = createComposerPublishFlow({
-    windowRef: { location: { origin: 'https://docs.example' } },
+    windowRef: {
+      location: { origin: 'https://docs.example' },
+      localStorage: receiptStorage
+    },
     documentRef: {},
     fetchImpl,
     t: (key, values = {}) => values && values.count ? `${key}:${values.count}` : key,
@@ -120,12 +141,16 @@ function createFlowHarness() {
     describeSummaryEntry: entry => entry && entry.label || 'summary',
     switchToPatFallbackAndFocusToken: () => calls.push(['fallback']),
     setGitHubCommitInFlight: value => calls.push(['inFlight', !!value]),
+    onPublishReceipt: receipt => receipts.push(receipt),
+    createPublishRunId: () => 'smoke-receipt',
     consoleRef: { error: (...args) => calls.push(['console:error', args.length]) }
   });
 
   return {
     calls,
     flow,
+    receiptStorage,
+    receipts,
     requests
   };
 }
@@ -156,6 +181,26 @@ function createFlowHarness() {
   assert.ok(harness.calls.some(call => call[0] === 'postCommit' && call[1].includes('wwwroot/post/smoke.md')));
   assert.ok(harness.calls.some(call => call[0] === 'status' && String(call[1]).startsWith('Checking Smoke post')));
   assert.ok(harness.calls.some(call => call[0] === 'status' && String(call[1]).startsWith('Checking Removed post')));
+  assert.deepEqual(harness.receipts.map(receipt => receipt.state), [
+    PUBLISH_STATES.PREPARING,
+    PUBLISH_STATES.AUTHORIZING,
+    PUBLISH_STATES.COMMITTING,
+    PUBLISH_STATES.COMMITTED,
+    PUBLISH_STATES.APPLYING_LOCAL_STATE,
+    PUBLISH_STATES.OBSERVING_PROPAGATION,
+    PUBLISH_STATES.OBSERVED
+  ]);
+  const finalReceipt = harness.receipts.at(-1);
+  assert.equal(finalReceipt.repository.owner, 'EkilyHQ');
+  assert.equal(finalReceipt.transport.type, 'connect');
+  assert.equal(finalReceipt.fileCount, 2);
+  assert.equal(finalReceipt.commit.oid, 'connect-smoke-commit');
+  assert.deepEqual(finalReceipt.propagation, { canceled: false, timedOut: false, observed: true });
+  const storedReceipt = JSON.parse(harness.receiptStorage.getItem(PUBLISH_RECEIPT_LATEST_STORAGE_KEY));
+  assert.equal(storedReceipt.runId, 'smoke-receipt');
+  assert.equal(JSON.stringify(storedReceipt).includes('grant-token'), false);
+  assert.equal(JSON.stringify(storedReceipt).includes('Updated from publish flow'), false);
+  assert.equal(JSON.stringify(storedReceipt).includes('base64'), false);
   assert.deepEqual(harness.calls.at(-2), ['toast', 'success', 'editor.toasts.commitSuccess:2', false]);
   assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
 }
@@ -193,6 +238,18 @@ function createFlowHarness() {
   );
   assert.ok(harness.calls.some(call => call[0] === 'status' && call[1] === 'Creating commit...'));
   assert.ok(harness.calls.some(call => call[0] === 'status' && call[1] === 'All files confirmed on site.'));
+  assert.deepEqual(harness.receipts.map(receipt => receipt.state), [
+    PUBLISH_STATES.PREPARING,
+    PUBLISH_STATES.COMMITTING,
+    PUBLISH_STATES.COMMITTED,
+    PUBLISH_STATES.APPLYING_LOCAL_STATE,
+    PUBLISH_STATES.OBSERVING_PROPAGATION,
+    PUBLISH_STATES.OBSERVED
+  ]);
+  const finalReceipt = harness.receipts.at(-1);
+  assert.equal(finalReceipt.transport.type, 'pat');
+  assert.equal(finalReceipt.commit.oid, 'publish-smoke-commit');
+  assert.equal(JSON.stringify(finalReceipt).includes('pat-token'), false);
   assert.deepEqual(harness.calls.at(-2), ['toast', 'success', 'editor.toasts.commitSuccess:2', false]);
   assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
 }

--- a/scripts/test-publish-receipt.js
+++ b/scripts/test-publish-receipt.js
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+
+import {
+  createPublishReceipt,
+  createPublishReceiptStore,
+  PUBLISH_STATES,
+  transitionPublishReceipt
+} from '../assets/js/publish/publish-receipt.js';
+
+function createMemoryStorage() {
+  const data = new Map();
+  return {
+    data,
+    getItem(key) {
+      return data.has(key) ? data.get(key) : null;
+    },
+    setItem(key, value) {
+      data.set(key, String(value));
+    }
+  };
+}
+
+function createClock() {
+  const values = [
+    '2026-05-31T00:00:00.000Z',
+    '2026-05-31T00:00:01.000Z',
+    '2026-05-31T00:00:02.000Z',
+    '2026-05-31T00:00:03.000Z'
+  ];
+  let index = 0;
+  return () => values[Math.min(index++, values.length - 1)];
+}
+
+{
+  const now = createClock();
+  const receipt = createPublishReceipt({
+    repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+    transport: {
+      type: 'connect',
+      token: 'pat-token-must-not-leak',
+      connect: { baseUrl: 'https://connect.example/path?grant=secret' }
+    },
+    contentRoot: '/wwwroot/',
+    headline: 'chore: sync drafts via Press',
+    files: [
+      {
+        path: '/wwwroot/post/main.md',
+        label: 'Main post',
+        content: 'private draft body',
+        base64: 'cHJpdmF0ZS1kcmFmdA==',
+        kind: 'post'
+      },
+      {
+        path: 'wwwroot/media/photo.jpg',
+        label: 'Photo',
+        binary: true,
+        mime: 'image/jpeg',
+        base64: 'private-image-bytes'
+      },
+      { path: 'wwwroot/post/old.md', deleted: true, content: 'removed body' }
+    ],
+    now,
+    runId: 'receipt-test'
+  });
+
+  assert.equal(receipt.runId, 'receipt-test');
+  assert.equal(receipt.state, PUBLISH_STATES.PREPARING);
+  assert.equal(receipt.contentRoot, 'wwwroot');
+  assert.deepEqual(receipt.repository, { owner: 'EkilyHQ', name: 'Press', branch: 'main' });
+  assert.deepEqual(receipt.transport, { type: 'connect', connectBaseUrl: 'https://connect.example' });
+  assert.equal(receipt.fileCount, 3);
+  assert.deepEqual(
+    receipt.files.map(file => ({
+      path: file.path,
+      deleted: file.deleted,
+      binary: !!file.binary,
+      hasContent: Object.prototype.hasOwnProperty.call(file, 'content'),
+      hasBase64: Object.prototype.hasOwnProperty.call(file, 'base64')
+    })),
+    [
+      { path: 'wwwroot/post/main.md', deleted: false, binary: false, hasContent: false, hasBase64: false },
+      { path: 'wwwroot/media/photo.jpg', deleted: false, binary: true, hasContent: false, hasBase64: false },
+      { path: 'wwwroot/post/old.md', deleted: true, binary: false, hasContent: false, hasBase64: false }
+    ]
+  );
+  const serialized = JSON.stringify(receipt);
+  assert.equal(serialized.includes('private draft body'), false);
+  assert.equal(serialized.includes('private-image-bytes'), false);
+  assert.equal(serialized.includes('pat-token-must-not-leak'), false);
+  assert.equal(serialized.includes('grant=secret'), false);
+
+  const committed = transitionPublishReceipt(receipt, PUBLISH_STATES.COMMITTED, {
+    publishResult: {
+      provider: 'connect',
+      transport: 'connect',
+      id: 'request-id-not-a-commit',
+      commit: { oid: 'abc123', url: 'https://github.example/commit/abc123' }
+    }
+  }, { now });
+  assert.equal(committed.commit.oid, 'abc123');
+  assert.equal(committed.publish.id, 'request-id-not-a-commit');
+  assert.equal(committed.finishedAt, null);
+
+  const observed = transitionPublishReceipt(committed, PUBLISH_STATES.OBSERVED, {
+    propagation: { canceled: false, timedOut: false }
+  }, { now });
+  assert.equal(observed.finishedAt, '2026-05-31T00:00:02.000Z');
+  assert.deepEqual(observed.propagation, { canceled: false, timedOut: false, observed: true });
+  assert.deepEqual(observed.history.map(entry => entry.state), [
+    PUBLISH_STATES.PREPARING,
+    PUBLISH_STATES.COMMITTED,
+    PUBLISH_STATES.OBSERVED
+  ]);
+}
+
+{
+  const receipt = createPublishReceipt({
+    repo: { owner: 'EkilyHQ', name: 'Press' },
+    transport: { type: 'connect', connect: { baseUrl: 'https://connect.example' } },
+    files: [{ path: 'wwwroot/post/main.md', content: 'body' }],
+    now: '2026-05-31T00:00:00.000Z',
+    runId: 'request-only'
+  });
+  const committed = transitionPublishReceipt(receipt, PUBLISH_STATES.COMMITTED, {
+    publishResult: { provider: 'connect', transport: 'connect', id: 'request-123' }
+  }, {
+    now: '2026-05-31T00:00:01.000Z'
+  });
+  assert.equal(committed.commit, null, 'Connect request ids should not be treated as Git commit ids');
+  assert.equal(committed.publish.id, 'request-123');
+}
+
+{
+  const receipt = createPublishReceipt({
+    repo: { owner: 'EkilyHQ', name: 'Press' },
+    transport: { type: 'connect', connect: { baseUrl: 'connect.local/path?grant=secret#hash' } },
+    files: [{ path: 'wwwroot/post/main.md', content: 'body' }],
+    now: '2026-05-31T00:00:00.000Z',
+    runId: 'bad-connect-url'
+  });
+  assert.equal(receipt.transport.connectBaseUrl, 'connect.local/path');
+  assert.equal(JSON.stringify(receipt).includes('grant=secret'), false);
+}
+
+{
+  const storage = createMemoryStorage();
+  const store = createPublishReceiptStore({ storage, limit: 1 });
+  const first = createPublishReceipt({
+    repo: { owner: 'EkilyHQ', name: 'Press' },
+    transport: { type: 'pat', token: 'pat-token' },
+    files: [{ path: 'wwwroot/a.md', content: 'a' }],
+    runId: 'first',
+    now: '2026-05-31T00:00:00.000Z'
+  });
+  const second = createPublishReceipt({
+    repo: { owner: 'EkilyHQ', name: 'Press' },
+    transport: { type: 'pat', token: 'pat-token' },
+    files: [{ path: 'wwwroot/b.md', content: 'b' }],
+    runId: 'second',
+    now: '2026-05-31T00:00:01.000Z'
+  });
+  assert.equal(store.save(first), true);
+  assert.equal(store.save(second), true);
+  assert.equal(store.loadLatest().runId, 'second');
+  assert.deepEqual(store.list().map(item => item.runId), ['second']);
+  assert.equal(JSON.stringify(store.list()).includes('pat-token'), false);
+}
+
+console.log('ok - publish receipt');

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -683,6 +683,11 @@ if ! grep -qx "press-system-${version}/assets/js/composer-publish-state-service.
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/publish/publish-receipt.js" "${entries_file}"; then
+  echo "expected package to include publish receipt state machine code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/composer-service-registry.js" "${entries_file}"; then
   echo "expected package to include composer service registry code" >&2
   exit 1

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -143,6 +143,11 @@ if ! grep -F 'node scripts/test-publish-flow-smoke.js' "${workflow}" >/dev/null;
   exit 1
 fi
 
+if ! grep -F 'node scripts/test-publish-receipt.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify publish receipt contracts before publishing" >&2
+  exit 1
+fi
+
 if ! grep -F 'node --experimental-default-type=module scripts/test-theme-contracts.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the shared Press theme contract surface before publishing" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add a browser-local publish receipt state machine for editor publish attempts
- wire Connect and PAT publishing through receipt states from authorization through propagation result
- keep receipts limited to safe metadata, and add release/main-guard coverage for the contract
- bump Press system metadata to v3.4.113

## Verification
- node --check assets/js/publish/publish-receipt.js && node --check assets/js/publish/commit-service.js && node --check assets/js/publish/transports/github-pat-transport.js && node --check assets/js/composer-publish-flow.js
- node scripts/test-publish-receipt.js
- node scripts/test-publish-commit-transports.js
- node scripts/test-publish-flow-smoke.js
- node scripts/test-composer-publish-flow.js
- node scripts/test-composer-identity-grid.js
- node scripts/test-composer-root-contract.js
- node scripts/test-composer-root-boundaries.js
- node scripts/test-editor-effects-boundary.js
- node scripts/test-composer-publish-service.js
- node scripts/test-composer-app-services.js
- node scripts/test-composer-service-registry.js
- node scripts/sync-runtime-cache-keys.mjs --check
- bash scripts/test-main-guard.sh
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-system-release-package.sh
- bash scripts/test-pages-artifact.sh
- bash scripts/test-pages-workflow.sh
- node scripts/test-press-system-surface.mjs
- node --experimental-default-type=module scripts/test-system-updates.js
- node --experimental-default-type=module scripts/test-theme-contracts.js
- node scripts/test-release-targets.js
- node scripts/test-release-intent.js
- node scripts/test-dispatch-system-release.js
- node scripts/test-product-state-ledger.js
- bash scripts/test-product-state-workflow.sh
- node scripts/test-product-state-dashboard.js
- node scripts/test-editor-app-kernel.mjs
- Browser smoke: local editor loaded, Publish entry visible, zero warning/error logs

## Impact
- Press system release: yes, expected v3.4.113
- Security: receipts intentionally exclude grants, GitHub tokens, file contents, base64 payloads, and commit payloads
- Connect/GitHub permissions: no new scopes or API endpoints