### PR TITLE
[codex] Record Connect publish jobs in receipts

### DIFF
--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -27,20 +27,63 @@ function emitPublishState(onPublishState, state) {
   if (typeof onPublishState === 'function') onPublishState(state);
 }
 
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
+function normalizeConnectPublishJob(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const id = safeString(source.id || source.jobId).trim();
+  if (!id) return null;
+  const out = { id };
+  if (source.requestId) out.requestId = safeString(source.requestId);
+  if (source.state) out.state = safeString(source.state);
+  if (source.statusUrl) out.statusUrl = safeString(source.statusUrl);
+  for (const key of ['createdAt', 'updatedAt', 'finishedAt', 'durationMs', 'fileCount', 'additionCount', 'deletionCount']) {
+    if (source[key] != null) out[key] = source[key];
+  }
+  const commit = source.commit && typeof source.commit === 'object' ? source.commit : null;
+  const commitOid = safeString(commit && (commit.oid || commit.sha || commit.id) || source.commitOid).trim();
+  if (commitOid) {
+    out.commit = { oid: commitOid };
+    const commitUrl = safeString(commit && commit.url || source.commitUrl).trim();
+    if (commitUrl) out.commit.url = commitUrl;
+  }
+  const error = source.error && typeof source.error === 'object' ? source.error : null;
+  const errorCode = safeString(error && error.code || source.errorCode).trim();
+  if (errorCode) {
+    out.error = {
+      code: errorCode,
+      message: safeString(error && error.message || source.errorMessage)
+    };
+    if ((error && error.upstreamStatus != null) || source.upstreamStatus != null) {
+      out.error.upstreamStatus = error && error.upstreamStatus != null ? error.upstreamStatus : source.upstreamStatus;
+    }
+    if ((error && error.upstreamCode) || source.upstreamCode) {
+      out.error.upstreamCode = safeString(error && error.upstreamCode || source.upstreamCode);
+    }
+  }
+  return out;
+}
+
 function normalizeConnectPublishResult(payload) {
   const source = payload && typeof payload === 'object' ? payload : {};
+  const job = normalizeConnectPublishJob(source.job || source.publishJob);
   const out = {
     ok: source.ok !== false,
     provider: 'connect',
     transport: 'connect'
   };
   if (source.id) out.id = String(source.id);
+  else if (job) out.id = job.id;
   if (source.requestId) out.requestId = String(source.requestId);
+  else if (job && job.requestId) out.requestId = job.requestId;
+  if (job) out.job = job;
   const commit = source.commit && typeof source.commit === 'object' ? source.commit : null;
-  const oid = (commit && (commit.oid || commit.sha || commit.id)) || source.commitSha || source.commitId;
+  const oid = (commit && (commit.oid || commit.sha || commit.id)) || source.commitSha || source.commitId || (job && job.commit && job.commit.oid);
   if (oid) out.commit = { oid: String(oid) };
-  if ((commit && commit.url) || source.commitUrl) {
-    out.commit = { ...(out.commit || {}), url: String((commit && commit.url) || source.commitUrl) };
+  if ((commit && commit.url) || source.commitUrl || (job && job.commit && job.commit.url)) {
+    out.commit = { ...(out.commit || {}), url: String((commit && commit.url) || source.commitUrl || job.commit.url) };
   }
   return out;
 }

--- a/assets/js/publish/publish-receipt.js
+++ b/assets/js/publish/publish-receipt.js
@@ -115,14 +115,46 @@ function normalizeCommitInfo(value) {
   return out;
 }
 
+function normalizePublishJobInfo(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const id = safeString(source.id || source.jobId).trim();
+  if (!id) return null;
+  const out = { id };
+  if (source.requestId) out.requestId = safeString(source.requestId);
+  if (source.state) out.state = safeString(source.state);
+  if (source.statusUrl) out.statusUrl = safeString(source.statusUrl);
+  for (const key of ['createdAt', 'updatedAt', 'finishedAt', 'durationMs', 'fileCount', 'additionCount', 'deletionCount']) {
+    if (source[key] != null) out[key] = source[key];
+  }
+  const commit = normalizeCommitInfo(source);
+  if (commit) out.commit = commit;
+  const error = source.error && typeof source.error === 'object' ? source.error : null;
+  const errorCode = safeString(error && error.code || source.errorCode).trim();
+  if (errorCode) {
+    out.error = {
+      code: errorCode,
+      message: safeString(error && error.message || source.errorMessage)
+    };
+    if ((error && error.upstreamStatus != null) || source.upstreamStatus != null) {
+      out.error.upstreamStatus = error && error.upstreamStatus != null ? error.upstreamStatus : source.upstreamStatus;
+    }
+    if ((error && error.upstreamCode) || source.upstreamCode) {
+      out.error.upstreamCode = safeString(error && error.upstreamCode || source.upstreamCode);
+    }
+  }
+  return out;
+}
+
 function normalizePublishResult(value) {
   const source = value && typeof value === 'object' ? value : {};
   const out = {};
   if (source.provider) out.provider = safeString(source.provider);
   if (source.transport) out.transport = safeString(source.transport);
-  if (source.id || source.requestId) out.id = safeString(source.id || source.requestId);
+  const job = normalizePublishJobInfo(source.job || source.publishJob);
+  if (source.id || source.requestId || job) out.id = safeString(source.id || source.requestId || job.id);
   if (source.branchName) out.branchName = safeString(source.branchName);
   if (source.expectedHeadOid) out.expectedHeadOid = safeString(source.expectedHeadOid);
+  if (job) out.job = job;
   return Object.keys(out).length ? out : null;
 }
 

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.113",
-  "tag": "v3.4.113",
+  "version": "3.4.114",
+  "tag": "v3.4.114",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.112 <3.4.113"
+      ">=3.4.113 <3.4.114"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.112 first."
+    "message": "Update to v3.4.113 first."
   }
 }

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -72,7 +72,22 @@ function createFlowHarness() {
 
     if (target === 'https://connect.example/api/press/publish') {
       const body = JSON.parse(String(options.body || '{}'));
-      return okJson({ ok: true, id: 'connect-smoke', commit: { oid: 'connect-smoke-commit' }, body });
+      return okJson({
+        ok: true,
+        id: 'connect-smoke',
+        commit: { oid: 'connect-smoke-commit' },
+        job: {
+          id: 'pubjob_connect_smoke',
+          requestId: 'connect-smoke',
+          state: 'committed',
+          statusUrl: 'https://connect.example/api/press/publish?job=pubjob_connect_smoke',
+          fileCount: 2,
+          additionCount: 1,
+          deletionCount: 1,
+          commit: { oid: 'connect-smoke-commit' }
+        },
+        body
+      });
     }
 
     if (target === 'https://api.github.com/graphql') {
@@ -195,9 +210,13 @@ function createFlowHarness() {
   assert.equal(finalReceipt.transport.type, 'connect');
   assert.equal(finalReceipt.fileCount, 2);
   assert.equal(finalReceipt.commit.oid, 'connect-smoke-commit');
+  assert.equal(finalReceipt.publish.job.id, 'pubjob_connect_smoke');
+  assert.equal(finalReceipt.publish.job.state, 'committed');
+  assert.equal(finalReceipt.publish.job.statusUrl, 'https://connect.example/api/press/publish?job=pubjob_connect_smoke');
   assert.deepEqual(finalReceipt.propagation, { canceled: false, timedOut: false, observed: true });
   const storedReceipt = JSON.parse(harness.receiptStorage.getItem(PUBLISH_RECEIPT_LATEST_STORAGE_KEY));
   assert.equal(storedReceipt.runId, 'smoke-receipt');
+  assert.equal(storedReceipt.publish.job.id, 'pubjob_connect_smoke');
   assert.equal(JSON.stringify(storedReceipt).includes('grant-token'), false);
   assert.equal(JSON.stringify(storedReceipt).includes('Updated from publish flow'), false);
   assert.equal(JSON.stringify(storedReceipt).includes('base64'), false);

--- a/scripts/test-publish-receipt.js
+++ b/scripts/test-publish-receipt.js
@@ -94,11 +94,25 @@ function createClock() {
       provider: 'connect',
       transport: 'connect',
       id: 'request-id-not-a-commit',
-      commit: { oid: 'abc123', url: 'https://github.example/commit/abc123' }
+      commit: { oid: 'abc123', url: 'https://github.example/commit/abc123' },
+      job: {
+        id: 'pubjob_123',
+        requestId: 'connect-request',
+        state: 'committed',
+        statusUrl: 'https://connect.example/api/press/publish?job=pubjob_123',
+        fileCount: 3,
+        additionCount: 2,
+        deletionCount: 1,
+        commit: { oid: 'abc123', url: 'https://github.example/commit/abc123' }
+      }
     }
   }, { now });
   assert.equal(committed.commit.oid, 'abc123');
   assert.equal(committed.publish.id, 'request-id-not-a-commit');
+  assert.equal(committed.publish.job.id, 'pubjob_123');
+  assert.equal(committed.publish.job.state, 'committed');
+  assert.equal(committed.publish.job.statusUrl, 'https://connect.example/api/press/publish?job=pubjob_123');
+  assert.equal(committed.publish.job.commit.oid, 'abc123');
   assert.equal(committed.finishedAt, null);
 
   const observed = transitionPublishReceipt(committed, PUBLISH_STATES.OBSERVED, {


### PR DESCRIPTION
## Summary

Teaches Press to preserve Connect publish job metadata in local publish receipts.

- Normalizes the optional Connect `job` response field into the publish result without treating request/job ids as commit ids.
- Persists safe job metadata in the local publish receipt: job id, request id, state, status URL, file counts, commit, and classified error fields.
- Bumps the Press system manifest to `v3.4.114` for the runtime change.

## Compatibility

This is backward-compatible with current Connect responses. If Connect does not return a `job`, receipts keep the existing shape.

## Validation

- `node scripts/test-publish-receipt.js`
- `node scripts/test-publish-flow-smoke.js`
- `node scripts/test-publish-commit-transports.js`
- `node scripts/test-composer-publish-flow.js`
- `node scripts/test-composer-root-contract.js && node scripts/test-composer-root-boundaries.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node scripts/test-press-system-surface.mjs`

## Release impact

This touches the Press runtime surface and should publish a Press system release after merge.

## Review note

Project guidance asks for subagent review on cross-repo/release-bearing changes. The available subagent tool in this session requires explicit user authorization, so I did a local review pass and marked the PR ready for automated review after CI passed.