### PR TITLE
Stop writing legacy editor state

### DIFF
--- a/assets/js/composer-editor-shell.js
+++ b/assets/js/composer-editor-shell.js
@@ -198,8 +198,7 @@ export function createComposerEditorShell(options = {}) {
   }
 
   function persistSystemTreeExpandedState() {
-    if (!editorSessionStateStore || typeof editorSessionStateStore.writeLegacySystemTreeExpanded !== 'function') return;
-    editorSessionStateStore.writeLegacySystemTreeExpanded(expandedEditorTreeNodeIds.has('system'));
+    scheduleEditorStatePersist();
   }
 
   function scheduleEditorStatePersist() {

--- a/assets/js/editor-session-state.js
+++ b/assets/js/editor-session-state.js
@@ -10,9 +10,9 @@ export function createEditorSessionStateStore({
     catch (_) { return ''; }
   }
 
-  function setItem(key, value) {
+  function removeItem(key) {
     try {
-      if (storage && storage.setItem) storage.setItem(scoped(key), String(value));
+      if (storage && storage.removeItem) storage.removeItem(scoped(key));
     } catch (_) {}
   }
 
@@ -27,15 +27,22 @@ export function createEditorSessionStateStore({
 
   function writeJson(key, value) {
     try {
-      if (storage && storage.setItem) storage.setItem(scoped(key), JSON.stringify(value));
-    } catch (_) {}
+      if (storage && storage.setItem) {
+        return storage.setItem(scoped(key), JSON.stringify(value)) !== false;
+      }
+    } catch (_) {
+      return false;
+    }
+    return false;
   }
 
   return {
     readEditorState: () => readJson(keys.editorState),
-    writeEditorState: (state) => writeJson(keys.editorState, state),
+    writeEditorState: (state) => {
+      if (writeJson(keys.editorState, state)) removeItem(keys.systemTreeExpanded);
+    },
     readLegacySystemTreeExpanded: () => getItem(keys.systemTreeExpanded) === '1',
-    writeLegacySystemTreeExpanded: (expanded) => setItem(keys.systemTreeExpanded, expanded ? '1' : '0'),
+    clearLegacySystemTreeExpanded: () => removeItem(keys.systemTreeExpanded),
     readUnscopedNumber(key, fallback = 0) {
       try {
         const raw = storage && storage.getItem ? storage.getItem(key) : null;

--- a/assets/js/publish/settings-store.js
+++ b/assets/js/publish/settings-store.js
@@ -100,6 +100,7 @@ export function createPublishSettingsStore(options = {}) {
     try {
       const storage = local();
       const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
+      let migratedLegacyMode = false;
       if (modeRaw === 'connect' || modeRaw === 'pat') {
         settings.mode = modeRaw;
         settings.enabled = modeRaw === 'connect';
@@ -108,13 +109,19 @@ export function createPublishSettingsStore(options = {}) {
         if (enabledRaw === '0') {
           settings.mode = 'pat';
           settings.enabled = false;
+          migratedLegacyMode = true;
         } else if (enabledRaw === '1') {
           settings.mode = 'connect';
           settings.enabled = true;
+          migratedLegacyMode = true;
         }
       }
       const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
       if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
+      if (migratedLegacyMode) {
+        const wroteMode = storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode) !== false;
+        if (wroteMode) storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+      }
     } catch (_) {
       /* ignore unavailable storage */
     }
@@ -139,8 +146,8 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishSettingsMemory = { ...settings };
     try {
       const storage = local();
-      storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
-      storage.setItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY), settings.enabled ? '1' : '0');
+      const wroteMode = storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode) !== false;
+      if (wroteMode) storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
       storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
     } catch (_) {
       /* ignore storage errors */

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.118",
-  "tag": "v3.4.118",
+  "version": "3.4.119",
+  "tag": "v3.4.119",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.117 <3.4.118"
+      ">=3.4.118 <3.4.119"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.117 first."
+    "message": "Update to v3.4.118 first."
   }
 }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3601,7 +3601,9 @@ function createMemoryStorage(seed = {}) {
 }
 
 {
-  const localStorage = createMemoryStorage();
+  const localStorage = createMemoryStorage({
+    'press_editor_system_tree_expanded:scope': '1'
+  });
   const store = createEditorSessionStateStore({
     storage: localStorage,
     scopeKey: (key) => `${key}:scope`,
@@ -3610,11 +3612,69 @@ function createMemoryStorage(seed = {}) {
       systemTreeExpanded: 'press_editor_system_tree_expanded'
     }
   });
+  assert.equal(store.readLegacySystemTreeExpanded(), true, 'transition release should still read the legacy system-tree state');
+  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
+  assert.equal(
+    localStorage.dump()['press_editor_system_tree_expanded:scope'],
+    undefined,
+    'writing current editor state should clear the legacy system-tree key'
+  );
   assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'missing rail width should preserve the default width');
   localStorage.setItem('press_editor_rail_width', '420');
   assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 420, 'stored rail width should be restored');
   localStorage.setItem('press_editor_rail_width', 'invalid');
   assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'invalid rail width should fall back to the default width');
+}
+
+{
+  const localStorage = createMemoryStorage({
+    'press_editor_system_tree_expanded:scope': '1'
+  });
+  const originalSetItem = localStorage.setItem;
+  localStorage.setItem = (key, value) => {
+    if (key === 'press_composer_editor_state:scope') throw new Error('quota exceeded');
+    originalSetItem(key, value);
+  };
+  const store = createEditorSessionStateStore({
+    storage: localStorage,
+    scopeKey: (key) => `${key}:scope`,
+    keys: {
+      editorState: 'press_composer_editor_state',
+      systemTreeExpanded: 'press_editor_system_tree_expanded'
+    }
+  });
+  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
+  assert.equal(
+    localStorage.dump()['press_editor_system_tree_expanded:scope'],
+    '1',
+    'failed current editor-state writes should keep the legacy fallback key for the next load'
+  );
+}
+
+{
+  const localStorage = createMemoryStorage({
+    'press_editor_system_tree_expanded:scope': '1'
+  });
+  const originalSetItem = localStorage.setItem;
+  localStorage.setItem = (key, value) => {
+    if (key === 'press_composer_editor_state:scope') return false;
+    originalSetItem(key, value);
+    return true;
+  };
+  const store = createEditorSessionStateStore({
+    storage: localStorage,
+    scopeKey: (key) => `${key}:scope`,
+    keys: {
+      editorState: 'press_composer_editor_state',
+      systemTreeExpanded: 'press_editor_system_tree_expanded'
+    }
+  });
+  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
+  assert.equal(
+    localStorage.dump()['press_editor_system_tree_expanded:scope'],
+    '1',
+    'storage wrappers that return false on editor-state writes should keep the legacy fallback key'
+  );
 }
 
 {
@@ -3627,10 +3687,36 @@ function createMemoryStorage(seed = {}) {
     scopeKey: (key) => `${key}:scope`
   });
   assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'legacy Connect opt-out should migrate to PAT fallback mode');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'pat', 'legacy opt-out should be normalized to the publish transport mode key');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'legacy Connect enabled key should be removed after normalization');
   store.setStoredConnectPublishSettings({ baseUrl: 'http://127.0.0.1:8788' });
   assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'editing the Connect URL should not silently leave PAT fallback mode');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'saving publish settings should not recreate the legacy Connect enabled key');
   store.setStoredConnectPublishSettings({ enabled: true });
   assert.equal(store.getStoredConnectPublishSettings().mode, 'connect', 'enabling Connect should persist Connect as the default publish mode');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'connect', 'enabling Connect should persist the current transport mode key');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'current publish settings should not write the legacy Connect enabled key');
+}
+
+{
+  const localStorage = createMemoryStorage({
+    'press_connect_publish_enabled:scope': '0'
+  });
+  const sessionStorage = createMemoryStorage();
+  const originalSetItem = localStorage.setItem;
+  localStorage.setItem = (key, value) => {
+    if (key === 'press_publish_transport_mode:scope') throw new Error('quota exceeded');
+    originalSetItem(key, value);
+  };
+  const store = createPublishSettingsStore({
+    windowRef: { localStorage, sessionStorage },
+    scopeKey: (key) => `${key}:scope`
+  });
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'legacy Connect opt-out should still be read when mode normalization fails');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], undefined, 'failed mode normalization should not create the current transport key');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'failed mode normalization should keep the legacy Connect enabled key');
+  store.setStoredConnectPublishSettings({ enabled: true });
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'failed current mode writes should not remove the legacy publish fallback key');
 }
 
 {
@@ -7729,7 +7815,13 @@ assert.match(
 assert.match(
   publishSettingsSource,
   /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
-  'Connect publish settings should keep legacy storage compatibility while defaulting to a transport mode key'
+  'Connect publish settings should keep the transition key names and Connect presets explicit'
+);
+
+assert.match(
+  publishSettingsSource,
+  /enabledRaw === '0'[\s\S]*migratedLegacyMode = true;[\s\S]*const wroteMode = storage\.setItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\), settings\.mode\) !== false;[\s\S]*if \(wroteMode\) storage\.removeItem\(scopedKey\(CONNECT_PUBLISH_ENABLED_STORAGE_KEY\)\);[\s\S]*function setStoredConnectPublishSettings[\s\S]*const wroteMode = storage\.setItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\), settings\.mode\) !== false;[\s\S]*if \(wroteMode\) storage\.removeItem\(scopedKey\(CONNECT_PUBLISH_ENABLED_STORAGE_KEY\)\);/,
+  'Connect publish settings should read legacy storage once and normalize it to the transport mode key'
 );
 
 assert.match(


### PR DESCRIPTION
## Summary
- stop persisting the legacy editor system-tree localStorage key after v3 editor state exists
- normalize the legacy Connect publish opt-out key into the current transport mode key and remove the old key on read/save
- bump the Press system manifest to v3.4.119 with upgradeFrom limited to v3.4.118

## Verification
- node scripts/test-composer-runtime.js
- node scripts/test-composer-identity-grid.js
- node scripts/test-publish-flow-smoke.js
- node scripts/test-press-version-runtime.js
- node --experimental-default-type=module scripts/test-system-updates.js
- node scripts/sync-runtime-cache-keys.mjs --check
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-pages-artifact.sh
- node scripts/test-release-intent.js
- node scripts/test-release-targets.js
- git diff --check
- bash scripts/test-system-release-package.sh after commit, from HEAD
- Browser smoke: http://127.0.0.1:8002/index_editor.html loaded with editor shell IDs present and no console warn/error

## Release impact
- Press system release v3.4.119 transition release
- No system package surface expansion
- Existing old browser-local keys are still readable during this release, then normalized into current durable state
