### PR TITLE
Gate theme controls legacy DOM by contract

### DIFF
--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -269,6 +269,10 @@ export class PressSearch extends HTMLElement {
 }
 
 export class PressThemeControls extends HTMLElement {
+  static get observedAttributes() {
+    return ['variant', 'contract-version'];
+  }
+
   constructor() {
     super();
     this._labels = {};
@@ -288,6 +292,10 @@ export class PressThemeControls extends HTMLElement {
 
   disconnectedCallback() {
     this._unbindEvents();
+  }
+
+  attributeChangedCallback(_name, oldValue, newValue) {
+    if (oldValue !== newValue && this.isConnected) this.render();
   }
 
   setLabels(labels = {}) {
@@ -335,18 +343,34 @@ export class PressThemeControls extends HTMLElement {
     return raw.replace(/[^a-z0-9_-]/g, '') || 'native';
   }
 
+  _contractVersion() {
+    const version = Number(this.getAttribute('contract-version') || 2);
+    return Number.isFinite(version) ? version : 2;
+  }
+
+  _usesLegacyDom() {
+    return this._contractVersion() <= 1;
+  }
+
   _syncHostClass() {
     const variant = this._variant();
-    if (!this.id) this.id = 'tools';
+    const legacyDom = this._usesLegacyDom();
+    if (legacyDom && !this.id) {
+      this.id = 'tools';
+      this.dataset.pressThemeControlsLegacyId = '1';
+    } else if (!legacyDom && this.id === 'tools' && this.dataset.pressThemeControlsLegacyId === '1') {
+      this.removeAttribute('id');
+      delete this.dataset.pressThemeControlsLegacyId;
+    }
     Array.from(this.classList || []).forEach((className) => {
       if (String(className || '').startsWith('press-theme-controls--')) {
         this.classList.remove(className);
       }
     });
     this.classList.remove('box', 'arcus-tools__groups', 'solstice-tools');
-    if (variant === 'arcus') {
+    if (legacyDom && variant === 'arcus') {
       this.classList.add('arcus-tools__groups', `press-theme-controls--${variant}`);
-    } else if (variant === 'solstice') {
+    } else if (legacyDom && variant === 'solstice') {
       this.classList.add('solstice-tools', `press-theme-controls--${variant}`);
     } else {
       this.classList.add('box', `press-theme-controls--${variant}`);

--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -14,6 +14,8 @@ const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
 ]);
 const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
 const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([1, 2]);
+const LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX = 1;
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
   '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
   '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'
@@ -23,7 +25,9 @@ const THEME_TEXT_EXTENSIONS = Object.freeze(['.css', '.js', '.json', '.mjs', '.s
 export const PRESS_THEME_CONTRACT = Object.freeze({
   schemaVersion: 1,
   type: 'press-theme-contract',
-  contractVersion: 1,
+  contractVersion: 2,
+  supportedContractVersions: SUPPORTED_THEME_CONTRACT_VERSIONS,
+  legacyThemeControlsDomContractMax: LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX,
   manifestSchemaPath: 'assets/schema/theme.json',
   manifest: Object.freeze({
     requiredFields: REQUIRED_THEME_MANIFEST_FIELDS,
@@ -46,6 +50,10 @@ export function getRequiredThemeManifestFields() {
 
 export function getDefaultThemeStyles() {
   return [...DEFAULT_THEME_STYLES];
+}
+
+export function getSupportedThemeContractVersions() {
+  return [...SUPPORTED_THEME_CONTRACT_VERSIONS];
 }
 
 export function getRequiredThemeViews() {
@@ -81,5 +89,11 @@ export function getThemeTextExtensions() {
 }
 
 export function isPressThemeContractVersionSupported(value) {
-  return Number(value) === PRESS_THEME_CONTRACT.contractVersion;
+  return SUPPORTED_THEME_CONTRACT_VERSIONS.includes(Number(value));
+}
+
+export function usesLegacyThemeControlsDom(value) {
+  const version = Number(value);
+  if (!Number.isFinite(version)) return false;
+  return version >= 1 && version <= LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX;
 }

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -23,6 +23,7 @@ import {
 } from './theme-regions.js';
 import {
   PRESS_THEME_CONTRACT,
+  isPressThemeContractVersionSupported,
   getDefaultThemeStyles,
   getRequiredThemeContentShapes
 } from './theme-contract-surface.mjs';
@@ -120,7 +121,7 @@ export function createThemeI18nContext() {
 function validateManifestContract(pack, manifest) {
   if (!isThemeDevMode()) return;
   const contractVersion = manifest && manifest.contractVersion;
-  if (contractVersion !== CONTRACT_VERSION) {
+  if (!isPressThemeContractVersionSupported(contractVersion)) {
     themeDevWarn(`Theme "${pack}" declares unsupported contract version`, contractVersion);
   }
   if (!manifest.version) {
@@ -514,6 +515,7 @@ async function mountPack(pack, allowFallback = true, options = {}) {
   };
 
   if (!isCurrentMountGeneration(mountGeneration, options)) return null;
+  regionController.setThemeLayoutContext(context);
   applyManifestStyles(pack, manifest);
 
   for (const { entry, mod } of loadedModules) {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,5 +1,9 @@
 import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js';
-import { getThemeRegion } from './theme-regions.js';
+import {
+  PRESS_THEME_CONTRACT,
+  usesLegacyThemeControlsDom
+} from './theme-contract-surface.mjs';
+import { getThemeLayoutContext, getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';
 const THEME_CONTROLS_BOUND = Symbol('pressThemeControlsBound');
@@ -331,6 +335,27 @@ function getThemeControlsElement(root = document) {
   return root && root.querySelector ? root.querySelector('press-theme-controls') : null;
 }
 
+function resolveThemeControlsContractVersion(options = {}) {
+  let activeContext = null;
+  try { activeContext = getThemeLayoutContext(); } catch (_) {}
+  const candidates = [
+    options.contractVersion,
+    options.themeContext && options.themeContext.theme && options.themeContext.theme.contractVersion,
+    options.themeContext && options.themeContext.manifest && options.themeContext.manifest.contractVersion,
+    options.context && options.context.theme && options.context.theme.contractVersion,
+    options.context && options.context.manifest && options.context.manifest.contractVersion,
+    options.manifest && options.manifest.contractVersion,
+    activeContext && activeContext.theme && activeContext.theme.contractVersion,
+    activeContext && activeContext.manifest && activeContext.manifest.contractVersion,
+    PRESS_THEME_CONTRACT.contractVersion
+  ];
+  for (const candidate of candidates) {
+    const version = Number(candidate);
+    if (Number.isFinite(version) && version > 0) return version;
+  }
+  return PRESS_THEME_CONTRACT.contractVersion;
+}
+
 function getThemeControlLabels() {
   return {
     sectionTitle: t('tools.sectionTitle'),
@@ -486,6 +511,8 @@ function populateThemeControls(component) {
 export function mountThemeControls(options = {}) {
   const opts = options && typeof options === 'object' ? options : {};
   const variant = String(opts.variant || document.body.dataset.themeLayout || 'native').toLowerCase();
+  const contractVersion = resolveThemeControlsContractVersion(opts);
+  const legacyDom = usesLegacyThemeControlsDom(contractVersion);
   const componentImport = ensurePressComponents();
   let component = null;
   const host = opts.host || null;
@@ -502,7 +529,7 @@ export function mountThemeControls(options = {}) {
   } else {
     component = getThemeControlsElement(document);
     if (!component) {
-      const legacyTools = document.getElementById('tools');
+      const legacyTools = legacyDom ? document.getElementById('tools') : null;
       if (legacyTools && legacyTools.parentElement) {
         component = document.createElement('press-theme-controls');
         legacyTools.parentElement.replaceChild(component, legacyTools);
@@ -519,6 +546,7 @@ export function mountThemeControls(options = {}) {
   }
 
   const finish = () => {
+    component.setAttribute('contract-version', String(contractVersion));
     component.setAttribute('variant', variant);
     const upgraded = typeof component.render === 'function' && typeof component.setLabels === 'function';
     if (!upgraded && componentImport) return;

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.120",
-  "tag": "v3.4.120",
+  "version": "3.4.121",
+  "tag": "v3.4.121",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.119 <3.4.120"
+      ">=3.4.120 <3.4.121"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.119 first."
+    "message": "Update to v3.4.120 first."
   }
 }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -23,8 +23,8 @@
     },
     "contractVersion": {
       "type": "integer",
-      "const": 1,
-      "description": "Press theme contract version this manifest targets."
+      "enum": [1, 2],
+      "description": "Press theme contract version this manifest targets. Contract v1 keeps legacy theme-controls DOM bridges; v2 uses the current component contract."
     },
     "engines": {
       "type": "object",

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -1349,7 +1349,7 @@ press-toc.box {
 }
 
 /* Tools (sidebar controls) */
-#tools .tools {
+:is(#tools, press-theme-controls.box) .tools {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   gap: 0.625rem;
@@ -1359,12 +1359,12 @@ press-toc.box {
 }
 
 /* Labeled tool items */
-#tools .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
-#tools .tool-label { font-size: .78rem; color: var(--muted); letter-spacing: .02em; }
+:is(#tools, press-theme-controls.box) .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
+:is(#tools, press-theme-controls.box) .tool-label { font-size: .78rem; color: var(--muted); letter-spacing:.02em; }
 
-#tools .btn,
+:is(#tools, press-theme-controls.box) .btn,
 #themeToggle.btn,
-#tools select {
+:is(#tools, press-theme-controls.box) select {
   width: 100%;
   padding: .5rem .65rem;
   height: 2.25rem;
@@ -1374,20 +1374,20 @@ press-toc.box {
   color: var(--text);
 }
 
-#tools .btn { cursor: pointer; user-select: none; }
+:is(#tools, press-theme-controls.box) .btn { cursor: pointer; user-select: none; }
 
-#tools .btn:hover,
-#tools select:hover {
+:is(#tools, press-theme-controls.box) .btn:hover,
+:is(#tools, press-theme-controls.box) select:hover {
   background: color-mix(in srgb, var(--primary) 10%, transparent);
   border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
 }
 
-#tools .btn:active {
+:is(#tools, press-theme-controls.box) .btn:active {
   transform: translateY(0.03125rem);
 }
 
-#tools .btn:focus-visible,
-#tools select:focus-visible,
+:is(#tools, press-theme-controls.box) .btn:focus-visible,
+:is(#tools, press-theme-controls.box) select:focus-visible,
 #searchbox input[type="search"]:focus-visible {
   outline: 0.125rem solid color-mix(in srgb, var(--primary) 55%, transparent);
   outline-offset: 0.125rem;
@@ -1405,15 +1405,15 @@ press-toc.box {
 .section-title { font-weight:700; font-size:.92rem; color: var(--muted); margin-bottom:0.5rem; letter-spacing:.02em; }
 
 /* Form controls */
-#tools select { appearance: none; background-repeat: no-repeat; background-position: right 0.625rem center; background-size: 0.875rem; padding-right: 1.875rem; }
-#tools select {
+:is(#tools, press-theme-controls.box) select { appearance: none; background-repeat: no-repeat; background-position: right 0.625rem center; background-size: 0.875rem; padding-right: 1.875rem; }
+:is(#tools, press-theme-controls.box) select {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%239CA3AF' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
 }
 
 /* Icon button */
-#tools .icon-btn { display:flex; align-items:center; justify-content:center; gap: 0.5rem; font-weight: 600; }
-#tools .icon-btn .icon { font-size: 1rem; line-height: 1; }
-#tools .icon-btn .btn-text { white-space: nowrap; }
+:is(#tools, press-theme-controls.box) .icon-btn { display:flex; align-items:center; justify-content:center; gap: 0.5rem; font-weight: 600; }
+:is(#tools, press-theme-controls.box) .icon-btn .icon { font-size: 1rem; line-height: 1; }
+:is(#tools, press-theme-controls.box) .icon-btn .btn-text { white-space: nowrap; }
 
 /* A11y helpers */
 .visually-hidden { position:absolute !important; width:0.0625rem; height:0.0625rem; padding:0; margin:-0.0625rem; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
@@ -1532,7 +1532,7 @@ press-toc.box {
   row-gap: 0; /* remove vertical spacing on mobile too */
   }
 
-  #tools .tools {
+  :is(#tools, press-theme-controls.box) .tools {
     grid-template-columns: 1fr; /* Single-column toolbar */
     gap: 0.5rem; /* Reduce spacing */
   }
@@ -1582,7 +1582,7 @@ press-toc.box {
   }
 
   /* Mobile buttons and inputs optimizations */
-  #tools .btn,
+  :is(#tools, press-theme-controls.box) .btn,
   #searchbox input[type="search"] {
     padding: .5rem .6rem; /* Reduce padding */
     height: 2.625rem; /* Touch-friendly height */

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -407,7 +407,7 @@ function setupThemeControlsNative(params = {}) {
   const bindToggle = typeof params.bindThemeToggle === 'function' ? params.bindThemeToggle : bindThemeToggle;
   const bindEditor = typeof params.bindPostEditor === 'function' ? params.bindPostEditor : bindPostEditor;
   const bindPack = typeof params.bindThemePackPicker === 'function' ? params.bindThemePackPicker : bindThemePackPicker;
-  try { mount(); } catch (_) {}
+  try { mount({ contractVersion: params.contractVersion, themeContext: params.themeContext || params.context }); } catch (_) {}
   try { apply(); } catch (_) {}
   try { bindToggle(); } catch (_) {}
   try { bindEditor(); } catch (_) {}
@@ -1424,11 +1424,15 @@ function resetThemeControlsNative(params = {}, documentRef = defaultDocument) {
   const refreshLang = typeof params.refreshLanguageSelector === 'function' ? params.refreshLanguageSelector : (() => {});
   if (documentRef) {
     try {
-      const tools = documentRef.getElementById('tools');
-      if (tools && tools.parentElement) tools.parentElement.removeChild(tools);
+      const controls = documentRef.querySelector('press-theme-controls');
+      if (controls && controls.parentElement) controls.parentElement.removeChild(controls);
+      else {
+        const tools = documentRef.getElementById('tools');
+        if (tools && tools.parentElement) tools.parentElement.removeChild(tools);
+      }
     } catch (_) {}
   }
-  try { mount(); } catch (_) {}
+  try { mount({ contractVersion: params.contractVersion, themeContext: params.themeContext || params.context }); } catch (_) {}
   try { applyTheme(); } catch (_) {}
   try { bindToggle(); } catch (_) {}
   try { bindPack(); } catch (_) {}

--- a/assets/themes/native/theme.json
+++ b/assets/themes/native/theme.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../../schema/theme.json",
   "name": "Native",
-  "version": "3.4.0",
-  "contractVersion": 1,
+  "version": "3.4.1",
+  "contractVersion": 2,
   "engines": {
-    "press": ">=3.4.0 <4.0.0"
+    "press": ">=3.4.121 <4.0.0"
   },
   "styles": [
     "theme.css"

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -2,10 +2,10 @@
   {
     "value": "native",
     "label": "Native",
-    "version": "3.4.0",
-    "contractVersion": 1,
+    "version": "3.4.1",
+    "contractVersion": 2,
     "engines": {
-      "press": ">=3.4.0 <4.0.0"
+      "press": ">=3.4.121 <4.0.0"
     },
     "builtIn": true,
     "removable": false,
@@ -13,7 +13,7 @@
       "type": "builtin"
     },
     "release": {
-      "tag": "v3.4.0"
+      "tag": "v3.4.1"
     },
     "files": [
       "base.css",

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -26,6 +26,7 @@ const SIGNED_URL_QUERY_KEYS = [
   'x-goog-signature'
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([1, 2]);
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,
   downstream: DEFAULT_RELEASE_SOURCES.downstream,
@@ -453,9 +454,9 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
     out.status = 'drift';
     out.problems.push(`theme release slug does not match catalog entry "${slug}"`);
   }
-  if (!out.version || out.contractVersion !== 1) {
+  if (!out.version || !SUPPORTED_THEME_CONTRACT_VERSIONS.has(out.contractVersion)) {
     out.status = 'drift';
-    out.problems.push('theme release must declare version and contractVersion 1');
+    out.problems.push('theme release must declare version and supported contractVersion');
   }
   if (!out.engines.press || !satisfiesSemverRange(pressVersion, out.engines.press)) {
     out.status = 'drift';

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -85,14 +85,14 @@ function pressManifest(version = '3.4.51') {
   };
 }
 
-function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0') {
+function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 1) {
   return {
     schemaVersion: 1,
     type: 'press-theme',
     value: slug,
     label: slug.charAt(0).toUpperCase() + slug.slice(1),
     version,
-    contractVersion: 1,
+    contractVersion,
     engines: {
       press: pressRange
     },
@@ -763,4 +763,31 @@ test('buildProductState marks incompatible theme release manifests as drift', as
   assert.equal(state.themes.entries[0].status, 'drift');
   assert.match(state.themes.entries[0].problems.join('\n'), /engines\.press/);
   assert.equal(shouldFailCheck(state, { allowPending: true, allowUnknown: true }), true);
+});
+
+test('buildProductState accepts supported theme contract versions', async () => {
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 2)
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.themes.entries[0].contractVersion, 2);
+  assert.notEqual(state.themes.entries[0].status, 'drift');
+});
+
+test('buildProductState rejects unsupported theme contract versions', async () => {
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 3)
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themes.entries[0].status, 'drift');
+  assert.match(state.themes.entries[0].problems.join('\n'), /supported contractVersion/);
 });

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -170,8 +170,8 @@ if (PRESS_THEME_CONTRACT.schemaVersion !== 1 || PRESS_THEME_CONTRACT.type !== 'p
 if (PRESS_THEME_CONTRACT.manifestSchemaPath !== 'assets/schema/theme.json') {
   fail('theme contract surface must point at assets/schema/theme.json');
 }
-if ((schema.properties && schema.properties.contractVersion && schema.properties.contractVersion.const) !== PRESS_THEME_CONTRACT.contractVersion) {
-  fail('assets/schema/theme.json contractVersion must match the shared theme contract surface');
+if (JSON.stringify(schema.properties && schema.properties.contractVersion && schema.properties.contractVersion.enum) !== JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions)) {
+  fail('assets/schema/theme.json supported contract versions must match the shared theme contract surface');
 }
 if (JSON.stringify(schema.required || []) !== JSON.stringify(REQUIRED_MANIFEST_FIELDS)) {
   fail('assets/schema/theme.json required fields must match the shared theme contract surface');
@@ -299,8 +299,8 @@ themeNames.forEach((themeName) => {
   }
   if (!manifest.name) fail(`${relManifest} must declare name`);
   if (!manifest.version) fail(`${relManifest} must declare version`);
-  if (manifest.contractVersion !== PRESS_THEME_CONTRACT.contractVersion) {
-    fail(`${relManifest} contractVersion must be ${PRESS_THEME_CONTRACT.contractVersion}`);
+  if (!PRESS_THEME_CONTRACT.supportedContractVersions.includes(manifest.contractVersion)) {
+    fail(`${relManifest} contractVersion must be supported by the shared theme contract surface`);
   }
   if (!manifest.engines || typeof manifest.engines.press !== 'string' || !manifest.engines.press.trim()) {
     fail(`${relManifest} must declare engines.press`);

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -680,7 +680,8 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
   });
   assert.equal(manifest.value, 'arcus');
   assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
-  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }), /contractVersion/i);
+  assert.equal(normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }).contractVersion, 2);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 3 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, engines: {} }), /engines\.press/i);
 });
 
@@ -722,7 +723,7 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
     /theme\.json|single|root/i
   );
   assert.throws(
-    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 2 })),
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })),
     /contractVersion/i
   );
 });
@@ -1184,7 +1185,7 @@ await run('failed replacement staging keeps uninstall fallback active', async ()
   assert.equal(themePack, 'native');
   assert(getThemeManagerCommitFiles().some((file) => file.path === 'assets/themes/test/theme.json' && file.deleted));
   await assert.rejects(
-    () => analyzeThemeArchive(makeThemeZip({ slug: 'replacement', contractVersion: 2 }), 'press-theme-replacement-v1.0.0.zip'),
+    () => analyzeThemeArchive(makeThemeZip({ slug: 'replacement', contractVersion: 3 }), 'press-theme-replacement-v1.0.0.zip'),
     /contractVersion/i
   );
   assert.equal(themePack, 'native');
@@ -1212,7 +1213,7 @@ await run('failed import keeps existing uninstall staging active', async () => {
   try {
     await handleImportFile({
       name: 'press-theme-bad-v1.0.0.zip',
-      arrayBuffer: async () => makeThemeZip({ slug: 'bad', contractVersion: 2 })
+      arrayBuffer: async () => makeThemeZip({ slug: 'bad', contractVersion: 3 })
     });
   } finally {
     console.error = originalError;

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -39,6 +39,24 @@ class TestElement {
     return child;
   }
 
+  insertBefore(child, ref) {
+    if (!child) return child;
+    const index = this.children.indexOf(ref);
+    if (index < 0) return this.appendChild(child);
+    child.parentElement = this;
+    this.children.splice(index, 0, child);
+    return child;
+  }
+
+  replaceChild(child, oldChild) {
+    const index = this.children.indexOf(oldChild);
+    if (index < 0) return this.appendChild(child);
+    if (child) child.parentElement = this;
+    if (oldChild) oldChild.parentElement = null;
+    this.children[index] = child;
+    return oldChild;
+  }
+
   remove() {
     if (!this.parentElement) return;
     const siblings = this.parentElement.children;
@@ -46,6 +64,10 @@ class TestElement {
     if (index >= 0) siblings.splice(index, 1);
     this.parentElement = null;
   }
+
+  addEventListener() {}
+
+  removeEventListener() {}
 
   setAttribute(name, value) {
     const key = String(name);
@@ -167,6 +189,8 @@ function installGlobals({ savedPack = 'native', manifests = {} } = {}) {
     location: { href: 'https://example.test/', search: '' },
     localStorage,
     matchMedia: () => ({ matches: false }),
+    addEventListener() {},
+    removeEventListener() {},
     __press_themeDevMode: false
   };
   globalThis.requestAnimationFrame = (fn) => setTimeout(fn, 0);
@@ -261,6 +285,81 @@ await run('theme pack controllers isolate suppressed state', async () => {
   assert.equal(first.isSuppressed('cartograph'), true);
   assert.equal(second.isSuppressed('cartograph'), false);
   assert.equal(isThemePackSuppressed('cartograph'), false);
+});
+
+await run('theme controls infer legacy DOM bridge from the active theme context', async () => {
+  const { setThemeLayoutContext } = await import('../assets/js/theme-regions.js');
+  const { mountThemeControls } = await freshThemeHelpers();
+  try {
+    let installed = installGlobals({ savedPack: 'arcus' });
+    let sidebar = installed.document.createElement('aside');
+    sidebar.setAttribute('class', 'sidebar');
+    let legacyTools = installed.document.createElement('div');
+    legacyTools.setAttribute('id', 'tools');
+    sidebar.appendChild(legacyTools);
+    installed.document.body.appendChild(sidebar);
+    setThemeLayoutContext({
+      manifest: { contractVersion: 1 },
+      theme: { contractVersion: 1 },
+      regions: {}
+    });
+
+    const legacyComponent = mountThemeControls({ variant: 'arcus' });
+    assert.equal(legacyComponent && legacyComponent.tagName, 'PRESS-THEME-CONTROLS');
+    assert.equal(legacyComponent.getAttribute('contract-version'), '1');
+    assert.equal(legacyTools.parentElement, null);
+    assert.equal(sidebar.children[0], legacyComponent);
+
+    installed = installGlobals({ savedPack: 'arcus' });
+    sidebar = installed.document.createElement('aside');
+    sidebar.setAttribute('class', 'sidebar');
+    legacyTools = installed.document.createElement('div');
+    legacyTools.setAttribute('id', 'tools');
+    sidebar.appendChild(legacyTools);
+    installed.document.body.appendChild(sidebar);
+    setThemeLayoutContext({
+      manifest: { contractVersion: 2 },
+      theme: { contractVersion: 2 },
+      regions: {}
+    });
+
+    const currentComponent = mountThemeControls({ variant: 'arcus' });
+    assert.equal(currentComponent && currentComponent.tagName, 'PRESS-THEME-CONTROLS');
+    assert.equal(currentComponent.getAttribute('contract-version'), '2');
+    assert.equal(legacyTools.parentElement, sidebar);
+    assert.notEqual(sidebar.children[0], currentComponent);
+  } finally {
+    setThemeLayoutContext(null);
+  }
+});
+
+await run('theme controls infer legacy DOM bridge during v1 theme module mount', async () => {
+  let mountedComponent = null;
+  let legacyTools = null;
+  const { mountThemeControls } = await freshThemeHelpers();
+  const { document } = installGlobals({
+    savedPack: 'legacy',
+    manifests: {
+      legacy: makeManifest('legacy', ['modules/layout.js'])
+    }
+  });
+  window.__pressThemeModuleLoader = async () => ({
+    mount() {
+      const sidebar = document.createElement('aside');
+      sidebar.setAttribute('class', 'sidebar');
+      legacyTools = document.createElement('div');
+      legacyTools.setAttribute('id', 'tools');
+      sidebar.appendChild(legacyTools);
+      document.body.appendChild(sidebar);
+      mountedComponent = mountThemeControls({ variant: 'arcus' });
+    }
+  });
+
+  const { ensureThemeLayout } = await freshThemeLayout();
+  await ensureThemeLayout({ pack: 'legacy', persist: false, reset: true });
+  assert.equal(mountedComponent && mountedComponent.tagName, 'PRESS-THEME-CONTROLS');
+  assert.equal(mountedComponent.getAttribute('contract-version'), '1');
+  assert.equal(legacyTools.parentElement, null);
 });
 
 await run('theme modules load in parallel and mount in manifest order', async () => {

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -60,7 +60,9 @@ const nativeCss = read('assets/themes/native/base.css');
 const languageManifest = read('assets/i18n/languages.json');
 const i18nEn = read('assets/i18n/en.js');
 
-assert.match(components, /arcus-tools__groups[\s\S]*arcus-tool[\s\S]*solstice-tools[\s\S]*solstice-tool/, 'theme controls should preserve legacy Arcus and Solstice control classes for already-installed themes');
+assert.match(components, /observedAttributes[\s\S]*'variant'[\s\S]*'contract-version'[\s\S]*_usesLegacyDom\(\)[\s\S]*this\._contractVersion\(\) <= 1/, 'theme controls should re-render when the theme contract changes and gate legacy DOM on contract v1');
+assert.match(components, /legacyDom && variant === 'arcus'[\s\S]*arcus-tools__groups[\s\S]*legacyDom && variant === 'solstice'[\s\S]*solstice-tools/, 'theme controls should preserve legacy Arcus and Solstice host classes only for contract v1 themes');
+assert.match(components, /arcus-tool[\s\S]*solstice-tool/, 'theme controls should preserve variant-specific control markup classes for shipped theme styling');
 assert.doesNotMatch(components, /\bcartograph\b/i, 'core UI components should not hard-code non-legacy external theme variants');
 
 function sliceBetween(source, startNeedle, endNeedle) {
@@ -270,6 +272,7 @@ assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own th
 assert.match(read('assets/js/tags.js'), /press:tag-select/, 'tag sidebar should emit press:tag-select');
 
 assert.match(theme, /mountThemeControls\(options = \{\}\)[\s\S]*document\.createElement\('press-theme-controls'\)/, 'core theme controls should mount press-theme-controls');
+assert.match(theme, /resolveThemeControlsContractVersion\(opts\)[\s\S]*usesLegacyThemeControlsDom\(contractVersion\)[\s\S]*legacyDom \? document\.getElementById\('tools'\) : null[\s\S]*component\.setAttribute\('contract-version', String\(contractVersion\)\)/, 'theme controls should scope #tools replacement and component legacy DOM to the active theme contract version');
 assert.match(theme, /component\.addEventListener\('press:theme-toggle'[\s\S]*component\.addEventListener\('press:language-reset'/, 'theme control side effects should be event-driven');
 assert.doesNotMatch(theme, /import ['"]\.\/components\.js['"]/, 'theme helpers should not top-level import browser-only custom elements');
 assert.doesNotMatch(theme, /^let\s+componentsReady\b/m, 'theme controls should not keep component import state in a module-level promise');
@@ -282,6 +285,7 @@ assert.doesNotMatch(nativeSearch, /setAttribute\('icon'/, 'native search should 
 
 assert.match(nativeToc, /createElement\('press-toc'\)/, 'native TOC module should mount press-toc');
 assert.match(toc, /typeof tocRoot\.enhance === 'function'/, 'legacy setupTOC should delegate to press-toc when present');
+assert.match(nativeCss, /:is\(#tools, press-theme-controls\.box\) \.tools[\s\S]*:is\(#tools, press-theme-controls\.box\) \.btn/, 'native theme CSS should style both legacy #tools and v2 press-theme-controls hosts');
 
 assert.match(nativeInteractions, /renderPressPostCardHtml\(/, 'native cards should render through press-post-card');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/theme\.js'/, 'native interactions should cache-bust theme helper imports');

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -31,7 +31,7 @@ remote repository at runtime; a selected theme must exist locally under
 The shared machine-readable contract surface lives in
 `assets/js/theme-contract-surface.mjs`. Theme Manager, runtime development
 warnings, contract tests, and the JSON schema are expected to agree with that
-surface for the current `contractVersion`, required views, regions, components,
+surface for the current `contractVersion`, supported legacy contract versions, required views, regions, components,
 content shapes, and archive file-type rules.
 
 ## Manifest
@@ -40,9 +40,9 @@ content shapes, and archive file-type rules.
 {
   "$schema": "../../schema/theme.json",
   "name": "Native",
-  "version": "3.4.0",
-  "contractVersion": 1,
-  "engines": { "press": ">=3.4.0 <4.0.0" },
+  "version": "3.4.1",
+  "contractVersion": 2,
+  "engines": { "press": ">=3.4.121 <4.0.0" },
   "styles": ["theme.css"],
   "modules": ["modules/layout.js", "modules/interactions.js", "modules/views.js"],
   "views": {
@@ -72,7 +72,10 @@ content shapes, and archive file-type rules.
 
 - `name` and `version`: Human-facing theme identity.
 - `contractVersion`: Press runtime contract version. The current value is
-  `1`.
+  `2`. Press still accepts `1` for existing themes; contract v1 keeps the
+  legacy theme-controls DOM bridge (`#tools` and older shipped-theme host
+  classes), while contract v2 uses the current `<press-theme-controls>`
+  component contract.
 - `engines.press`: Press system SemVer range the theme supports. Theme Manager
   rejects official and manually imported themes outside the current Press
   version.
@@ -102,8 +105,8 @@ changes to it through Publish, and Press system updates do not overwrite it.
   "value": "arcus",
   "label": "Arcus",
   "version": "3.4.0",
-  "contractVersion": 1,
-  "engines": { "press": ">=3.4.0 <4.0.0" },
+  "contractVersion": 2,
+  "engines": { "press": ">=3.4.121 <4.0.0" },
   "builtIn": false,
   "removable": true,
   "source": {
@@ -142,8 +145,8 @@ Official theme repositories publish a root `theme-release.json`:
   "value": "arcus",
   "label": "Arcus",
   "version": "3.4.0",
-  "contractVersion": 1,
-  "engines": { "press": ">=3.4.0 <4.0.0" },
+  "contractVersion": 2,
+  "engines": { "press": ">=3.4.121 <4.0.0" },
   "release": {
     "tag": "v3.4.0",
     "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.0",


### PR DESCRIPTION
## Summary
- bump the Press theme contract surface to v2 while keeping v1 as a supported migration contract
- gate the legacy `#tools` / Arcus / Solstice theme-controls DOM bridge behind contract v1
- update Native to contract v2 and Press v3.4.121 with `upgradeFrom` limited to v3.4.120
- teach theme validation, Theme Manager, Product State, docs, and regression tests about supported contract versions

## Verification
- `node scripts/test-theme-runtime.js`
- `node scripts/test-ui-components.js`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node scripts/test-product-state-ledger.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `git diff --check`
- `node scripts/test-press-version-runtime.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node scripts/test-release-intent.js`
- `node scripts/test-release-targets.js`
- `node scripts/test-press-system-surface.mjs`
- `node scripts/test-product-state-dashboard.js`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-pages-artifact.sh`
- `bash scripts/test-pages-workflow.sh`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- Browser smoke: `http://127.0.0.1:8013/` rendered Native theme controls as contract v2 without `#tools`; `index_editor.html` loaded editor shell with no warning/error logs.

## Release impact
- Press system release: yes, v3.4.121.
- Upgrade path: requires v3.4.120 as the source release.
- Theme contract: current contract becomes v2; v1 remains supported only for the legacy theme-controls DOM bridge.
- Downstream sync: YAP, Theme Starter, and official theme demo sync should process the Press system release through release intent.
