### PR TITLE
Remove legacy browser state reads

### DIFF
--- a/assets/js/composer-runtime.js
+++ b/assets/js/composer-runtime.js
@@ -182,8 +182,7 @@ export function createComposerRuntime(options = {}) {
 
   function initializeEditorSessionState({
     editorSessionStateStore = null,
-    editorStateVersion = null,
-    legacySystemTreeNodeId = 'system'
+    editorStateVersion = null
   } = {}) {
     hasEditorStateV3Snapshot = false;
     try {
@@ -195,14 +194,6 @@ export function createComposerRuntime(options = {}) {
     } catch (_) {
       hasEditorStateV3Snapshot = false;
     }
-    try {
-      if (!hasEditorStateV3Snapshot
-        && editorSessionStateStore
-        && typeof editorSessionStateStore.readLegacySystemTreeExpanded === 'function'
-        && editorSessionStateStore.readLegacySystemTreeExpanded()) {
-        expandedEditorTreeNodeIds.add(String(legacySystemTreeNodeId || 'system'));
-      }
-    } catch (_) {}
     return hasEditorStateV3Snapshot;
   }
 

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -197,8 +197,7 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   // --- Persisted UI state keys ---
   const LS_KEYS = {
     cfile: 'press_composer_file',           // 'index' | 'tabs' | 'site'
-    editorState: 'press_composer_editor_state', // persisted dynamic editor info
-    systemTreeExpanded: 'press_editor_system_tree_expanded'
+    editorState: 'press_composer_editor_state' // persisted dynamic editor info
   };
   const EDITOR_STATE_VERSION = 3;
 

--- a/assets/js/editor-session-state.js
+++ b/assets/js/editor-session-state.js
@@ -10,12 +10,6 @@ export function createEditorSessionStateStore({
     catch (_) { return ''; }
   }
 
-  function removeItem(key) {
-    try {
-      if (storage && storage.removeItem) storage.removeItem(scoped(key));
-    } catch (_) {}
-  }
-
   function readJson(key) {
     try {
       const raw = getItem(key);
@@ -38,11 +32,7 @@ export function createEditorSessionStateStore({
 
   return {
     readEditorState: () => readJson(keys.editorState),
-    writeEditorState: (state) => {
-      if (writeJson(keys.editorState, state)) removeItem(keys.systemTreeExpanded);
-    },
-    readLegacySystemTreeExpanded: () => getItem(keys.systemTreeExpanded) === '1',
-    clearLegacySystemTreeExpanded: () => removeItem(keys.systemTreeExpanded),
+    writeEditorState: (state) => writeJson(keys.editorState, state),
     readUnscopedNumber(key, fallback = 0) {
       try {
         const raw = storage && storage.getItem ? storage.getItem(key) : null;

--- a/assets/js/publish/settings-store.js
+++ b/assets/js/publish/settings-store.js
@@ -5,7 +5,6 @@ import {
 
 export const GITHUB_PAT_STORAGE_KEY = 'press_fg_pat_cache';
 export const CONNECT_PUBLISH_GRANT_STORAGE_KEY = 'press_connect_publish_grant_cache';
-export const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';
 export const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';
 export const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';
 export const CONNECT_PUBLISH_MESSAGE_TYPE = 'press-connect-publish-authorized';
@@ -100,28 +99,12 @@ export function createPublishSettingsStore(options = {}) {
     try {
       const storage = local();
       const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
-      let migratedLegacyMode = false;
       if (modeRaw === 'connect' || modeRaw === 'pat') {
         settings.mode = modeRaw;
         settings.enabled = modeRaw === 'connect';
-      } else {
-        const enabledRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
-        if (enabledRaw === '0') {
-          settings.mode = 'pat';
-          settings.enabled = false;
-          migratedLegacyMode = true;
-        } else if (enabledRaw === '1') {
-          settings.mode = 'connect';
-          settings.enabled = true;
-          migratedLegacyMode = true;
-        }
       }
       const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
       if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
-      if (migratedLegacyMode) {
-        const wroteMode = storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode) !== false;
-        if (wroteMode) storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
-      }
     } catch (_) {
       /* ignore unavailable storage */
     }
@@ -146,8 +129,7 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishSettingsMemory = { ...settings };
     try {
       const storage = local();
-      const wroteMode = storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode) !== false;
-      if (wroteMode) storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+      storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
       storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
     } catch (_) {
       /* ignore storage errors */

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.119",
-  "tag": "v3.4.119",
+  "version": "3.4.120",
+  "tag": "v3.4.120",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.118 <3.4.119"
+      ">=3.4.119 <3.4.120"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.118 first."
+    "message": "Update to v3.4.119 first."
   }
 }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3608,16 +3608,15 @@ function createMemoryStorage(seed = {}) {
     storage: localStorage,
     scopeKey: (key) => `${key}:scope`,
     keys: {
-      editorState: 'press_composer_editor_state',
-      systemTreeExpanded: 'press_editor_system_tree_expanded'
+      editorState: 'press_composer_editor_state'
     }
   });
-  assert.equal(store.readLegacySystemTreeExpanded(), true, 'transition release should still read the legacy system-tree state');
-  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
+  assert.equal(typeof store.readLegacySystemTreeExpanded, 'undefined', 'cleanup release should not expose legacy system-tree readers');
+  assert.equal(store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] }), true, 'current editor state should persist through the v3 store');
   assert.equal(
     localStorage.dump()['press_editor_system_tree_expanded:scope'],
-    undefined,
-    'writing current editor state should clear the legacy system-tree key'
+    '1',
+    'current editor-state writes should not mutate the retired legacy system-tree key'
   );
   assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'missing rail width should preserve the default width');
   localStorage.setItem('press_editor_rail_width', '420');
@@ -3628,57 +3627,6 @@ function createMemoryStorage(seed = {}) {
 
 {
   const localStorage = createMemoryStorage({
-    'press_editor_system_tree_expanded:scope': '1'
-  });
-  const originalSetItem = localStorage.setItem;
-  localStorage.setItem = (key, value) => {
-    if (key === 'press_composer_editor_state:scope') throw new Error('quota exceeded');
-    originalSetItem(key, value);
-  };
-  const store = createEditorSessionStateStore({
-    storage: localStorage,
-    scopeKey: (key) => `${key}:scope`,
-    keys: {
-      editorState: 'press_composer_editor_state',
-      systemTreeExpanded: 'press_editor_system_tree_expanded'
-    }
-  });
-  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
-  assert.equal(
-    localStorage.dump()['press_editor_system_tree_expanded:scope'],
-    '1',
-    'failed current editor-state writes should keep the legacy fallback key for the next load'
-  );
-}
-
-{
-  const localStorage = createMemoryStorage({
-    'press_editor_system_tree_expanded:scope': '1'
-  });
-  const originalSetItem = localStorage.setItem;
-  localStorage.setItem = (key, value) => {
-    if (key === 'press_composer_editor_state:scope') return false;
-    originalSetItem(key, value);
-    return true;
-  };
-  const store = createEditorSessionStateStore({
-    storage: localStorage,
-    scopeKey: (key) => `${key}:scope`,
-    keys: {
-      editorState: 'press_composer_editor_state',
-      systemTreeExpanded: 'press_editor_system_tree_expanded'
-    }
-  });
-  store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] });
-  assert.equal(
-    localStorage.dump()['press_editor_system_tree_expanded:scope'],
-    '1',
-    'storage wrappers that return false on editor-state writes should keep the legacy fallback key'
-  );
-}
-
-{
-  const localStorage = createMemoryStorage({
     'press_connect_publish_enabled:scope': '0'
   });
   const sessionStorage = createMemoryStorage();
@@ -3686,37 +3634,12 @@ function createMemoryStorage(seed = {}) {
     windowRef: { localStorage, sessionStorage },
     scopeKey: (key) => `${key}:scope`
   });
-  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'legacy Connect opt-out should migrate to PAT fallback mode');
-  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'pat', 'legacy opt-out should be normalized to the publish transport mode key');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'legacy Connect enabled key should be removed after normalization');
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'connect', 'retired legacy Connect opt-out should no longer change the current default mode');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], undefined, 'retired legacy opt-out should not be normalized by the cleanup release');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'cleanup release should leave retired legacy publish keys untouched');
   store.setStoredConnectPublishSettings({ baseUrl: 'http://127.0.0.1:8788' });
-  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'editing the Connect URL should not silently leave PAT fallback mode');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'saving publish settings should not recreate the legacy Connect enabled key');
-  store.setStoredConnectPublishSettings({ enabled: true });
-  assert.equal(store.getStoredConnectPublishSettings().mode, 'connect', 'enabling Connect should persist Connect as the default publish mode');
-  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'connect', 'enabling Connect should persist the current transport mode key');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'current publish settings should not write the legacy Connect enabled key');
-}
-
-{
-  const localStorage = createMemoryStorage({
-    'press_connect_publish_enabled:scope': '0'
-  });
-  const sessionStorage = createMemoryStorage();
-  const originalSetItem = localStorage.setItem;
-  localStorage.setItem = (key, value) => {
-    if (key === 'press_publish_transport_mode:scope') throw new Error('quota exceeded');
-    originalSetItem(key, value);
-  };
-  const store = createPublishSettingsStore({
-    windowRef: { localStorage, sessionStorage },
-    scopeKey: (key) => `${key}:scope`
-  });
-  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'legacy Connect opt-out should still be read when mode normalization fails');
-  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], undefined, 'failed mode normalization should not create the current transport key');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'failed mode normalization should keep the legacy Connect enabled key');
-  store.setStoredConnectPublishSettings({ enabled: true });
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'failed current mode writes should not remove the legacy publish fallback key');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'connect', 'saving current publish settings should write the current transport mode key');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'saving current publish settings should not remove or rewrite the retired key');
 }
 
 {
@@ -7814,14 +7737,14 @@ assert.match(
 
 assert.match(
   publishSettingsSource,
-  /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
-  'Connect publish settings should keep the transition key names and Connect presets explicit'
+  /const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
+  'Connect publish settings should keep the current transport key and Connect presets explicit'
 );
 
-assert.match(
+assert.doesNotMatch(
   publishSettingsSource,
-  /enabledRaw === '0'[\s\S]*migratedLegacyMode = true;[\s\S]*const wroteMode = storage\.setItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\), settings\.mode\) !== false;[\s\S]*if \(wroteMode\) storage\.removeItem\(scopedKey\(CONNECT_PUBLISH_ENABLED_STORAGE_KEY\)\);[\s\S]*function setStoredConnectPublishSettings[\s\S]*const wroteMode = storage\.setItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\), settings\.mode\) !== false;[\s\S]*if \(wroteMode\) storage\.removeItem\(scopedKey\(CONNECT_PUBLISH_ENABLED_STORAGE_KEY\)\);/,
-  'Connect publish settings should read legacy storage once and normalize it to the transport mode key'
+  /CONNECT_PUBLISH_ENABLED_STORAGE_KEY|press_connect_publish_enabled|enabledRaw|migratedLegacyMode/,
+  'cleanup release should remove the retired Connect publish storage bridge'
 );
 
 assert.match(
@@ -7838,8 +7761,8 @@ assert.match(
 
 assert.match(
   publishSettingsSource,
-  /mode: 'connect'[\s\S]*const modeRaw = storage\.getItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\)\)[\s\S]*enabledRaw === '0'[\s\S]*mode = 'pat'[\s\S]*function resolvePublishTransport/,
-  'Publish transport should default to Connect while preserving legacy opt-out to PAT fallback'
+  /mode: 'connect'[\s\S]*const modeRaw = storage\.getItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\)\)[\s\S]*modeRaw === 'connect' \|\| modeRaw === 'pat'[\s\S]*function resolvePublishTransport/,
+  'Publish transport should default to Connect and read only the current transport mode key'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-runtime.js
+++ b/scripts/test-composer-runtime.js
@@ -192,12 +192,14 @@ const legacyStateRuntime = createComposerRuntime({ windowRef, documentRef, navig
 assert.equal(legacyStateRuntime.initializeEditorSessionState({
   editorSessionStateStore: {
     readEditorState: () => ({ v: 2 }),
-    readLegacySystemTreeExpanded: () => true
+    readLegacySystemTreeExpanded: () => {
+      throw new Error('legacy tree state should no longer be read');
+    }
   },
   editorStateVersion: 3
 }), false);
 assert.equal(legacyStateRuntime.hasEditorStateSnapshot(), false);
-assert.deepEqual(legacyStateRuntime.getExpandedEditorTreeNodeIdsSnapshot(), ['articles', 'pages', 'system']);
+assert.deepEqual(legacyStateRuntime.getExpandedEditorTreeNodeIdsSnapshot(), ['articles', 'pages']);
 assert.equal(runtime.getAllowEditorStatePersist(), false);
 assert.equal(runtime.setAllowEditorStatePersist(true), true);
 assert.equal(runtime.getAllowEditorStatePersist(), true);


### PR DESCRIPTION
## Summary
- remove the retired editor tree and Connect publish localStorage read bridges after the v3.4.119 transition release
- keep current v3 editor session state and publish transport mode storage as the only runtime contract
- bump the Press system manifest to v3.4.120 and require upgrades to pass through v3.4.119 first

## Release impact
- Press system-surface change; expected to publish v3.4.120 after merge
- `assets/press-system.json` declares `upgradeFrom.ranges: [">=3.4.119 <3.4.120"]` and `allowUnknownSource: false`
- Users on pre-v3.4.119 must update to v3.4.119 before v3.4.120

## Verification
- `node scripts/test-composer-runtime.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-publish-flow-smoke.js`
- `node scripts/test-press-version-runtime.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- `node scripts/test-release-intent.js`
- `node scripts/test-release-targets.js`
- `node scripts/test-press-system-surface.mjs`
- `node scripts/test-product-state-ledger.js`
- `bash scripts/test-system-release-package.sh`
- `git diff --check`
- Browser smoke: `http://127.0.0.1:8002/index_editor.html` loaded editor shell, composer panes, and theme panels with no warning/error console logs
- Local subagent review: no blocker findings
