### PR TITLE
Use Connect publish propagation status

### DIFF
--- a/assets/js/composer-publish-flow.js
+++ b/assets/js/composer-publish-flow.js
@@ -1,5 +1,6 @@
 import { ensurePublishGrant, publishCommit as publishStagedCommit } from './publish/commit-service.js';
 import { waitForRemotePropagation as waitForPublishedFiles } from './publish/propagation-watcher.js';
+import { waitForConnectPublishPropagation } from './publish/transports/connect-transport.js';
 import {
   createPublishReceipt,
   createPublishReceiptStore,
@@ -89,6 +90,35 @@ export function createComposerPublishFlow({
       setStatus: setSyncOverlayStatus,
       setCancelHandler: setSyncOverlayCancelHandler
     });
+  }
+
+  async function waitForConnectManagedPropagation(transport, publishResult) {
+    const job = publishResult && publishResult.job && typeof publishResult.job === 'object'
+      ? publishResult.job
+      : null;
+    const propagation = job && job.propagation && typeof job.propagation === 'object'
+      ? job.propagation
+      : null;
+    if (!transport || transport.type !== 'connect' || !propagation || propagation.source !== 'connect') return null;
+    const grant = typeof getCachedConnectPublishGrant === 'function' ? getCachedConnectPublishGrant() : null;
+    if (!grant || !grant.token) return null;
+    try {
+      return await waitForConnectPublishPropagation({
+        connect: transport.connect,
+        grant,
+        job,
+        fetchImpl: fetchRef,
+        translate: t,
+        onStatus: setSyncOverlayStatus,
+        setCancelHandler: setSyncOverlayCancelHandler,
+        sleepImpl: sleepMs
+      });
+    } catch (err) {
+      if (consoleRef && typeof consoleRef.warn === 'function') {
+        consoleRef.warn('Press Connect propagation status unavailable; falling back to local checks', err);
+      }
+      return null;
+    }
   }
 
   async function performPublishCommit(transport, summaryEntries = []) {
@@ -183,10 +213,13 @@ export function createComposerPublishFlow({
       const summaryLabel = fileCount === 1 ? describeSummaryEntry(summaryEntries[0] || files[0]) : `${fileCount} files`;
       setPublishReceiptState(PUBLISH_STATES.OBSERVING_PROPAGATION);
       setSyncOverlayMessage(`Commit accepted for ${summaryLabel}. Press recorded a local publish receipt and is checking the live site… This can take a few minutes. If you stop waiting, the commit stays on GitHub but the live site might not show the changes yet.`);
-      const propagationResult = await waitForRemotePropagation(files);
+      const propagationResult = await waitForConnectManagedPropagation(transport, publishResult)
+        || await waitForRemotePropagation(files);
       setPublishReceiptState(propagationResult && propagationResult.canceled
         ? PUBLISH_STATES.CANCELED
-        : propagationResult && propagationResult.timedOut
+        : propagationResult && propagationResult.failed
+          ? PUBLISH_STATES.FAILED
+          : propagationResult && propagationResult.timedOut
           ? PUBLISH_STATES.TIMED_OUT
           : PUBLISH_STATES.OBSERVED, {
         propagation: propagationResult
@@ -195,7 +228,7 @@ export function createComposerPublishFlow({
       hideSyncOverlay();
       if (propagationResult && propagationResult.canceled) {
         showToast('info', t('editor.toasts.siteWaitStopped'));
-      } else if (propagationResult && propagationResult.timedOut) {
+      } else if (propagationResult && (propagationResult.timedOut || propagationResult.failed)) {
         showToast('warning', t('editor.toasts.siteWaitTimedOut'));
       } else {
         showToast('success', t('editor.toasts.commitSuccess', { count: fileCount }));

--- a/assets/js/publish/commit-service.js
+++ b/assets/js/publish/commit-service.js
@@ -63,6 +63,28 @@ function normalizeConnectPublishJob(value) {
       out.error.upstreamCode = safeString(error && error.upstreamCode || source.upstreamCode);
     }
   }
+  const propagation = source.propagation && typeof source.propagation === 'object' ? source.propagation : null;
+  if (propagation && safeString(propagation.source || 'connect').trim() === 'connect') {
+    const propagationState = safeString(propagation.state).trim();
+    if (propagationState) {
+      out.propagation = {
+        source: 'connect',
+        state: propagationState
+      };
+      for (const key of ['markerPath', 'markerUrl', 'startedAt', 'updatedAt', 'observedAt', 'timedOutAt', 'lastAttemptAt']) {
+        if (propagation[key] != null) out.propagation[key] = safeString(propagation[key]);
+      }
+      if (propagation.attemptCount != null) out.propagation.attemptCount = Number(propagation.attemptCount) || 0;
+      const propagationError = propagation.error && typeof propagation.error === 'object' ? propagation.error : null;
+      const propagationErrorCode = safeString(propagationError && propagationError.code || propagation.errorCode).trim();
+      if (propagationErrorCode) {
+        out.propagation.error = {
+          code: propagationErrorCode,
+          message: safeString(propagationError && propagationError.message || propagation.errorMessage)
+        };
+      }
+    }
+  }
   return out;
 }
 

--- a/assets/js/publish/publish-receipt.js
+++ b/assets/js/publish/publish-receipt.js
@@ -142,7 +142,36 @@ function normalizePublishJobInfo(value) {
       out.error.upstreamCode = safeString(error && error.upstreamCode || source.upstreamCode);
     }
   }
+  const propagation = normalizePublishPropagationInfo(source.propagation);
+  if (propagation) out.propagation = propagation;
   return out;
+}
+
+function normalizePublishPropagationInfo(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const state = safeString(source.state).trim();
+  const sourceName = safeString(source.source).trim();
+  if (!state && !sourceName) return null;
+  const out = {};
+  if (sourceName) out.source = sourceName;
+  if (state) out.state = state;
+  for (const key of ['jobId', 'markerPath', 'markerUrl', 'observedAt', 'timedOutAt']) {
+    if (source[key] != null) out[key] = safeString(source[key]);
+  }
+  if (source.attemptCount != null) out.attemptCount = Number(source.attemptCount) || 0;
+  if (source.canceled) out.canceled = true;
+  if (source.timedOut) out.timedOut = true;
+  if (source.failed) out.failed = true;
+  if (source.observed) out.observed = true;
+  const error = source.error && typeof source.error === 'object' ? source.error : null;
+  const errorCode = safeString(error && error.code || source.errorCode).trim();
+  if (errorCode) {
+    out.error = {
+      code: errorCode,
+      message: safeString(error && error.message || source.errorMessage)
+    };
+  }
+  return Object.keys(out).length ? out : null;
 }
 
 function normalizePublishResult(value) {
@@ -160,11 +189,17 @@ function normalizePublishResult(value) {
 
 function normalizePropagation(value) {
   const source = value && typeof value === 'object' ? value : {};
-  return {
+  const out = {
     canceled: !!source.canceled,
     timedOut: !!source.timedOut,
-    observed: !source.canceled && !source.timedOut
+    observed: source.observed != null
+      ? !!source.observed
+      : !source.canceled && !source.timedOut && !source.failed
   };
+  const info = normalizePublishPropagationInfo(source);
+  if (info) Object.assign(out, info);
+  if (source.failed) out.failed = true;
+  return out;
 }
 
 export function classifyPublishError(err) {

--- a/assets/js/publish/transports/connect-transport.js
+++ b/assets/js/publish/transports/connect-transport.js
@@ -25,6 +25,10 @@ function resolveSleep(sleepImpl) {
   return ms => new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
 function resolveWindow(windowRef) {
   if (windowRef) return windowRef;
   const ambientWindow = resolveAmbientValue('window');
@@ -95,6 +99,144 @@ function resolveConnectPublishStatusTarget(job, endpoint) {
   const target = new URL(endpoint.href);
   if (jobId) target.searchParams.set('job', jobId);
   return target;
+}
+
+function normalizeConnectPublishPropagation(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const state = safeString(source.state).trim();
+  if (!state) return null;
+  const out = {
+    source: safeString(source.source || 'connect').trim() || 'connect',
+    state
+  };
+  for (const key of ['markerPath', 'markerUrl', 'startedAt', 'updatedAt', 'observedAt', 'timedOutAt', 'lastAttemptAt']) {
+    if (source[key] != null) out[key] = safeString(source[key]);
+  }
+  if (source.attemptCount != null) out.attemptCount = Number(source.attemptCount) || 0;
+  const error = source.error && typeof source.error === 'object' ? source.error : null;
+  const errorCode = safeString(error && error.code || source.errorCode).trim();
+  if (errorCode) {
+    out.error = {
+      code: errorCode,
+      message: safeString(error && error.message || source.errorMessage)
+    };
+  }
+  return out;
+}
+
+function formatConnectPropagationResult(job, propagation, patch = {}) {
+  if (!propagation || propagation.source !== 'connect') return null;
+  const state = safeString(propagation.state).trim();
+  if (!state) return null;
+  const timedOut = state === 'timedOut' || state === 'failed' || !!patch.timedOut;
+  const failed = state === 'failed' || !!patch.failed;
+  return {
+    source: 'connect',
+    state,
+    jobId: safeString(job && (job.id || job.jobId)).trim(),
+    markerPath: propagation.markerPath || '',
+    markerUrl: propagation.markerUrl || '',
+    observedAt: propagation.observedAt || '',
+    timedOutAt: propagation.timedOutAt || '',
+    attemptCount: propagation.attemptCount || 0,
+    canceled: !!patch.canceled,
+    timedOut,
+    failed,
+    observed: !patch.canceled && !timedOut && state === 'observed',
+    error: propagation.error || patch.error || null,
+    job
+  };
+}
+
+function isConnectPropagationTerminal(propagation) {
+  const state = safeString(propagation && propagation.state).trim();
+  return state === 'observed' || state === 'timedOut' || state === 'failed';
+}
+
+export async function waitForConnectPublishPropagation({
+  connect,
+  grant,
+  job,
+  fetchImpl = null,
+  translate = (key) => key,
+  onStatus = null,
+  setCancelHandler = null,
+  pollIntervalMs = 30000,
+  pollTimeoutMs = 10 * 60 * 1000,
+  sleepImpl = null
+} = {}) {
+  const message = (key, fallback) => {
+    const value = typeof translate === 'function' ? translate(key) : '';
+    return value && value !== key ? value : fallback;
+  };
+  const fetchRef = resolveFetch(fetchImpl);
+  const sleep = resolveSleep(sleepImpl);
+  if (!fetchRef || !connect || !connect.baseUrl || !grant || !grant.token || !job) return null;
+  const endpoint = new URL('/api/press/publish', connect.baseUrl);
+  const startedAt = Date.now();
+  let latestPayload = null;
+  let latestJob = job;
+  let canceled = false;
+
+  const setStatus = (text) => {
+    if (typeof onStatus === 'function') onStatus(text);
+  };
+  if (typeof setCancelHandler === 'function') {
+    setCancelHandler(() => {
+      canceled = true;
+      setStatus(message('editor.composer.github.modal.connectPropagationStopping', 'Stopping Connect live-site checks...'));
+    }, true);
+  }
+
+  try {
+    while (latestJob && typeof latestJob === 'object') {
+      const propagation = normalizeConnectPublishPropagation(latestJob.propagation);
+      if (isConnectPropagationTerminal(propagation)) {
+        return formatConnectPropagationResult(latestJob, propagation);
+      }
+      if (canceled) {
+        return formatConnectPropagationResult(latestJob, propagation || { source: 'connect', state: 'canceled' }, { canceled: true });
+      }
+      if (Date.now() - startedAt >= pollTimeoutMs) {
+        return formatConnectPropagationResult(latestJob, propagation || { source: 'connect', state: 'localTimeout' }, { timedOut: true });
+      }
+
+      setStatus(message('editor.composer.github.modal.connectCheckingLiveSite', 'Connect is checking the live site...'));
+      await sleep(Math.max(0, Number(pollIntervalMs) || 0));
+      if (canceled) {
+        return formatConnectPropagationResult(latestJob, propagation || { source: 'connect', state: 'canceled' }, { canceled: true });
+      }
+
+      const target = resolveConnectPublishStatusTarget(latestJob, endpoint);
+      let response = null;
+      try {
+        response = await fetchRef(target.href, {
+          method: 'GET',
+          referrerPolicy: 'unsafe-url',
+          headers: {
+            'Authorization': `Bearer ${grant.token}`
+          }
+        });
+      } catch (err) {
+        const error = new Error(message('editor.composer.github.modal.connectPropagationUnavailable', 'Connect propagation status is temporarily unavailable.'));
+        error.cause = err;
+        throw error;
+      }
+      latestPayload = await response.json().catch(() => null);
+      if (!response.ok || !latestPayload || latestPayload.ok === false) {
+        const error = new Error(latestPayload && latestPayload.error && latestPayload.error.message
+          ? latestPayload.error.message
+          : message('editor.composer.github.modal.connectPropagationUnavailable', 'Connect propagation status is temporarily unavailable.'));
+        error.status = response.status;
+        error.response = latestPayload;
+        throw error;
+      }
+      latestJob = resolveConnectPublishJob(latestPayload) || latestJob;
+    }
+  } finally {
+    if (typeof setCancelHandler === 'function') setCancelHandler(null, true);
+  }
+  return null;
 }
 
 export async function createConnectPublishCommit({

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.115",
-  "tag": "v3.4.115",
+  "version": "3.4.116",
+  "tag": "v3.4.116",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.114 <3.4.115"
+      ">=3.4.115 <3.4.116"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.114 first."
+    "message": "Update to v3.4.115 first."
   }
 }

--- a/scripts/test-publish-commit-transports.js
+++ b/scripts/test-publish-commit-transports.js
@@ -4,7 +4,8 @@ import { createGitHubSiteRepositoryProvider } from '../assets/js/provider-adapte
 import { publishCommit } from '../assets/js/publish/commit-service.js';
 import {
   createConnectPublishCommit,
-  requestConnectPublishGrant
+  requestConnectPublishGrant,
+  waitForConnectPublishPropagation
 } from '../assets/js/publish/transports/connect-transport.js';
 import {
   buildGithubFileChanges,
@@ -388,6 +389,64 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
           return Promise.resolve(okJson({
             ok: true,
             accepted: true,
+            job: {
+              id: 'pubjob_async_propagation',
+              state: 'queued',
+              statusUrl: 'https://connect.example/api/press/publish?job=pubjob_async_propagation'
+            }
+          }, 202));
+        }
+        return Promise.resolve(okJson({
+          ok: true,
+          job: {
+            id: 'pubjob_async_propagation',
+            requestId: 'request-async-propagation',
+            state: 'committed',
+            repository: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+            commit: { oid: 'async-propagation-commit' },
+            propagation: {
+              source: 'connect',
+              state: 'observing',
+              markerPath: 'wwwroot/press-publish-status.json',
+              markerUrl: 'https://ekilyhq.github.io/Press/press-publish-status.json',
+              attemptCount: 0
+            }
+          }
+        }));
+      }
+    });
+    assert.equal(result.job.id, 'pubjob_async_propagation');
+    assert.equal(result.job.propagation.source, 'connect');
+    assert.equal(result.job.propagation.state, 'observing');
+    assert.equal(result.job.propagation.markerPath, 'wwwroot/press-publish-status.json');
+    assert.equal(result.job.propagation.markerUrl, 'https://ekilyhq.github.io/Press/press-publish-status.json');
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 2);
+  assert.deepEqual(ambientCalls, [], 'Connect publish result should preserve durable propagation metadata');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  try {
+    const result = await createConnectPublishCommit({
+      connect: { baseUrl: 'https://connect.example' },
+      repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' },
+      headline: 'Sync draft',
+      files: [{ path: 'wwwroot/post/main.md', content: utf8Fixture }],
+      contentRoot: 'wwwroot',
+      grant: { token: 'grant-token' },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      fetchImpl(url, options) {
+        requests.push({ url, options, body: options.body ? JSON.parse(options.body) : null });
+        if (requests.length === 1) {
+          return Promise.resolve(okJson({
+            ok: true,
+            accepted: true,
             publishJob: {
               id: 'pubjob_alias',
               state: 'queued',
@@ -416,6 +475,68 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
   assert.equal(requests[1].url, 'https://connect.example/api/press/publish?job=pubjob_alias');
   assert.equal(requests[1].options.headers.Authorization, 'Bearer grant-token');
   assert.deepEqual(ambientCalls, [], 'Connect publish polling should support publishJob aliases without ambient fetch');
+}
+
+{
+  const ambientCalls = [];
+  const restores = ['fetch', 'window', 'document'].map((name) => installAmbientTrap(name, ambientCalls));
+  const requests = [];
+  const statuses = [];
+  const cancelHandlers = [];
+  try {
+    const result = await waitForConnectPublishPropagation({
+      connect: { baseUrl: 'https://connect.example' },
+      grant: { token: 'grant-token' },
+      job: {
+        id: 'pubjob_propagation',
+        state: 'committed',
+        statusUrl: 'https://connect.example/api/press/publish?job=pubjob_propagation',
+        propagation: {
+          source: 'connect',
+          state: 'observing',
+          markerUrl: 'https://site.example/press-publish-status.json'
+        }
+      },
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      onStatus: status => statuses.push(status),
+      setCancelHandler: handler => cancelHandlers.push(typeof handler === 'function'),
+      fetchImpl(url, options) {
+        requests.push({ url, options });
+        return Promise.resolve(okJson({
+          ok: true,
+          job: {
+            id: 'pubjob_propagation',
+            state: 'committed',
+            statusUrl: 'https://connect.example/api/press/publish?job=pubjob_propagation',
+            propagation: {
+              source: 'connect',
+              state: 'observed',
+              markerPath: 'wwwroot/press-publish-status.json',
+              markerUrl: 'https://site.example/press-publish-status.json',
+              observedAt: '2026-05-31T00:00:00.000Z',
+              attemptCount: 1
+            }
+          }
+        }));
+      }
+    });
+    assert.equal(result.source, 'connect');
+    assert.equal(result.state, 'observed');
+    assert.equal(result.observed, true);
+    assert.equal(result.timedOut, false);
+    assert.equal(result.jobId, 'pubjob_propagation');
+    assert.equal(result.markerUrl, 'https://site.example/press-publish-status.json');
+    assert.equal(result.attemptCount, 1);
+  } finally {
+    restores.reverse().forEach((restore) => restore());
+  }
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, 'https://connect.example/api/press/publish?job=pubjob_propagation');
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer grant-token');
+  assert.ok(statuses.includes('Connect is checking the live site...'));
+  assert.deepEqual(cancelHandlers, [true, false]);
+  assert.deepEqual(ambientCalls, [], 'Connect propagation polling should use injected fetch only');
 }
 
 {
@@ -731,17 +852,33 @@ const expectedBase64 = Buffer.from(utf8Fixture, 'utf8').toString('base64');
       }),
       fetchImpl(url, options) {
         requests.push({ url, options });
-        return Promise.resolve(okJson({ ok: true, id: 'published', commit: { oid: 'connect-commit' } }));
+        return Promise.resolve(okJson({
+          ok: true,
+          id: 'published',
+          commit: { oid: 'connect-commit' },
+          job: {
+            id: 'pubjob_normalized',
+            state: 'committed',
+            propagation: {
+              source: 'connect',
+              state: 'observed',
+              markerUrl: 'https://site.example/press-publish-status.json',
+              attemptCount: 1
+            }
+          }
+        }));
       },
       onPublishState: state => states.push(state)
     });
-    assert.deepEqual(result, {
-      ok: true,
-      provider: 'connect',
-      transport: 'connect',
-      id: 'published',
-      commit: { oid: 'connect-commit' }
-    });
+    assert.equal(result.ok, true);
+    assert.equal(result.provider, 'connect');
+    assert.equal(result.transport, 'connect');
+    assert.equal(result.id, 'published');
+    assert.deepEqual(result.commit, { oid: 'connect-commit' });
+    assert.equal(result.job.id, 'pubjob_normalized');
+    assert.equal(result.job.propagation.source, 'connect');
+    assert.equal(result.job.propagation.state, 'observed');
+    assert.equal(result.job.propagation.markerUrl, 'https://site.example/press-publish-status.json');
   } finally {
     restores.reverse().forEach((restore) => restore());
   }

--- a/scripts/test-publish-flow-smoke.js
+++ b/scripts/test-publish-flow-smoke.js
@@ -44,11 +44,15 @@ function createMemoryStorage() {
   };
 }
 
-function createFlowHarness() {
+function createFlowHarness(options = {}) {
   const calls = [];
   const requests = [];
   const receipts = [];
   const receiptStorage = createMemoryStorage();
+  const connectPropagationSequence = Array.isArray(options.connectPropagationSequence)
+    ? options.connectPropagationSequence
+    : [];
+  let connectStatusCalls = 0;
   const liveFiles = new Map([
     ['post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n'],
     ['wwwroot/post/smoke.md', '# Smoke\n\nUpdated from publish flow.\n']
@@ -89,20 +93,24 @@ function createFlowHarness() {
     }
 
     if (target === 'https://connect.example/api/press/publish?job=pubjob_connect_smoke') {
+      connectStatusCalls += 1;
+      const propagation = connectPropagationSequence[Math.min(connectStatusCalls - 1, connectPropagationSequence.length - 1)] || null;
+      const job = {
+        id: 'pubjob_connect_smoke',
+        requestId: 'connect-smoke',
+        state: 'committed',
+        statusUrl: 'https://connect.example/api/press/publish?job=pubjob_connect_smoke',
+        fileCount: 2,
+        additionCount: 1,
+        deletionCount: 1,
+        commit: { oid: 'connect-smoke-commit' }
+      };
+      if (propagation) job.propagation = propagation;
       return okJson({
         ok: true,
         id: 'connect-smoke',
         commit: { oid: 'connect-smoke-commit' },
-        job: {
-          id: 'pubjob_connect_smoke',
-          requestId: 'connect-smoke',
-          state: 'committed',
-          statusUrl: 'https://connect.example/api/press/publish?job=pubjob_connect_smoke',
-          fileCount: 2,
-          additionCount: 1,
-          deletionCount: 1,
-          commit: { oid: 'connect-smoke-commit' }
-        }
+        job
       });
     }
 
@@ -179,6 +187,7 @@ function createFlowHarness() {
 
   return {
     calls,
+    connectStatusCalls: () => connectStatusCalls,
     flow,
     receiptStorage,
     receipts,
@@ -239,6 +248,51 @@ function createFlowHarness() {
   assert.equal(JSON.stringify(storedReceipt).includes('base64'), false);
   assert.deepEqual(harness.calls.at(-2), ['toast', 'success', 'editor.toasts.commitSuccess:2', false]);
   assert.deepEqual(harness.calls.at(-1), ['inFlight', false]);
+}
+
+{
+  const harness = createFlowHarness({
+    connectPropagationSequence: [
+      {
+        source: 'connect',
+        state: 'observing',
+        markerPath: 'wwwroot/press-publish-status.json',
+        markerUrl: 'https://docs.example/press-publish-status.json',
+        attemptCount: 0
+      },
+      {
+        source: 'connect',
+        state: 'observed',
+        markerPath: 'wwwroot/press-publish-status.json',
+        markerUrl: 'https://docs.example/press-publish-status.json',
+        observedAt: '2026-05-31T00:00:00.000Z',
+        attemptCount: 1
+      }
+    ]
+  });
+  await harness.flow.performConnectGithubCommit({ baseUrl: 'https://connect.example' }, [
+    { kind: 'site', label: 'site.yaml' }
+  ]);
+
+  assert.equal(harness.connectStatusCalls(), 2, 'Connect-managed propagation should poll the durable job status after commit');
+  assert.ok(harness.calls.some(call => call[0] === 'status' && call[1] === 'Connect is checking the live site...'));
+  assert.equal(
+    harness.calls.some(call => call[0] === 'status' && String(call[1]).startsWith('Checking Smoke post')),
+    false,
+    'Connect-managed propagation should avoid local per-file browser polling'
+  );
+  const finalReceipt = harness.receipts.at(-1);
+  assert.equal(finalReceipt.state, PUBLISH_STATES.OBSERVED);
+  assert.equal(finalReceipt.publish.job.propagation.source, 'connect');
+  assert.equal(finalReceipt.publish.job.propagation.state, 'observing');
+  assert.equal(finalReceipt.propagation.source, 'connect');
+  assert.equal(finalReceipt.propagation.state, 'observed');
+  assert.equal(finalReceipt.propagation.jobId, 'pubjob_connect_smoke');
+  assert.equal(finalReceipt.propagation.markerUrl, 'https://docs.example/press-publish-status.json');
+  assert.equal(finalReceipt.propagation.observedAt, '2026-05-31T00:00:00.000Z');
+  assert.equal(finalReceipt.propagation.attemptCount, 1);
+  assert.equal(finalReceipt.propagation.observed, true);
+  assert.equal(finalReceipt.propagation.timedOut, false);
 }
 
 {


### PR DESCRIPTION
## Summary
- let the browser publish flow prefer Connect-managed propagation status when a committed job includes it
- preserve safe propagation metadata in Connect publish jobs and local publish receipts
- keep the existing browser per-file propagation watcher as the fallback path
- bump Press system metadata to `v3.4.116`

## Verification
- `node scripts/test-publish-commit-transports.js`
- `node scripts/test-publish-flow-smoke.js`
- `node scripts/test-composer-publish-flow.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `node scripts/test-ui-components.js`
- `node scripts/test-press-system-surface.mjs`
- `node --experimental-default-type=module scripts/test-system-updates.js`

## Release / Deployment Impact
- This is a Press system-surface change and should publish `v3.4.116` after merge.
- Durable propagation status depends on Connect PR https://github.com/EkilyHQ/Connect/pull/12 being deployed. Until then, the editor continues to use the existing local propagation watcher fallback.

## Review
- Local pre-PR review completed with no blockers. A subagent review was not spawned because the current tool policy only permits spawning subagents when the user explicitly requests delegation.