### PR TITLE
Bump Press system metadata to v3.4.117

### DIFF
--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.116",
-  "tag": "v3.4.116",
+  "version": "3.4.117",
+  "tag": "v3.4.117",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.115 <3.4.116"
+      ">=3.4.116 <3.4.117"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.115 first."
+    "message": "Update to v3.4.116 first."
   }
 }


### PR DESCRIPTION
## Summary
- bump assets/press-system.json to v3.4.117 after PR #461 changed the Press system surface
- update the supported upgrade range/message from v3.4.116 so System Release and Pages can publish the architecture-contract build

## Validation
- node scripts/sync-runtime-cache-keys.mjs --check
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-pages-artifact.sh
- bash scripts/test-pages-workflow.sh
- node scripts/test-press-system-surface.mjs
- node --experimental-default-type=module scripts/test-system-updates.js
- bash scripts/test-main-guard.sh
- git diff --check
- node scripts/test-release-intent.js
- node scripts/test-release-targets.js

## Impact
- release package: enables the next Press system release v3.4.117 for the editor architecture contract changes merged in #461
- UI/security: no runtime behavior or permission changes beyond the version metadata
