### PR TITLE
[codex] Remove legacy theme controls bridge

### DIFF
--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -270,7 +270,7 @@ export class PressSearch extends HTMLElement {
 
 export class PressThemeControls extends HTMLElement {
   static get observedAttributes() {
-    return ['variant', 'contract-version'];
+    return ['variant'];
   }
 
   constructor() {
@@ -343,38 +343,15 @@ export class PressThemeControls extends HTMLElement {
     return raw.replace(/[^a-z0-9_-]/g, '') || 'native';
   }
 
-  _contractVersion() {
-    const version = Number(this.getAttribute('contract-version') || 2);
-    return Number.isFinite(version) ? version : 2;
-  }
-
-  _usesLegacyDom() {
-    return this._contractVersion() <= 1;
-  }
-
   _syncHostClass() {
     const variant = this._variant();
-    const legacyDom = this._usesLegacyDom();
-    if (legacyDom && !this.id) {
-      this.id = 'tools';
-      this.dataset.pressThemeControlsLegacyId = '1';
-    } else if (!legacyDom && this.id === 'tools' && this.dataset.pressThemeControlsLegacyId === '1') {
-      this.removeAttribute('id');
-      delete this.dataset.pressThemeControlsLegacyId;
-    }
     Array.from(this.classList || []).forEach((className) => {
       if (String(className || '').startsWith('press-theme-controls--')) {
         this.classList.remove(className);
       }
     });
-    this.classList.remove('box', 'arcus-tools__groups', 'solstice-tools');
-    if (legacyDom && variant === 'arcus') {
-      this.classList.add('arcus-tools__groups', `press-theme-controls--${variant}`);
-    } else if (legacyDom && variant === 'solstice') {
-      this.classList.add('solstice-tools', `press-theme-controls--${variant}`);
-    } else {
-      this.classList.add('box', `press-theme-controls--${variant}`);
-    }
+    this.classList.remove('box');
+    this.classList.add('box', `press-theme-controls--${variant}`);
   }
 
   _markup() {

--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -14,8 +14,7 @@ const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
 ]);
 const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
 const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([1, 2]);
-const LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX = 1;
+const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([2]);
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
   '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
   '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'
@@ -27,7 +26,6 @@ export const PRESS_THEME_CONTRACT = Object.freeze({
   type: 'press-theme-contract',
   contractVersion: 2,
   supportedContractVersions: SUPPORTED_THEME_CONTRACT_VERSIONS,
-  legacyThemeControlsDomContractMax: LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX,
   manifestSchemaPath: 'assets/schema/theme.json',
   manifest: Object.freeze({
     requiredFields: REQUIRED_THEME_MANIFEST_FIELDS,
@@ -90,10 +88,4 @@ export function getThemeTextExtensions() {
 
 export function isPressThemeContractVersionSupported(value) {
   return SUPPORTED_THEME_CONTRACT_VERSIONS.includes(Number(value));
-}
-
-export function usesLegacyThemeControlsDom(value) {
-  const version = Number(value);
-  if (!Number.isFinite(version)) return false;
-  return version >= 1 && version <= LEGACY_THEME_CONTROLS_DOM_CONTRACT_MAX;
 }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,9 +1,5 @@
 import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js';
-import {
-  PRESS_THEME_CONTRACT,
-  usesLegacyThemeControlsDom
-} from './theme-contract-surface.mjs';
-import { getThemeLayoutContext, getThemeRegion } from './theme-regions.js';
+import { getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';
 const THEME_CONTROLS_BOUND = Symbol('pressThemeControlsBound');
@@ -335,27 +331,6 @@ function getThemeControlsElement(root = document) {
   return root && root.querySelector ? root.querySelector('press-theme-controls') : null;
 }
 
-function resolveThemeControlsContractVersion(options = {}) {
-  let activeContext = null;
-  try { activeContext = getThemeLayoutContext(); } catch (_) {}
-  const candidates = [
-    options.contractVersion,
-    options.themeContext && options.themeContext.theme && options.themeContext.theme.contractVersion,
-    options.themeContext && options.themeContext.manifest && options.themeContext.manifest.contractVersion,
-    options.context && options.context.theme && options.context.theme.contractVersion,
-    options.context && options.context.manifest && options.context.manifest.contractVersion,
-    options.manifest && options.manifest.contractVersion,
-    activeContext && activeContext.theme && activeContext.theme.contractVersion,
-    activeContext && activeContext.manifest && activeContext.manifest.contractVersion,
-    PRESS_THEME_CONTRACT.contractVersion
-  ];
-  for (const candidate of candidates) {
-    const version = Number(candidate);
-    if (Number.isFinite(version) && version > 0) return version;
-  }
-  return PRESS_THEME_CONTRACT.contractVersion;
-}
-
 function getThemeControlLabels() {
   return {
     sectionTitle: t('tools.sectionTitle'),
@@ -505,14 +480,12 @@ function populateThemeControls(component) {
   }
 }
 
-// Render theme tools UI through <press-theme-controls>. Options are sourced from
-// assets/themes/packs.json; legacy button/select binders remain below for older
-// custom themes that have not migrated yet.
+// Render theme tools UI through the current <press-theme-controls> contract.
+// Options are sourced from assets/themes/packs.json; legacy button/select
+// binders remain below for custom themes that still render their own controls.
 export function mountThemeControls(options = {}) {
   const opts = options && typeof options === 'object' ? options : {};
   const variant = String(opts.variant || document.body.dataset.themeLayout || 'native').toLowerCase();
-  const contractVersion = resolveThemeControlsContractVersion(opts);
-  const legacyDom = usesLegacyThemeControlsDom(contractVersion);
   const componentImport = ensurePressComponents();
   let component = null;
   const host = opts.host || null;
@@ -529,13 +502,6 @@ export function mountThemeControls(options = {}) {
   } else {
     component = getThemeControlsElement(document);
     if (!component) {
-      const legacyTools = legacyDom ? document.getElementById('tools') : null;
-      if (legacyTools && legacyTools.parentElement) {
-        component = document.createElement('press-theme-controls');
-        legacyTools.parentElement.replaceChild(component, legacyTools);
-      }
-    }
-    if (!component) {
       const sidebar = document.querySelector('.sidebar');
       if (!sidebar) return null;
       component = document.createElement('press-theme-controls');
@@ -546,7 +512,6 @@ export function mountThemeControls(options = {}) {
   }
 
   const finish = () => {
-    component.setAttribute('contract-version', String(contractVersion));
     component.setAttribute('variant', variant);
     const upgraded = typeof component.render === 'function' && typeof component.setLabels === 'function';
     if (!upgraded && componentImport) return;

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,13 +1,17 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.122",
-  "tag": "v3.4.122",
+  "version": "3.4.123",
+  "tag": "v3.4.123",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.121 <3.4.122"
+      ">=3.4.122 <3.4.123"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.121 first."
+    "message": "Update to v3.4.122 first."
+  },
+  "themeContractUpgrade": {
+    "requiresInstalledThemeContractVersion": 2,
+    "message": "Update installed themes to contract v2 before installing v3.4.123."
   }
 }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -23,8 +23,8 @@
     },
     "contractVersion": {
       "type": "integer",
-      "enum": [1, 2],
-      "description": "Press theme contract version this manifest targets. Contract v1 keeps legacy theme-controls DOM bridges; v2 uses the current component contract."
+      "enum": [2],
+      "description": "Press theme contract version this manifest targets. Contract v2 is the current component contract."
     },
     "engines": {
       "type": "object",

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -1349,7 +1349,7 @@ press-toc.box {
 }
 
 /* Tools (sidebar controls) */
-:is(#tools, press-theme-controls.box) .tools {
+press-theme-controls.box .tools {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   gap: 0.625rem;
@@ -1359,12 +1359,12 @@ press-toc.box {
 }
 
 /* Labeled tool items */
-:is(#tools, press-theme-controls.box) .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
-:is(#tools, press-theme-controls.box) .tool-label { font-size: .78rem; color: var(--muted); letter-spacing:.02em; }
+press-theme-controls.box .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
+press-theme-controls.box .tool-label { font-size: .78rem; color: var(--muted); letter-spacing:.02em; }
 
-:is(#tools, press-theme-controls.box) .btn,
+press-theme-controls.box .btn,
 #themeToggle.btn,
-:is(#tools, press-theme-controls.box) select {
+press-theme-controls.box select {
   width: 100%;
   padding: .5rem .65rem;
   height: 2.25rem;
@@ -1374,20 +1374,20 @@ press-toc.box {
   color: var(--text);
 }
 
-:is(#tools, press-theme-controls.box) .btn { cursor: pointer; user-select: none; }
+press-theme-controls.box .btn { cursor: pointer; user-select: none; }
 
-:is(#tools, press-theme-controls.box) .btn:hover,
-:is(#tools, press-theme-controls.box) select:hover {
+press-theme-controls.box .btn:hover,
+press-theme-controls.box select:hover {
   background: color-mix(in srgb, var(--primary) 10%, transparent);
   border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
 }
 
-:is(#tools, press-theme-controls.box) .btn:active {
+press-theme-controls.box .btn:active {
   transform: translateY(0.03125rem);
 }
 
-:is(#tools, press-theme-controls.box) .btn:focus-visible,
-:is(#tools, press-theme-controls.box) select:focus-visible,
+press-theme-controls.box .btn:focus-visible,
+press-theme-controls.box select:focus-visible,
 #searchbox input[type="search"]:focus-visible {
   outline: 0.125rem solid color-mix(in srgb, var(--primary) 55%, transparent);
   outline-offset: 0.125rem;
@@ -1405,15 +1405,15 @@ press-toc.box {
 .section-title { font-weight:700; font-size:.92rem; color: var(--muted); margin-bottom:0.5rem; letter-spacing:.02em; }
 
 /* Form controls */
-:is(#tools, press-theme-controls.box) select { appearance: none; background-repeat: no-repeat; background-position: right 0.625rem center; background-size: 0.875rem; padding-right: 1.875rem; }
-:is(#tools, press-theme-controls.box) select {
+press-theme-controls.box select { appearance: none; background-repeat: no-repeat; background-position: right 0.625rem center; background-size: 0.875rem; padding-right: 1.875rem; }
+press-theme-controls.box select {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%239CA3AF' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
 }
 
 /* Icon button */
-:is(#tools, press-theme-controls.box) .icon-btn { display:flex; align-items:center; justify-content:center; gap: 0.5rem; font-weight: 600; }
-:is(#tools, press-theme-controls.box) .icon-btn .icon { font-size: 1rem; line-height: 1; }
-:is(#tools, press-theme-controls.box) .icon-btn .btn-text { white-space: nowrap; }
+press-theme-controls.box .icon-btn { display:flex; align-items:center; justify-content:center; gap: 0.5rem; font-weight: 600; }
+press-theme-controls.box .icon-btn .icon { font-size: 1rem; line-height: 1; }
+press-theme-controls.box .icon-btn .btn-text { white-space: nowrap; }
 
 /* A11y helpers */
 .visually-hidden { position:absolute !important; width:0.0625rem; height:0.0625rem; padding:0; margin:-0.0625rem; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
@@ -1532,7 +1532,7 @@ press-toc.box {
   row-gap: 0; /* remove vertical spacing on mobile too */
   }
 
-  :is(#tools, press-theme-controls.box) .tools {
+  press-theme-controls.box .tools {
     grid-template-columns: 1fr; /* Single-column toolbar */
     gap: 0.5rem; /* Reduce spacing */
   }
@@ -1582,7 +1582,7 @@ press-toc.box {
   }
 
   /* Mobile buttons and inputs optimizations */
-  :is(#tools, press-theme-controls.box) .btn,
+  press-theme-controls.box .btn,
   #searchbox input[type="search"] {
     padding: .5rem .6rem; /* Reduce padding */
     height: 2.625rem; /* Touch-friendly height */

--- a/assets/themes/native/theme.json
+++ b/assets/themes/native/theme.json
@@ -4,7 +4,7 @@
   "version": "3.4.1",
   "contractVersion": 2,
   "engines": {
-    "press": ">=3.4.122 <4.0.0"
+    "press": ">=3.4.123 <4.0.0"
   },
   "styles": [
     "theme.css"

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -5,7 +5,7 @@
     "version": "3.4.1",
     "contractVersion": 2,
     "engines": {
-      "press": ">=3.4.122 <4.0.0"
+      "press": ">=3.4.123 <4.0.0"
     },
     "builtIn": true,
     "removable": false,

--- a/scripts/link-local-themes.sh
+++ b/scripts/link-local-themes.sh
@@ -47,7 +47,7 @@ const entries = themes.map((slug) => {
     value: slug,
     label: manifest.name || slug,
     version: manifest.version || 'local',
-    contractVersion: manifest.contractVersion || 1,
+    contractVersion: manifest.contractVersion || 2,
     source: {
       type: 'local-dev',
       symlink: `../../Press-Theme-${manifest.name || slug}/theme`

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -26,7 +26,7 @@ const SIGNED_URL_QUERY_KEYS = [
   'x-goog-signature'
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([1, 2]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([2]);
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,
   downstream: DEFAULT_RELEASE_SOURCES.downstream,

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -85,7 +85,7 @@ function pressManifest(version = '3.4.51') {
   };
 }
 
-function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 1) {
+function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 2) {
   return {
     schemaVersion: 1,
     type: 'press-theme',
@@ -799,11 +799,11 @@ test('buildProductState accepts supported theme contract versions', async () => 
   assert.notEqual(state.themes.entries[0].status, 'drift');
 });
 
-test('buildProductState rejects unsupported theme contract versions', async () => {
+test('buildProductState rejects legacy theme contract versions', async () => {
   const state = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
-      'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 3)
+      'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 1)
     })),
     generatedAt: '2026-05-25T00:00:00Z'
   });

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -73,7 +73,7 @@ async function sha256(buffer) {
 function makeThemeManifest({
   name = 'Test',
   version = '1.0.0',
-  contractVersion = 1,
+  contractVersion = 2,
   engines = { press: '>=3.4.0 <4.0.0' },
   styles = ['theme.css'],
   modules = ['modules/layout.js'],
@@ -110,7 +110,7 @@ function makeThemeManifest({
   };
 }
 
-function makeThemeZip({ slug = 'test', name = 'Test', version = '1.0.0', contractVersion = 1, files = {} } = {}) {
+function makeThemeZip({ slug = 'test', name = 'Test', version = '1.0.0', contractVersion = 2, files = {} } = {}) {
   const manifest = makeThemeManifest({ name, version, contractVersion });
   return makeZip({
     [`press-theme-${slug}/theme.json`]: JSON.stringify(manifest, null, 2),
@@ -699,7 +699,7 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
     value: 'arcus',
     label: 'Arcus',
     version: '1.2.3',
-    contractVersion: 1,
+    contractVersion: 2,
     engines: { press: '>=3.4.0 <4.0.0' },
     release: { tag: 'v1.2.3' },
     asset: {
@@ -712,7 +712,8 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
   });
   assert.equal(manifest.value, 'arcus');
   assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
-  assert.equal(normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }).contractVersion, 2);
+  assert.equal(manifest.contractVersion, 2);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 1 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 3 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, engines: {} }), /engines\.press/i);
 });
@@ -724,21 +725,21 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      '../theme.json': '{"name":"Test","version":"1.0.0","contractVersion":1}',
+      '../theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
       '../theme.css': 'body{}'
     })),
     /unsafe/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      './theme.json': '{"name":"Test","version":"1.0.0","contractVersion":1}',
+      './theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
       './theme.css': 'body{}'
     })),
     /unsafe/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      'press-theme-test/theme.json': '{"name":"Test","version":"1.0.0","contractVersion":1}',
+      'press-theme-test/theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
       'press-theme-test/modules//layout.js': 'export {};'
     })),
     /unsafe/i
@@ -749,10 +750,14 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      'arcus/theme.json': '{"name":"Arcus","contractVersion":1}',
-      'solstice/theme.json': '{"name":"Solstice","contractVersion":1}'
+      'arcus/theme.json': '{"name":"Arcus","contractVersion":2}',
+      'solstice/theme.json': '{"name":"Solstice","contractVersion":2}'
     })),
     /theme\.json|single|root/i
+  );
+  assert.throws(
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 1 })),
+    /contractVersion/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })),
@@ -767,7 +772,7 @@ await run('rejects invalid theme manifests before staging', async () => {
       'press-theme-bad/theme.json': JSON.stringify({
         name: 'Bad',
         version: '1.0.0',
-        contractVersion: 1,
+        contractVersion: 2,
         styles: ['theme.css']
       }, null, 2),
       'press-theme-bad/theme.css': ':root{}'
@@ -844,7 +849,7 @@ await run('blocks official theme releases outside the current Press engine range
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 1,
+        contractVersion: 2,
         engines: { press: '>=4.0.0 <5.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
@@ -993,7 +998,7 @@ await run('staged inactive theme update preserves the current site theme', async
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'cartograph', label: 'Cartograph', version: '1.0.0', contractVersion: 1, files: ['theme.json', 'theme.css', 'modules/layout.js'] }
+    { value: 'cartograph', label: 'Cartograph', version: '1.0.0', contractVersion: 2, files: ['theme.json', 'theme.css', 'modules/layout.js'] }
   ], {
     textFiles: themeTextFiles('cartograph', ['theme.json', 'theme.css', 'modules/layout.js'])
   });
@@ -1024,7 +1029,7 @@ await run('refuses to stage theme writes when registry cannot be loaded', async 
 await run('stages removed old files during theme update', async () => {
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '0.9.0', contractVersion: 1, files: ['theme.json', 'theme.css', 'modules/old.js'] }
+    { value: 'test', label: 'Test', version: '0.9.0', contractVersion: 2, files: ['theme.json', 'theme.css', 'modules/old.js'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css', 'modules/old.js'])
   });
@@ -1042,7 +1047,7 @@ await run('infers old registry file inventory during theme update', async () => 
       'assets/themes/legacy/theme.json': JSON.stringify({
         name: 'Legacy',
         version: '0.9.0',
-        contractVersion: 1,
+        contractVersion: 2,
         modules: ['modules/old.js']
       }),
       'assets/themes/legacy/modules/old.js': 'export {};'
@@ -1071,7 +1076,7 @@ await run('stages uninstall deletions and falls back current default to native',
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });
@@ -1095,7 +1100,7 @@ await run('infers old registry file inventory during uninstall', async () => {
       'assets/themes/legacy/theme.json': JSON.stringify({
         name: 'Legacy',
         version: '0.9.0',
-        contractVersion: 1,
+        contractVersion: 2,
         modules: ['modules/layout.js']
       }),
       'assets/themes/legacy/theme.css': 'body{}',
@@ -1157,7 +1162,7 @@ await run('filters catalog-inferred inventory to existing files during uninstall
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 1,
+        contractVersion: 2,
         engines: { press: '>=3.4.0 <4.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
@@ -1190,7 +1195,7 @@ await run('clearing uninstall staging restores the previous default theme', asyn
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });
@@ -1209,7 +1214,7 @@ await run('failed replacement staging keeps uninstall fallback active', async ()
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });
@@ -1233,7 +1238,7 @@ await run('failed import keeps existing uninstall staging active', async () => {
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });
@@ -1264,7 +1269,7 @@ await run('successful replacement staging clears uninstall fallback', async () =
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });
@@ -1285,7 +1290,7 @@ await run('post-commit theme cleanup keeps the published fallback default', asyn
   });
   mockFetchRegistry([
     { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 1, removable: true, files: ['theme.json', 'theme.css'] }
+    { value: 'test', label: 'Test', version: '1.0.0', contractVersion: 2, removable: true, files: ['theme.json', 'theme.css'] }
   ], {
     textFiles: themeTextFiles('test', ['theme.json', 'theme.css'])
   });

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -170,7 +170,7 @@ function makeManifest(pack, modules) {
   return {
     name: pack,
     version: '1.0.0',
-    contractVersion: 1,
+    contractVersion: 2,
     styles: ['theme.css', 'extra.css'],
     modules,
     views: { post: {}, posts: {}, search: {}, tab: {} },
@@ -287,14 +287,14 @@ await run('theme pack controllers isolate suppressed state', async () => {
   assert.equal(isThemePackSuppressed('cartograph'), false);
 });
 
-await run('theme controls infer legacy DOM bridge from the active theme context', async () => {
+await run('theme controls ignore retired legacy DOM bridge hints from the active theme context', async () => {
   const { setThemeLayoutContext } = await import('../assets/js/theme-regions.js');
   const { mountThemeControls } = await freshThemeHelpers();
   try {
-    let installed = installGlobals({ savedPack: 'arcus' });
-    let sidebar = installed.document.createElement('aside');
+    const installed = installGlobals({ savedPack: 'arcus' });
+    const sidebar = installed.document.createElement('aside');
     sidebar.setAttribute('class', 'sidebar');
-    let legacyTools = installed.document.createElement('div');
+    const legacyTools = installed.document.createElement('div');
     legacyTools.setAttribute('id', 'tools');
     sidebar.appendChild(legacyTools);
     installed.document.body.appendChild(sidebar);
@@ -306,41 +306,23 @@ await run('theme controls infer legacy DOM bridge from the active theme context'
 
     const legacyComponent = mountThemeControls({ variant: 'arcus' });
     assert.equal(legacyComponent && legacyComponent.tagName, 'PRESS-THEME-CONTROLS');
-    assert.equal(legacyComponent.getAttribute('contract-version'), '1');
-    assert.equal(legacyTools.parentElement, null);
-    assert.equal(sidebar.children[0], legacyComponent);
-
-    installed = installGlobals({ savedPack: 'arcus' });
-    sidebar = installed.document.createElement('aside');
-    sidebar.setAttribute('class', 'sidebar');
-    legacyTools = installed.document.createElement('div');
-    legacyTools.setAttribute('id', 'tools');
-    sidebar.appendChild(legacyTools);
-    installed.document.body.appendChild(sidebar);
-    setThemeLayoutContext({
-      manifest: { contractVersion: 2 },
-      theme: { contractVersion: 2 },
-      regions: {}
-    });
-
-    const currentComponent = mountThemeControls({ variant: 'arcus' });
-    assert.equal(currentComponent && currentComponent.tagName, 'PRESS-THEME-CONTROLS');
-    assert.equal(currentComponent.getAttribute('contract-version'), '2');
+    assert.equal(legacyComponent.getAttribute('contract-version'), null);
     assert.equal(legacyTools.parentElement, sidebar);
-    assert.notEqual(sidebar.children[0], currentComponent);
+    assert.equal(sidebar.children[0], legacyTools);
+    assert.equal(sidebar.children[1], legacyComponent);
   } finally {
     setThemeLayoutContext(null);
   }
 });
 
-await run('theme controls infer legacy DOM bridge during v1 theme module mount', async () => {
+await run('theme controls keep current component contract during legacy theme module mount', async () => {
   let mountedComponent = null;
   let legacyTools = null;
   const { mountThemeControls } = await freshThemeHelpers();
   const { document } = installGlobals({
     savedPack: 'legacy',
     manifests: {
-      legacy: makeManifest('legacy', ['modules/layout.js'])
+      legacy: { ...makeManifest('legacy', ['modules/layout.js']), contractVersion: 1 }
     }
   });
   window.__pressThemeModuleLoader = async () => ({
@@ -358,8 +340,9 @@ await run('theme controls infer legacy DOM bridge during v1 theme module mount',
   const { ensureThemeLayout } = await freshThemeLayout();
   await ensureThemeLayout({ pack: 'legacy', persist: false, reset: true });
   assert.equal(mountedComponent && mountedComponent.tagName, 'PRESS-THEME-CONTROLS');
-  assert.equal(mountedComponent.getAttribute('contract-version'), '1');
-  assert.equal(legacyTools.parentElement, null);
+  assert.equal(mountedComponent.getAttribute('contract-version'), null);
+  assert.equal(legacyTools.parentElement && legacyTools.parentElement.matches('.sidebar'), true);
+  assert.notEqual(legacyTools.parentElement.children[0], mountedComponent);
 });
 
 await run('theme modules load in parallel and mount in manifest order', async () => {

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -60,8 +60,8 @@ const nativeCss = read('assets/themes/native/base.css');
 const languageManifest = read('assets/i18n/languages.json');
 const i18nEn = read('assets/i18n/en.js');
 
-assert.match(components, /observedAttributes[\s\S]*'variant'[\s\S]*'contract-version'[\s\S]*_usesLegacyDom\(\)[\s\S]*this\._contractVersion\(\) <= 1/, 'theme controls should re-render when the theme contract changes and gate legacy DOM on contract v1');
-assert.match(components, /legacyDom && variant === 'arcus'[\s\S]*arcus-tools__groups[\s\S]*legacyDom && variant === 'solstice'[\s\S]*solstice-tools/, 'theme controls should preserve legacy Arcus and Solstice host classes only for contract v1 themes');
+assert.match(components, /observedAttributes[\s\S]*return \['variant'\]/, 'theme controls should only observe the current variant contract');
+assert.doesNotMatch(components, /contract-version|_usesLegacyDom|_contractVersion|arcus-tools__groups|solstice-tools/, 'theme controls should not retain the retired contract v1 legacy DOM bridge');
 assert.match(components, /arcus-tool[\s\S]*solstice-tool/, 'theme controls should preserve variant-specific control markup classes for shipped theme styling');
 assert.doesNotMatch(components, /\bcartograph\b/i, 'core UI components should not hard-code non-legacy external theme variants');
 
@@ -272,7 +272,7 @@ assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own th
 assert.match(read('assets/js/tags.js'), /press:tag-select/, 'tag sidebar should emit press:tag-select');
 
 assert.match(theme, /mountThemeControls\(options = \{\}\)[\s\S]*document\.createElement\('press-theme-controls'\)/, 'core theme controls should mount press-theme-controls');
-assert.match(theme, /resolveThemeControlsContractVersion\(opts\)[\s\S]*usesLegacyThemeControlsDom\(contractVersion\)[\s\S]*legacyDom \? document\.getElementById\('tools'\) : null[\s\S]*component\.setAttribute\('contract-version', String\(contractVersion\)\)/, 'theme controls should scope #tools replacement and component legacy DOM to the active theme contract version');
+assert.doesNotMatch(theme, /resolveThemeControlsContractVersion|usesLegacyThemeControlsDom|document\.getElementById\('tools'\)|setAttribute\('contract-version'/, 'theme controls should not retain the retired contract v1 #tools bridge');
 assert.match(theme, /component\.addEventListener\('press:theme-toggle'[\s\S]*component\.addEventListener\('press:language-reset'/, 'theme control side effects should be event-driven');
 assert.doesNotMatch(theme, /import ['"]\.\/components\.js['"]/, 'theme helpers should not top-level import browser-only custom elements');
 assert.doesNotMatch(theme, /^let\s+componentsReady\b/m, 'theme controls should not keep component import state in a module-level promise');
@@ -285,7 +285,8 @@ assert.doesNotMatch(nativeSearch, /setAttribute\('icon'/, 'native search should 
 
 assert.match(nativeToc, /createElement\('press-toc'\)/, 'native TOC module should mount press-toc');
 assert.match(toc, /typeof tocRoot\.enhance === 'function'/, 'legacy setupTOC should delegate to press-toc when present');
-assert.match(nativeCss, /:is\(#tools, press-theme-controls\.box\) \.tools[\s\S]*:is\(#tools, press-theme-controls\.box\) \.btn/, 'native theme CSS should style both legacy #tools and v2 press-theme-controls hosts');
+assert.match(nativeCss, /press-theme-controls\.box \.tools[\s\S]*press-theme-controls\.box \.btn/, 'native theme CSS should style the v2 press-theme-controls host');
+assert.doesNotMatch(nativeCss, /#tools/, 'native theme CSS should not style the retired legacy #tools host');
 
 assert.match(nativeInteractions, /renderPressPostCardHtml\(/, 'native cards should render through press-post-card');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/theme\.js'/, 'native interactions should cache-bust theme helper imports');

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -31,7 +31,7 @@ remote repository at runtime; a selected theme must exist locally under
 The shared machine-readable contract surface lives in
 `assets/js/theme-contract-surface.mjs`. Theme Manager, runtime development
 warnings, contract tests, and the JSON schema are expected to agree with that
-surface for the current `contractVersion`, supported legacy contract versions, required views, regions, components,
+surface for the current `contractVersion`, required views, regions, components,
 content shapes, and archive file-type rules.
 
 ## Manifest
@@ -42,7 +42,7 @@ content shapes, and archive file-type rules.
   "name": "Native",
   "version": "3.4.1",
   "contractVersion": 2,
-  "engines": { "press": ">=3.4.122 <4.0.0" },
+  "engines": { "press": ">=3.4.123 <4.0.0" },
   "styles": ["theme.css"],
   "modules": ["modules/layout.js", "modules/interactions.js", "modules/views.js"],
   "views": {
@@ -71,12 +71,11 @@ content shapes, and archive file-type rules.
 ```
 
 - `name` and `version`: Human-facing theme identity.
-- `contractVersion`: Press runtime contract version. The current value is
-  `2`. Press still accepts `1` for existing themes; contract v1 keeps the
-  legacy theme-controls DOM bridge (`#tools` and older shipped-theme host
-  classes), while contract v2 uses the current `<press-theme-controls>`
-  component contract. System updates can require installed themes to reach
-  contract v2 before a later release removes the v1 bridge.
+- `contractVersion`: Press runtime contract version. The current and only
+  supported value is `2`. Contract v2 uses the `<press-theme-controls>`
+  component contract. Sites with older contract v1 themes must pass through
+  Press v3.4.122, update installed themes to contract v2, and then install
+  Press v3.4.123 or later.
 - `engines.press`: Press system SemVer range the theme supports. Theme Manager
   rejects official and manually imported themes outside the current Press
   version.
@@ -107,7 +106,7 @@ changes to it through Publish, and Press system updates do not overwrite it.
   "label": "Arcus",
   "version": "3.4.0",
   "contractVersion": 2,
-  "engines": { "press": ">=3.4.122 <4.0.0" },
+  "engines": { "press": ">=3.4.123 <4.0.0" },
   "builtIn": false,
   "removable": true,
   "source": {
@@ -147,7 +146,7 @@ Official theme repositories publish a root `theme-release.json`:
   "label": "Arcus",
   "version": "3.4.0",
   "contractVersion": 2,
-  "engines": { "press": ">=3.4.122 <4.0.0" },
+  "engines": { "press": ">=3.4.123 <4.0.0" },
   "release": {
     "tag": "v3.4.0",
     "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.0",


### PR DESCRIPTION
## Summary
- retire the contract v1 theme controls DOM bridge from Press runtime and shared theme contract metadata
- make v3.4.123 a v2-only system release gated by v3.4.122 plus installed theme contract v2
- update native theme CSS, schema/docs, Theme Manager/product-state checks, and regression tests for the clean contract

## Release impact
- Press v3.4.123 can only upgrade from >=3.4.122 <3.4.123
- system update metadata requires installed themes to declare contractVersion 2 before v3.4.123 installs
- new theme imports/release manifests with contractVersion 1 are rejected; installed v1 registry entries still render as migration candidates in Theme Manager

## Verification
- node scripts/test-press-version-runtime.js
- node --experimental-default-type=module scripts/test-system-updates.js
- node scripts/test-ui-components.js
- node --experimental-default-type=module scripts/test-theme-runtime.js
- node --experimental-default-type=module scripts/test-theme-manager.js
- node --experimental-default-type=module scripts/test-theme-contracts.js
- node scripts/test-product-state-ledger.js
- node scripts/sync-runtime-cache-keys.mjs --check
- node scripts/test-composer-action-contract.js
- node scripts/test-composer-root-contract.js
- node scripts/test-composer-root-boundaries.js
- node scripts/test-editor-effects-boundary.js
- node scripts/test-composer-app-services.js
- node scripts/test-composer-service-registry.js
- node scripts/test-press-system-surface.mjs
- node scripts/test-editor-app-kernel.mjs
- node scripts/test-provider-adapters.js
- node scripts/test-provider-boundary.js
- node scripts/test-publish-receipt.js
- node scripts/test-publish-flow-smoke.js
- node scripts/test-release-targets.js
- node scripts/test-release-intent.js
- node scripts/test-dispatch-system-release.js
- bash scripts/test-pages-workflow.sh
- bash scripts/test-pages-artifact.sh
- bash scripts/test-system-release-package.sh
- git diff --check

## Notes
- attempted Playwright browser smoke against local preview, but the bundled Playwright browser executable and local Chrome/Chromium were unavailable in this desktop environment; runtime DOM behavior is covered by the focused theme runtime/UI tests above.