### PR TITLE
Poll Connect publish jobs

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -832,6 +832,7 @@ const translations = {
             connectPublishing: '正在通过 Connect 创建提交…',
             connectNetworkError: '无法连接到 Connect，请检查网络。',
             connectPublishFailed: 'Connect 发布失败。',
+            connectPublishTimedOut: 'Connect 仍在处理本次发布任务，请查看发布回执获取最新状态。',
             connectAuthorizationFailed: 'Connect 授权失败。',
             connectAuthorizationCanceled: '已取消 Connect 授权。',
             connectAuthorizationTimedOut: 'Connect 授权超时，请重新登录。',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -832,6 +832,7 @@ const translations = {
             connectPublishing: '正在透過 Connect 建立提交…',
             connectNetworkError: '無法連接到 Connect，請檢查網路。',
             connectPublishFailed: 'Connect 發布失敗。',
+            connectPublishTimedOut: 'Connect 仍在處理本次發布任務，請查看發布回執取得最新狀態。',
             connectAuthorizationFailed: 'Connect 授權失敗。',
             connectAuthorizationCanceled: '已取消 Connect 授權。',
             connectAuthorizationTimedOut: 'Connect 授權逾時，請重新登入。',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -839,6 +839,7 @@ const translations = {
             connectPublishing: 'Creating commit through Connect…',
             connectNetworkError: 'Could not reach Connect. Check your connection.',
             connectPublishFailed: 'Connect publish failed.',
+            connectPublishTimedOut: 'Connect is still working on this publish job. Check the publish receipt for the latest status.',
             connectAuthorizationFailed: 'Connect authorization failed.',
             connectAuthorizationCanceled: 'Connect authorization was canceled.',
             connectAuthorizationTimedOut: 'Connect authorization timed out. Try signing in again.',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -832,6 +832,7 @@ const translations = {
             connectPublishing: 'Connect 経由でコミットを作成しています…',
             connectNetworkError: 'Connect に接続できません。接続状態を確認してください。',
             connectPublishFailed: 'Connect 公開に失敗しました。',
+            connectPublishTimedOut: 'Connect はこの公開ジョブをまだ処理しています。最新の状態は公開レシートで確認してください。',
             connectAuthorizationFailed: 'Connect 認可に失敗しました。',
             connectAuthorizationCanceled: 'Connect 認可がキャンセルされました。',
             connectAuthorizationTimedOut: 'Connect 認可がタイムアウトしました。もう一度サインインしてください。',

--- a/assets/js/composer-publish-flow.js
+++ b/assets/js/composer-publish-flow.js
@@ -202,6 +202,18 @@ export function createComposerPublishFlow({
       }
       return publishReceipt;
     } catch (err) {
+      if (transport && transport.type === 'connect' && err && err.pendingPublishResult) {
+        connectFallbackActionAvailable = false;
+        setPublishReceiptState(PUBLISH_STATES.TIMED_OUT, {
+          publishResult: err.pendingPublishResult,
+          error: err
+        });
+        hideSyncOverlay();
+        showToast('warning', err.message || t('editor.composer.github.modal.connectPublishTimedOut'), {
+          duration: 9000
+        });
+        return publishReceipt;
+      }
       setPublishReceiptState(PUBLISH_STATES.FAILED, { error: err });
       hideSyncOverlay();
       let message = err && err.message ? err.message : t('editor.toasts.githubCommitFailed');

--- a/assets/js/composer-publish-flow.js
+++ b/assets/js/composer-publish-flow.js
@@ -203,7 +203,6 @@ export function createComposerPublishFlow({
       return publishReceipt;
     } catch (err) {
       if (transport && transport.type === 'connect' && err && err.pendingPublishResult) {
-        connectFallbackActionAvailable = false;
         setPublishReceiptState(PUBLISH_STATES.TIMED_OUT, {
           publishResult: err.pendingPublishResult,
           error: err

--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -142,7 +142,8 @@ export async function publishCommit({
       grant,
       contentRoot,
       fetchImpl,
-      translate
+      translate,
+      onStatus
     });
     return normalizeConnectPublishResult(payload);
   }

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -57,6 +57,40 @@ export function serializeConnectPublishFile(file) {
   return out;
 }
 
+function resolveConnectPublishJob(payload) {
+  return payload && typeof payload === 'object'
+    ? payload.job || payload.publishJob || null
+    : null;
+}
+
+function createConnectPublishJobTimeoutError({ job, translate }) {
+  const error = new Error(translate('editor.composer.github.modal.connectPublishTimedOut'));
+  error.name = 'ConnectPublishJobTimeoutError';
+  error.status = 202;
+  error.response = { ok: true, error: { code: 'publish_job_timeout' }, job };
+  error.pendingPublishResult = {
+    ok: true,
+    provider: 'connect',
+    transport: 'connect',
+    job
+  };
+  return error;
+}
+
+function resolveConnectPublishStatusTarget(job, endpoint) {
+  const jobId = String(job && (job.id || job.jobId) || '').trim();
+  const statusUrl = String(job && job.statusUrl || '').trim();
+  if (statusUrl) {
+    try {
+      const target = new URL(statusUrl, endpoint.href);
+      if (target.origin === endpoint.origin) return target;
+    } catch (_) {}
+  }
+  const target = new URL(endpoint.href);
+  if (jobId) target.searchParams.set('job', jobId);
+  return target;
+}
+
 export async function createConnectPublishCommit({
   connect,
   repo,
@@ -120,12 +154,14 @@ export async function createConnectPublishCommit({
     error.response = payload;
     throw error;
   }
-  if (response.status === 202 && payload && payload.job) {
+  const job = resolveConnectPublishJob(payload);
+  if (response.status === 202 && job) {
     if (typeof onStatus === 'function') {
       onStatus(message('editor.composer.github.modal.connectPublishing', 'Creating commit through Connect...'));
     }
     return pollConnectPublishJob({
       payload,
+      job,
       endpoint,
       grant,
       fetchRef,
@@ -140,6 +176,7 @@ export async function createConnectPublishCommit({
 
 async function pollConnectPublishJob({
   payload,
+  job,
   endpoint,
   grant,
   fetchRef,
@@ -150,7 +187,6 @@ async function pollConnectPublishJob({
 }) {
   const startedAt = Date.now();
   let latest = payload;
-  let job = latest && typeof latest === 'object' ? latest.job : null;
   while (job && typeof job === 'object') {
     const state = String(job.state || '').trim();
     if (state === 'committed') {
@@ -174,15 +210,10 @@ async function pollConnectPublishJob({
       throw error;
     }
     if (Date.now() - startedAt >= pollTimeoutMs) {
-      const error = new Error(translate('editor.composer.github.modal.connectPublishTimedOut'));
-      error.status = 504;
-      error.response = { ok: false, error: { code: 'publish_job_timeout' }, job };
-      throw error;
+      throw createConnectPublishJobTimeoutError({ job, translate });
     }
     await sleep(Math.max(0, Number(pollIntervalMs) || 0));
-    const statusUrl = String(job.statusUrl || '').trim();
-    const target = statusUrl ? new URL(statusUrl) : new URL(endpoint.href);
-    if (!statusUrl) target.searchParams.set('job', String(job.id || ''));
+    const target = resolveConnectPublishStatusTarget(job, endpoint);
     const response = await fetchRef(target.href, {
       method: 'GET',
       referrerPolicy: 'unsafe-url',
@@ -199,7 +230,7 @@ async function pollConnectPublishJob({
       error.response = latest;
       throw error;
     }
-    job = latest.job;
+    job = resolveConnectPublishJob(latest);
   }
   const error = new Error(translate('editor.composer.github.modal.connectPublishFailed'));
   error.status = 502;

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -262,7 +262,7 @@ async function pollConnectPublishJob({
           name: 'ConnectPublishJobPollError'
         });
       }
-      const error = new Error(latest && latest.error && latest.error.message
+      const error = new Error(latest.error && latest.error.message
         ? latest.error.message
         : translate('editor.composer.github.modal.connectPublishFailed'));
       error.status = response.status;

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -63,17 +63,18 @@ function resolveConnectPublishJob(payload) {
     : null;
 }
 
-function createConnectPublishJobTimeoutError({ job, translate }) {
+function createConnectPublishJobPendingError({ job, translate, code, name, cause = null }) {
   const error = new Error(translate('editor.composer.github.modal.connectPublishTimedOut'));
-  error.name = 'ConnectPublishJobTimeoutError';
+  error.name = name || 'ConnectPublishJobPendingError';
   error.status = 202;
-  error.response = { ok: true, error: { code: 'publish_job_timeout' }, job };
+  error.response = { ok: true, error: { code }, job };
   error.pendingPublishResult = {
     ok: true,
     provider: 'connect',
     transport: 'connect',
     job
   };
+  if (cause) error.cause = cause;
   return error;
 }
 
@@ -210,17 +211,33 @@ async function pollConnectPublishJob({
       throw error;
     }
     if (Date.now() - startedAt >= pollTimeoutMs) {
-      throw createConnectPublishJobTimeoutError({ job, translate });
+      throw createConnectPublishJobPendingError({
+        job,
+        translate,
+        code: 'publish_job_timeout',
+        name: 'ConnectPublishJobTimeoutError'
+      });
     }
     await sleep(Math.max(0, Number(pollIntervalMs) || 0));
     const target = resolveConnectPublishStatusTarget(job, endpoint);
-    const response = await fetchRef(target.href, {
-      method: 'GET',
-      referrerPolicy: 'unsafe-url',
-      headers: {
-        'Authorization': `Bearer ${grant.token}`
-      }
-    });
+    let response = null;
+    try {
+      response = await fetchRef(target.href, {
+        method: 'GET',
+        referrerPolicy: 'unsafe-url',
+        headers: {
+          'Authorization': `Bearer ${grant.token}`
+        }
+      });
+    } catch (err) {
+      throw createConnectPublishJobPendingError({
+        job,
+        translate,
+        code: 'publish_job_poll_failed',
+        name: 'ConnectPublishJobPollError',
+        cause: err
+      });
+    }
     latest = await response.json().catch(() => null);
     if (!response.ok || !latest || latest.ok === false) {
       const error = new Error(latest && latest.error && latest.error.message
@@ -230,7 +247,21 @@ async function pollConnectPublishJob({
       error.response = latest;
       throw error;
     }
-    job = resolveConnectPublishJob(latest);
+    const nextJob = resolveConnectPublishJob(latest);
+    if (!nextJob && latest && typeof latest === 'object' && latest.commit) {
+      return {
+        ...latest,
+        ok: true,
+        provider: 'connect',
+        transport: 'connect',
+        job: {
+          ...job,
+          state: 'committed',
+          commit: latest.commit
+        }
+      };
+    }
+    job = nextJob;
   }
   const error = new Error(translate('editor.composer.github.modal.connectPublishFailed'));
   error.status = 502;

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -63,17 +63,22 @@ function resolveConnectPublishJob(payload) {
     : null;
 }
 
-function createConnectPublishJobPendingError({ job, translate, code, name, cause = null }) {
+function createConnectPublishJobPendingError({ job = null, payload = null, translate, code, name, cause = null }) {
   const error = new Error(translate('editor.composer.github.modal.connectPublishTimedOut'));
   error.name = name || 'ConnectPublishJobPendingError';
   error.status = 202;
   error.response = { ok: true, error: { code }, job };
-  error.pendingPublishResult = {
+  const pendingPublishResult = {
     ok: true,
     provider: 'connect',
-    transport: 'connect',
-    job
+    transport: 'connect'
   };
+  if (job) pendingPublishResult.job = job;
+  if (payload && typeof payload === 'object') {
+    if (payload.id) pendingPublishResult.id = String(payload.id);
+    if (payload.requestId) pendingPublishResult.requestId = String(payload.requestId);
+  }
+  error.pendingPublishResult = pendingPublishResult;
   if (cause) error.cause = cause;
   return error;
 }
@@ -172,6 +177,14 @@ export async function createConnectPublishCommit({
       sleep
     });
   }
+  if (response.status === 202) {
+    throw createConnectPublishJobPendingError({
+      payload,
+      translate,
+      code: 'publish_job_missing',
+      name: 'ConnectPublishJobMissingError'
+    });
+  }
   return payload;
 }
 
@@ -240,6 +253,15 @@ async function pollConnectPublishJob({
     }
     latest = await response.json().catch(() => null);
     if (!response.ok || !latest || latest.ok === false) {
+      if (response.status >= 500 || !latest) {
+        throw createConnectPublishJobPendingError({
+          job,
+          payload: latest,
+          translate,
+          code: 'publish_job_poll_failed',
+          name: 'ConnectPublishJobPollError'
+        });
+      }
       const error = new Error(latest && latest.error && latest.error.message
         ? latest.error.message
         : translate('editor.composer.github.modal.connectPublishFailed'));
@@ -248,7 +270,7 @@ async function pollConnectPublishJob({
       throw error;
     }
     const nextJob = resolveConnectPublishJob(latest);
-    if (!nextJob && latest && typeof latest === 'object' && latest.commit) {
+    if (!nextJob && typeof latest === 'object' && latest.commit) {
       return {
         ...latest,
         ok: true,

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -20,6 +20,11 @@ function resolveFetch(fetchImpl) {
   return typeof fetchImpl === 'function' ? fetchImpl : resolveAmbientFunction('fetch');
 }
 
+function resolveSleep(sleepImpl) {
+  if (typeof sleepImpl === 'function') return sleepImpl;
+  return ms => new Promise(resolve => setTimeout(resolve, ms));
+}
+
 function resolveWindow(windowRef) {
   if (windowRef) return windowRef;
   const ambientWindow = resolveAmbientValue('window');
@@ -60,13 +65,18 @@ export async function createConnectPublishCommit({
   contentRoot,
   grant,
   fetchImpl = null,
-  translate = (key) => key
+  translate = (key) => key,
+  onStatus = null,
+  pollIntervalMs = 1500,
+  pollTimeoutMs = 120000,
+  sleepImpl = null
 } = {}) {
   const message = (key, fallback) => {
     const value = typeof translate === 'function' ? translate(key) : '';
     return value && value !== key ? value : fallback;
   };
   const fetchRef = resolveFetch(fetchImpl);
+  const sleep = resolveSleep(sleepImpl);
   if (!connect || !connect.baseUrl) {
     throw new Error(message('editor.composer.github.modal.connectMissing', 'Connect publish settings are missing.'));
   }
@@ -91,7 +101,8 @@ export async function createConnectPublishCommit({
       referrerPolicy: 'unsafe-url',
       headers: {
         'Authorization': `Bearer ${grant.token}`,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Prefer': 'respond-async'
       },
       body: JSON.stringify(body)
     });
@@ -109,7 +120,91 @@ export async function createConnectPublishCommit({
     error.response = payload;
     throw error;
   }
+  if (response.status === 202 && payload && payload.job) {
+    if (typeof onStatus === 'function') {
+      onStatus(message('editor.composer.github.modal.connectPublishing', 'Creating commit through Connect...'));
+    }
+    return pollConnectPublishJob({
+      payload,
+      endpoint,
+      grant,
+      fetchRef,
+      translate,
+      pollIntervalMs,
+      pollTimeoutMs,
+      sleep
+    });
+  }
   return payload;
+}
+
+async function pollConnectPublishJob({
+  payload,
+  endpoint,
+  grant,
+  fetchRef,
+  translate = (key) => key,
+  pollIntervalMs = 1500,
+  pollTimeoutMs = 120000,
+  sleep = resolveSleep(null)
+}) {
+  const startedAt = Date.now();
+  let latest = payload;
+  let job = latest && typeof latest === 'object' ? latest.job : null;
+  while (job && typeof job === 'object') {
+    const state = String(job.state || '').trim();
+    if (state === 'committed') {
+      return {
+        ok: true,
+        provider: 'connect',
+        transport: 'connect',
+        owner: job.repository && job.repository.owner,
+        name: job.repository && job.repository.name,
+        branch: job.repository && job.repository.branch,
+        commit: job.commit || latest.commit,
+        job
+      };
+    }
+    if (state === 'failed') {
+      const error = new Error(job.error && job.error.message
+        ? job.error.message
+        : translate('editor.composer.github.modal.connectPublishFailed'));
+      error.status = job.error && job.error.upstreamStatus ? job.error.upstreamStatus : 502;
+      error.response = { ok: false, error: job.error, job };
+      throw error;
+    }
+    if (Date.now() - startedAt >= pollTimeoutMs) {
+      const error = new Error(translate('editor.composer.github.modal.connectPublishTimedOut'));
+      error.status = 504;
+      error.response = { ok: false, error: { code: 'publish_job_timeout' }, job };
+      throw error;
+    }
+    await sleep(Math.max(0, Number(pollIntervalMs) || 0));
+    const statusUrl = String(job.statusUrl || '').trim();
+    const target = statusUrl ? new URL(statusUrl) : new URL(endpoint.href);
+    if (!statusUrl) target.searchParams.set('job', String(job.id || ''));
+    const response = await fetchRef(target.href, {
+      method: 'GET',
+      referrerPolicy: 'unsafe-url',
+      headers: {
+        'Authorization': `Bearer ${grant.token}`
+      }
+    });
+    latest = await response.json().catch(() => null);
+    if (!response.ok || !latest || latest.ok === false) {
+      const error = new Error(latest && latest.error && latest.error.message
+        ? latest.error.message
+        : translate('editor.composer.github.modal.connectPublishFailed'));
+      error.status = response.status;
+      error.response = latest;
+      throw error;
+    }
+    job = latest.job;
+  }
+  const error = new Error(translate('editor.composer.github.modal.connectPublishFailed'));
+  error.status = 502;
+  error.response = latest;
+  throw error;
 }
 
 export async function ensureConnectPublishGrant({

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.114",
-  "tag": "v3.4.114",
+  "version": "3.4.115",
+  "tag": "v3.4.115",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.113 <3.4.114"
+      ">=3.4.114 <3.4.115"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.113 first."
+    "message": "Update to v3.4.114 first."
   }
 }

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -40,10 +40,10 @@ function installAmbientGlobal(name, value) {
   };
 }
 
-function okJson(payload) {
+function okJson(payload, status = 200) {
   return {
     ok: true,
-    status: 200,
+    status,
     json: () => Promise.resolve(payload)
   };
 }
@@ -308,8 +308,64 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   assert.equal(requests[0].url, 'https://connect.example/api/press/publish');
   assert.equal(requests[0].options.referrerPolicy, 'unsafe-url');
   assert.equal(requests[0].options.headers.Authorization, 'Bearer grant-token');
+  assert.equal(requests[0].options.headers.Prefer, 'respond-async');
   assert.equal(requests[0].body.contentRoot, 'wwwroot');
   assert.deepEqual(ambientCalls, [], 'Connect publish POST should use injected fetch only');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    const result = await createConnectPublishCommit({
+      connect: { baseUrl: 'https://connect.example' },
+      repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+      headline: 'Sync draft',
+      files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+      contentRoot: 'wwwroot',
+      grant: { token: 'grant-token' },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      fetchImpl(url, options) {
+        requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+        if (requests.length === 1) {
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            job: {
+              id: 'pubjob_async',
+              state: 'queued',
+              statusUrl: 'https://connect.example/api/press/publish?job=pubjob_async'
+            }
+          }, 202));
+        }
+        return Promise.resolve(okJson({
+          ok: true,
+          job: {
+            id: 'pubjob_async',
+            requestId: 'request-async',
+            state: 'committed',
+            repository: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+            commit: { oid: 'async-commit' }
+          }
+        }));
+      }
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.job.id, 'pubjob_async');
+    assert.equal(result.job.state, 'committed');
+    assert.equal(result.commit.oid, 'async-commit');
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].url, 'https://connect.example/api/press/publish');
+  assert.equal(requests[1].url, 'https://connect.example/api/press/publish?job=pubjob_async');
+  assert.equal(requests[1].options.method, 'GET');
+  assert.equal(requests[1].options.referrerPolicy, 'unsafe-url');
+  assert.equal(requests[1].options.headers.Authorization, 'Bearer grant-token');
+  assert.deepEqual(ambientCalls, [], 'Connect publish polling should use injected fetch only');
 }
 
 {

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -370,6 +370,146 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
 
 {
   const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    const result = await createConnectPublishCommit({
+      connect: { baseUrl: 'https://connect.example' },
+      repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+      headline: 'Sync draft',
+      files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+      contentRoot: 'wwwroot',
+      grant: { token: 'grant-token' },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      fetchImpl(url, options) {
+        requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+        if (requests.length === 1) {
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            publishJob: {
+              id: 'pubjob_alias',
+              state: 'queued',
+              statusUrl: '/api/press/publish?job=pubjob_alias'
+            }
+          }, 202));
+        }
+        return Promise.resolve(okJson({
+          ok: true,
+          publishJob: {
+            id: 'pubjob_alias',
+            state: 'committed',
+            repository: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+            commit: { oid: 'alias-commit' }
+          }
+        }));
+      }
+    });
+    assert.equal(result.job.id, 'pubjob_alias');
+    assert.equal(result.job.state, 'committed');
+    assert.equal(result.commit.oid, 'alias-commit');
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].url, 'https://connect.example/api/press/publish?job=pubjob_alias');
+  assert.equal(requests[1].options.headers.Authorization, 'Bearer grant-token');
+  assert.deepEqual(ambientCalls, [], 'Connect publish polling should support publishJob aliases without ambient fetch');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    const result = await createConnectPublishCommit({
+      connect: { baseUrl: 'https://connect.example' },
+      repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+      headline: 'Sync draft',
+      files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+      contentRoot: 'wwwroot',
+      grant: { token: 'grant-token' },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      fetchImpl(url, options) {
+        requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+        if (requests.length === 1) {
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            job: {
+              id: 'pubjob_safe',
+              state: 'queued',
+              statusUrl: 'https://evil.example/collect?job=pubjob_safe'
+            }
+          }, 202));
+        }
+        return Promise.resolve(okJson({
+          ok: true,
+          job: {
+            id: 'pubjob_safe',
+            state: 'committed',
+            repository: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+            commit: { oid: 'safe-commit' }
+          }
+        }));
+      }
+    });
+    assert.equal(result.commit.oid, 'safe-commit');
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].url, 'https://connect.example/api/press/publish?job=pubjob_safe');
+  assert.equal(requests[1].options.headers.Authorization, 'Bearer grant-token');
+  assert.deepEqual(ambientCalls, [], 'Connect publish polling should not leak grants to foreign statusUrl origins');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    await assert.rejects(
+      () => createConnectPublishCommit({
+        connect: { baseUrl: 'https://connect.example' },
+        repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+        headline: 'Sync draft',
+        files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+        contentRoot: 'wwwroot',
+        grant: { token: 'grant-token' },
+        pollTimeoutMs: 0,
+        fetchImpl(url, options) {
+          requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            job: {
+              id: 'pubjob_timeout',
+              state: 'queued',
+              statusUrl: 'https://connect.example/api/press/publish?job=pubjob_timeout'
+            }
+          }, 202));
+        }
+      }),
+      (err) => {
+        assert.equal(err.name, 'ConnectPublishJobTimeoutError');
+        assert.equal(err.status, 202);
+        assert.equal(err.pendingPublishResult.job.id, 'pubjob_timeout');
+        assert.equal(err.response.ok, true);
+        return true;
+      }
+    );
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 1);
+  assert.deepEqual(ambientCalls, [], 'Connect publish timeout should preserve the accepted job');
+}
+
+{
+  const ambientCalls = [];
   const restores = ['fetch', 'window', 'document', 'btoa'].map((name) => installAmbientTrap(name, ambientCalls));
   const patRequests = [];
   const states = [];

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -513,6 +513,43 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
   const requests = [];
   try {
+    await assert.rejects(
+      () => createConnectPublishCommit({
+        connect: { baseUrl: 'https://connect.example' },
+        repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+        headline: 'Sync draft',
+        files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+        contentRoot: 'wwwroot',
+        grant: { token: 'grant-token' },
+        fetchImpl(url, options) {
+          requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            id: 'accepted-without-job'
+          }, 202));
+        }
+      }),
+      (err) => {
+        assert.equal(err.name, 'ConnectPublishJobMissingError');
+        assert.equal(err.status, 202);
+        assert.equal(err.pendingPublishResult.id, 'accepted-without-job');
+        assert.equal(err.pendingPublishResult.job, undefined);
+        return true;
+      }
+    );
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 1);
+  assert.deepEqual(ambientCalls, [], 'Bare Connect 202 responses should not be treated as committed');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
     const result = await createConnectPublishCommit({
       connect: { baseUrl: 'https://connect.example' },
       repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
@@ -595,6 +632,56 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   }
   assert.equal(requests.length, 2);
   assert.deepEqual(ambientCalls, [], 'Connect publish poll failures should preserve the accepted job');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    await assert.rejects(
+      () => createConnectPublishCommit({
+        connect: { baseUrl: 'https://connect.example' },
+        repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+        headline: 'Sync draft',
+        files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+        contentRoot: 'wwwroot',
+        grant: { token: 'grant-token' },
+        pollIntervalMs: 0,
+        sleepImpl: async () => {},
+        fetchImpl(url, options) {
+          requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+          if (requests.length === 1) {
+            return Promise.resolve(okJson({
+              ok: true,
+              accepted: true,
+              job: {
+                id: 'pubjob_status_503',
+                state: 'queued',
+                statusUrl: 'https://connect.example/api/press/publish?job=pubjob_status_503'
+              }
+            }, 202));
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            json: () => Promise.reject(new Error('temporary html response'))
+          });
+        }
+      }),
+      (err) => {
+        assert.equal(err.name, 'ConnectPublishJobPollError');
+        assert.equal(err.status, 202);
+        assert.equal(err.pendingPublishResult.job.id, 'pubjob_status_503');
+        assert.equal(err.response.error.code, 'publish_job_poll_failed');
+        return true;
+      }
+    );
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.deepEqual(ambientCalls, [], 'Connect publish status 5xx responses should preserve the accepted job');
 }
 
 {

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -510,6 +510,95 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
 
 {
   const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    const result = await createConnectPublishCommit({
+      connect: { baseUrl: 'https://connect.example' },
+      repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+      headline: 'Sync draft',
+      files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+      contentRoot: 'wwwroot',
+      grant: { token: 'grant-token' },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      fetchImpl(url, options) {
+        requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+        if (requests.length === 1) {
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
+            job: {
+              id: 'pubjob_direct_status',
+              state: 'queued',
+              statusUrl: 'https://connect.example/api/press/publish?job=pubjob_direct_status'
+            }
+          }, 202));
+        }
+        return Promise.resolve(okJson({
+          ok: true,
+          commit: { oid: 'direct-status-commit' }
+        }));
+      }
+    });
+    assert.equal(result.commit.oid, 'direct-status-commit');
+    assert.equal(result.job.id, 'pubjob_direct_status');
+    assert.equal(result.job.state, 'committed');
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.deepEqual(ambientCalls, [], 'Connect publish polling should accept direct committed status payloads');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    await assert.rejects(
+      () => createConnectPublishCommit({
+        connect: { baseUrl: 'https://connect.example' },
+        repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+        headline: 'Sync draft',
+        files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+        contentRoot: 'wwwroot',
+        grant: { token: 'grant-token' },
+        pollIntervalMs: 0,
+        sleepImpl: async () => {},
+        fetchImpl(url, options) {
+          requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+          if (requests.length === 1) {
+            return Promise.resolve(okJson({
+              ok: true,
+              accepted: true,
+              job: {
+                id: 'pubjob_poll_failed',
+                state: 'queued',
+                statusUrl: 'https://connect.example/api/press/publish?job=pubjob_poll_failed'
+              }
+            }, 202));
+          }
+          throw new Error('poll network failed');
+        }
+      }),
+      (err) => {
+        assert.equal(err.name, 'ConnectPublishJobPollError');
+        assert.equal(err.status, 202);
+        assert.equal(err.pendingPublishResult.job.id, 'pubjob_poll_failed');
+        assert.equal(err.response.error.code, 'publish_job_poll_failed');
+        return true;
+      }
+    );
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.deepEqual(ambientCalls, [], 'Connect publish poll failures should preserve the accepted job');
+}
+
+{
+  const ambientCalls = [];
   const restores = ['fetch', 'window', 'document', 'btoa'].map((name) => installAmbientTrap(name, ambientCalls));
   const patRequests = [];
   const states = [];

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -6,10 +6,10 @@ import {
   PUBLISH_STATES
 } from '../assets/js/publish/publish-receipt.js';
 
-function okJson(payload) {
+function okJson(payload, status = 200) {
   return {
     ok: true,
-    status: 200,
+    status,
     json: () => Promise.resolve(payload),
     text: () => Promise.resolve(JSON.stringify(payload))
   };
@@ -74,6 +74,23 @@ function createFlowHarness() {
       const body = JSON.parse(String(options.body || '{}'));
       return okJson({
         ok: true,
+        accepted: true,
+        job: {
+          id: 'pubjob_connect_smoke',
+          requestId: 'connect-smoke',
+          state: 'queued',
+          statusUrl: 'https://connect.example/api/press/publish?job=pubjob_connect_smoke',
+          fileCount: 2,
+          additionCount: 1,
+          deletionCount: 1
+        },
+        body
+      }, 202);
+    }
+
+    if (target === 'https://connect.example/api/press/publish?job=pubjob_connect_smoke') {
+      return okJson({
+        ok: true,
         id: 'connect-smoke',
         commit: { oid: 'connect-smoke-commit' },
         job: {
@@ -85,8 +102,7 @@ function createFlowHarness() {
           additionCount: 1,
           deletionCount: 1,
           commit: { oid: 'connect-smoke-commit' }
-        },
-        body
+        }
       });
     }
 
@@ -180,6 +196,7 @@ function createFlowHarness() {
   assert.ok(connectPost, 'Connect smoke should POST to the Connect publish endpoint');
   assert.equal(connectPost.options.referrerPolicy, 'unsafe-url');
   assert.equal(connectPost.options.headers.Authorization, 'Bearer grant-token');
+  assert.equal(connectPost.options.headers.Prefer, 'respond-async');
   const connectBody = JSON.parse(connectPost.options.body);
   assert.deepEqual(connectBody.repository, { owner: 'EkilyHQ', name: 'Press', branch: 'main' });
   assert.equal(connectBody.contentRoot, 'wwwroot');

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -242,6 +242,46 @@ function createFlowHarness() {
 }
 
 {
+  const realDateNow = Date.now;
+  let dateNowCalls = 0;
+  Date.now = () => {
+    dateNowCalls += 1;
+    return dateNowCalls === 1 ? 1000 : 122000;
+  };
+  try {
+    const harness = createFlowHarness();
+    await harness.flow.performConnectGithubCommit({ baseUrl: 'https://connect.example' }, [
+      { kind: 'site', label: 'site.yaml' }
+    ]);
+
+    assert.equal(
+      harness.requests.some(request => request.url === 'https://connect.example/api/press/publish?job=pubjob_connect_smoke'),
+      false,
+      'Connect timeout should not keep polling after the accepted job exceeds the local wait budget'
+    );
+    assert.equal(
+      harness.calls.some(call => call[0] === 'postCommit'),
+      false,
+      'Connect timeout should not apply local post-commit state before a commit exists'
+    );
+    assert.deepEqual(harness.receipts.map(receipt => receipt.state), [
+      PUBLISH_STATES.PREPARING,
+      PUBLISH_STATES.AUTHORIZING,
+      PUBLISH_STATES.COMMITTING,
+      PUBLISH_STATES.TIMED_OUT
+    ]);
+    const finalReceipt = harness.receipts.at(-1);
+    assert.equal(finalReceipt.publish.job.id, 'pubjob_connect_smoke');
+    assert.equal(finalReceipt.publish.job.state, 'queued');
+    assert.equal(finalReceipt.error.status, 202);
+    assert.deepEqual(harness.calls.at(-2), ['toast', 'warning', 'editor.composer.github.modal.connectPublishTimedOut', false]);
+    assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
+  } finally {
+    Date.now = realDateNow;
+  }
+}
+
+{
   const harness = createFlowHarness();
   await harness.flow.performDirectGithubCommit('pat-token', [
     { kind: 'site', label: 'site.yaml' }


### PR DESCRIPTION
## Summary
- send Connect publish requests with `Prefer: respond-async`
- poll protected Connect publish job status until `committed` or `failed` before advancing the local publish receipt
- bump Press system metadata to v3.4.115 and cover async Connect polling in publish transport/smoke tests

## Verification
- node scripts/test-publish-commit-transports.js
- node scripts/test-publish-flow-smoke.js
- node scripts/test-publish-receipt.js
- node scripts/test-composer-publish-flow.js
- node scripts/test-composer-identity-grid.js
- node scripts/sync-runtime-cache-keys.mjs --check
- bash scripts/test-main-guard.sh
- node scripts/test-press-system-surface.mjs
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- node scripts/test-release-intent.js
- node scripts/test-release-targets.js
- bash scripts/test-pages-artifact.sh
- bash scripts/test-pages-workflow.sh
- node scripts/test-product-state-ledger.js
- bash scripts/test-product-state-workflow.sh

## Deployment notes
- Merge after Connect PR #11 is deployed with the queue binding, D1 migration, and publish executor worker.

## Review
- Local pre-PR review completed; subagent review skipped because this environment only permits subagents on explicit user request.