### PR TITLE
Add content model migration guard

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -374,6 +374,7 @@ jobs:
               "notes": release.get("body") or "",
               "upgradeFrom": system.get("upgradeFrom") or {},
               "themeContractUpgrade": system.get("themeContractUpgrade") or {},
+              "contentModelUpgrade": system.get("contentModelUpgrade") or {},
               "runtime": {
                   "manifestPath": runtime_manifest_path,
                   "type": runtime.get("type") or "",

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -265,6 +265,7 @@ const translations = {
           themeRegistryUnavailable: ({ target, required }) => `Cannot verify installed themes before updating to ${target}. Make sure assets/themes/packs.json is readable before applying an update that requires ${required}.`,
           themeContractUpgradeBlocked: ({ target, required, themes }) => `Update installed themes to ${required} before updating to ${target}. Update or uninstall: ${themes}.`,
           themeContractUpgradeThemes: ({ themes }) => `Update or uninstall: ${themes}.`,
+          contentModelUpgradeBlocked: ({ target, paths }) => `Publish the content model migration before updating to ${target}. Legacy YAML: ${paths}.`,
           sizeMismatch: ({ expected, actual }) => `The selected archive size (${actual}) does not match the release asset (${expected}).`,
           digestMismatch: 'The selected archive SHA-256 does not match the release asset.',
           generic: 'System update failed. Please try again.'
@@ -547,6 +548,7 @@ const translations = {
         statusMessages: {
           loadingConfig: 'Loading config…',
           restoredDraft: ({ label }) => `Restored local draft for ${label}`,
+          contentModelMigrationReady: 'Legacy content YAML was normalized. Publish once before installing the next clean Press release.',
           refreshSuccess: ({ name }) => `${name} refreshed from remote`,
           remoteUpdated: 'Remote snapshot updated. Highlights now include remote differences.',
           remoteUnchanged: 'Remote snapshot unchanged.',

--- a/assets/js/composer-bootstrap.js
+++ b/assets/js/composer-bootstrap.js
@@ -1,6 +1,10 @@
 import { createEditorAppKernel } from './editor-app-kernel.js';
 import { createDomEffects } from './editor-effects.js';
 import { EDITOR_SHELL_IDS, EDITOR_SHELL_SELECTORS } from './editor-shell-contract.js';
+import {
+  CONTENT_MODEL_MIGRATION_STATE_KEY,
+  getLegacyContentModelMigrationFiles
+} from './content-model-migration.js';
 
 function noop() {}
 
@@ -202,7 +206,8 @@ export async function loadInitialComposerState({
   setRemoteBaseline,
   getActiveDynamicTab = () => null,
   updateMarkdownPushButton = noop,
-  showStatus = noop
+  showStatus = noop,
+  loadContentModelMigration = null
 } = {}) {
   try {
     ensureSiteRepo();
@@ -222,12 +227,45 @@ export async function loadInitialComposerState({
     ]);
     const remoteIndex = prepareIndexState(idx || {});
     const remoteTabs = prepareTabsState(tbs || {});
+    let migration = null;
+    if (typeof loadContentModelMigration === 'function') {
+      try {
+        migration = await loadContentModelMigration({
+          contentRoot: root,
+          indexRaw: idx || {},
+          tabsRaw: tbs || {}
+        });
+      } catch (err) {
+        if (consoleRef && typeof consoleRef.warn === 'function') {
+          consoleRef.warn('Composer: failed to inspect legacy content model files', err);
+        }
+        migration = null;
+      }
+    }
+    const hasContentModelMigration = !!(migration && migration.hasLegacyContentModel);
+    const migratedIndex = hasContentModelMigration
+      ? prepareIndexState(migration.indexRaw || idx || {})
+      : remoteIndex;
+    const migratedTabs = hasContentModelMigration
+      ? prepareTabsState(migration.tabsRaw || tbs || {})
+      : remoteTabs;
     setRemoteBaseline('index', deepClone(remoteIndex));
     setRemoteBaseline('tabs', deepClone(remoteTabs));
     setRemoteBaseline('site', cloneSiteState(remoteSite));
-    state.index = deepClone(remoteIndex);
-    state.tabs = deepClone(remoteTabs);
+    state.index = deepClone(migratedIndex);
+    state.tabs = deepClone(migratedTabs);
     state.site = cloneSiteState(remoteSite);
+    if (hasContentModelMigration) {
+      Object.defineProperty(state, CONTENT_MODEL_MIGRATION_STATE_KEY, {
+        value: {
+          contentRoot: root,
+          legacyFiles: getLegacyContentModelMigrationFiles(migration)
+        },
+        enumerable: false,
+        configurable: true
+      });
+      showStatus(t('editor.composer.statusMessages.contentModelMigrationReady'));
+    }
   } catch (err) {
     if (consoleRef && typeof consoleRef.warn === 'function') {
       consoleRef.warn('Composer: failed to load configs', err);

--- a/assets/js/composer-content-staging.js
+++ b/assets/js/composer-content-staging.js
@@ -35,6 +35,7 @@ export function createContentCommitStagingProvider({
   computeIndexDiff = () => null,
   recomputeDiff = () => null,
   listMarkdownAssetDeletions = () => [],
+  getContentModelMigrationFiles = () => [],
   safeString = (value) => String(value == null ? '' : value),
   draftHasAssetDeletions = () => false,
   textWithFallback = (key, fallback) => fallback,
@@ -72,6 +73,25 @@ export function createContentCommitStagingProvider({
       }
     } catch (_) {}
     return Array.from(paths);
+  }
+
+  function collectContentModelMigrationFiles() {
+    try {
+      const files = getContentModelMigrationFiles();
+      return Array.isArray(files) ? files
+        .filter(file => file && file.path)
+        .map(file => ({
+          ...file,
+          kind: file.kind || 'content-model-migration',
+          category: file.category || 'legacy-content-model',
+          state: 'deleted',
+          deleted: true,
+          path: normalizeRelPath(file.path)
+        }))
+        .filter(file => file.path) : [];
+    } catch (_) {
+      return [];
+    }
   }
 
   function formatRepositoryDeletionBlockers(blocked = []) {
@@ -190,6 +210,7 @@ export function createContentCommitStagingProvider({
       const yaml = toSiteYaml(state);
       addFile({ kind: 'site', label: 'site.yaml', path: 'site.yaml', content: yaml });
     }
+    collectContentModelMigrationFiles().forEach(addFile);
 
     const contentDeletionPlan = planManagedContentDeletions({
       index: getStateSlice('index') || { __order: [] },

--- a/assets/js/composer-post-commit-state.js
+++ b/assets/js/composer-post-commit-state.js
@@ -35,6 +35,7 @@ export function createPostCommitStateApplier({
   updateDynamicTabDirtyState = () => {},
   removeMarkdownAsset = () => {},
   removeMarkdownAssetDeletion = () => {},
+  clearContentModelMigration = () => {},
   updateUnsyncedSummary = () => {}
 } = {}) {
   function apply(files = []) {
@@ -178,6 +179,9 @@ export function createPostCommitStateApplier({
         }
       }
     });
+    if (files.some(file => file && file.kind === 'content-model-migration')) {
+      clearContentModelMigration();
+    }
     updateUnsyncedSummary();
     updateMarkdownPushButton(getActiveDynamicTab());
     updateMarkdownDiscardButton(getActiveDynamicTab());

--- a/assets/js/composer-publish-state-service.js
+++ b/assets/js/composer-publish-state-service.js
@@ -67,6 +67,7 @@ export function createComposerPublishStateService(options = {}) {
     computeIndexDiff: options.computeIndexDiff || (() => null),
     recomputeDiff: options.recomputeDiff || (() => null),
     listMarkdownAssetDeletions: options.listMarkdownAssetDeletions || (() => []),
+    getContentModelMigrationFiles: options.getContentModelMigrationFiles || (() => []),
     safeString,
     draftHasAssetDeletions: options.draftHasAssetDeletions || (() => false),
     textWithFallback: options.textWithFallback || ((_key, fallback) => fallback),
@@ -122,6 +123,7 @@ export function createComposerPublishStateService(options = {}) {
     updateDynamicTabDirtyState: options.updateDynamicTabDirtyState || noop,
     removeMarkdownAsset: options.removeMarkdownAsset || noop,
     removeMarkdownAssetDeletion: options.removeMarkdownAssetDeletion || noop,
+    clearContentModelMigration: options.clearContentModelMigration || noop,
     updateUnsyncedSummary: options.updateUnsyncedSummary || noop
   });
 

--- a/assets/js/composer-root-contract.js
+++ b/assets/js/composer-root-contract.js
@@ -15,6 +15,7 @@ export const COMPOSER_ROOT_IMPORT_CONTRACT = Object.freeze([
   Object.freeze({ specifier: './yaml.js', group: 'shared', reason: 'tracked YAML loading and parsing primitives' }),
   Object.freeze({ specifier: './utils.js', group: 'shared', reason: 'shared text escaping helper' }),
   Object.freeze({ specifier: './i18n.js', group: 'runtime', reason: 'editor translation and language labels' }),
+  Object.freeze({ specifier: './content-model-migration.js', group: 'service', reason: 'legacy content-model migration and upgrade guard helpers' }),
   Object.freeze({ specifier: './composer-index-tabs-model.js', group: 'model', reason: 'index and tabs state normalization, diffing, and signatures' }),
   Object.freeze({ specifier: './composer-site-model.js', group: 'model', reason: 'site.yaml normalization, diffing, and serialization helpers' }),
   Object.freeze({ specifier: './editor-storage.js', group: 'state', reason: 'scoped browser storage keys' }),

--- a/assets/js/composer-system-theme-bridge.js
+++ b/assets/js/composer-system-theme-bridge.js
@@ -13,9 +13,13 @@ export function createComposerSystemThemeBridge(options = {}) {
   const getStagedThemeCommitFiles = typeof options.getStagedThemeCommitFiles === 'function'
     ? options.getStagedThemeCommitFiles
     : () => (themeManager && typeof themeManager.getCommitFiles === 'function' ? themeManager.getCommitFiles() : []);
+  const getStagedContentCommitFiles = typeof options.getStagedContentCommitFiles === 'function'
+    ? options.getStagedContentCommitFiles
+    : () => [];
   const systemUpdates = options.systemUpdatesController || createSystemUpdatesController({
     localStorageRef,
     getStagedThemeCommitFiles,
+    getStagedContentCommitFiles,
     getCurrentThemePack
   });
   let initialized = false;

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4,7 +4,12 @@ import {
   parseYAML
 } from './yaml.js';
 import { escapeHtml } from './utils.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js';
+import { t, getAvailableLangs, getCurrentLang, getLanguageLabel } from './i18n.js';
+import {
+  CONTENT_MODEL_MIGRATION_STATE_KEY,
+  getLegacyContentModelMigrationFiles,
+  loadLegacyContentModelMigration
+} from './content-model-migration.js';
 import {
   cloneIndexMetadataValue,
   computeIndexDiff,
@@ -391,6 +396,9 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     getStateSlice,
     setStateSlice,
     notifyComposerChange,
+    getStagedContentCommitFiles: () => getLegacyContentModelMigrationFiles(
+      composerStateStore.getActiveState() && composerStateStore.getActiveState()[CONTENT_MODEL_MIGRATION_STATE_KEY]
+    ),
     updateUnsyncedSummary: () => composerActions.refreshSystemThemeState({ preserveStructure: true }),
     refreshEditorContentTree: (options) => composerActions.refreshEditorContentTree(options)
   });
@@ -442,6 +450,9 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     computeIndexDiff,
     recomputeDiff,
     listMarkdownAssetDeletions,
+    getContentModelMigrationFiles: () => getLegacyContentModelMigrationFiles(
+      composerStateStore.getActiveState() && composerStateStore.getActiveState()[CONTENT_MODEL_MIGRATION_STATE_KEY]
+    ),
     draftHasAssetDeletions,
     textWithFallback,
     getRemoteBaselineSite: () => composerStateStore.getRemoteBaseline('site'),
@@ -467,6 +478,12 @@ export function createComposerController(editorRuntime = createComposerRuntime()
     scheduleMarkdownDraftSave,
     updateDynamicTabDirtyState,
     removeMarkdownAssetDeletion,
+    clearContentModelMigration: () => {
+      const state = composerStateStore.getActiveState();
+      if (state && Object.prototype.hasOwnProperty.call(state, CONTENT_MODEL_MIGRATION_STATE_KEY)) {
+        delete state[CONTENT_MODEL_MIGRATION_STATE_KEY];
+      }
+    },
     updateUnsyncedSummary,
     registerExternalStagingProviders: (registry) => composerSystemThemeBridge.registerStagingProviders(registry),
     parseEncryptedMarkdownEnvelope,
@@ -1230,6 +1247,12 @@ export function createComposerController(editorRuntime = createComposerRuntime()
       fetchTrackedSiteConfig: fetchComposerTrackedSiteConfig,
       applyEffectiveSiteConfig: applyComposerEffectiveSiteConfig,
       fetchConfigWithYamlFallback,
+      loadContentModelMigration: (options) => loadLegacyContentModelMigration({
+        ...options,
+        languages: getAvailableLangs(),
+        currentLang: getCurrentLang(),
+        fetchImpl: (url, fetchOptions) => editorRuntime.fetchContent(url, fetchOptions)
+      }),
       prepareSiteState,
       prepareIndexState,
       prepareTabsState,

--- a/assets/js/content-model-migration.js
+++ b/assets/js/content-model-migration.js
@@ -1,0 +1,396 @@
+import { parseYAML } from './yaml.js';
+
+export const CONTENT_MODEL_MIGRATION_STATE_KEY = '__contentModelMigration';
+export const CONTENT_MODEL_MIGRATION_KIND = 'content-model-migration';
+
+const DEFAULT_CONTENT_LANGUAGES = ['en', 'chs', 'cht-tw', 'cht-hk', 'ja'];
+const LEGACY_CONTENT_BASES = ['index', 'tabs'];
+const LEGACY_CONTENT_EXTENSIONS = ['yaml', 'yml'];
+const LANGUAGE_MANIFEST_PATH = 'assets/i18n/languages.json';
+const INDEX_METADATA_KEYS = new Set([
+  'location',
+  'path',
+  'title',
+  'tag',
+  'tags',
+  'date',
+  'image',
+  'thumb',
+  'cover',
+  'excerpt',
+  'readTime',
+  'readMinutes',
+  'minutes',
+  'version',
+  'versionLabel',
+  'ai',
+  'aiGenerated',
+  'llm',
+  'draft',
+  'wip',
+  'unfinished',
+  'inprogress',
+  'protected',
+  'encryption',
+  'versions',
+  'summary'
+]);
+
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
+function deepClone(value) {
+  try {
+    if (typeof structuredClone === 'function') return structuredClone(value);
+  } catch (_) {}
+  try { return JSON.parse(JSON.stringify(value)); }
+  catch (_) { return value; }
+}
+
+export function normalizeContentRoot(value) {
+  const root = safeString(value || 'wwwroot')
+    .replace(/[\\]/g, '/')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\/+/g, '/');
+  return root || 'wwwroot';
+}
+
+function normalizeLanguageCode(value) {
+  return safeString(value).trim().toLowerCase();
+}
+
+export function getLegacyContentLanguageCandidates(options = {}) {
+  const provided = Array.isArray(options.languages) ? options.languages : [];
+  const registered = Array.isArray(options.registeredLanguages) ? options.registeredLanguages : [];
+  const values = [
+    options.defaultLang || 'en',
+    options.currentLang,
+    ...DEFAULT_CONTENT_LANGUAGES,
+    ...registered,
+    ...provided
+  ];
+  const out = [];
+  const seen = new Set();
+  values.forEach((value) => {
+    const normalized = normalizeLanguageCode(value);
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    out.push(normalized);
+  });
+  return out;
+}
+
+async function loadRegisteredLanguages(fetchImpl, manifestPath = LANGUAGE_MANIFEST_PATH) {
+  if (typeof fetchImpl !== 'function') return [];
+  try {
+    const response = await fetchImpl(manifestPath, { cache: 'no-store' });
+    if (!response || !response.ok) return [];
+    let data = null;
+    if (typeof response.json === 'function') {
+      try { data = await response.json(); }
+      catch (_) { data = null; }
+    }
+    if (!data && typeof response.text === 'function') {
+      try { data = JSON.parse(await response.text()); }
+      catch (_) { data = null; }
+    }
+    if (!Array.isArray(data)) return [];
+    return data
+      .map(entry => normalizeLanguageCode(entry && (entry.value || entry.code || entry.lang || entry.language)))
+      .filter(Boolean);
+  } catch (_) {
+    return [];
+  }
+}
+
+export function listLegacyContentModelPaths(options = {}) {
+  const root = normalizeContentRoot(options.contentRoot);
+  const languages = getLegacyContentLanguageCandidates(options);
+  const paths = [];
+  for (const base of LEGACY_CONTENT_BASES) {
+    for (const lang of languages) {
+      for (const ext of LEGACY_CONTENT_EXTENSIONS) {
+        paths.push({
+          base,
+          lang,
+          path: `${root}/${base}.${lang}.${ext}`
+        });
+      }
+    }
+  }
+  return paths;
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isIndexVariantBucket(value) {
+  if (typeof value === 'string') return !!value.trim();
+  if (Array.isArray(value)) {
+    return value.every(item => (
+      typeof item === 'string'
+      || (isPlainObject(item) && (item.location != null || item.path != null))
+    ));
+  }
+  return isPlainObject(value) && (value.location != null || value.path != null);
+}
+
+function isUnifiedIndexEntry(value, languageSet) {
+  if (!isPlainObject(value)) return false;
+  if (Object.prototype.hasOwnProperty.call(value, 'default')) return true;
+  if (isIndexVariantBucket(value)) return false;
+  return Object.keys(value).some((key) => {
+    if (INDEX_METADATA_KEYS.has(key)) return false;
+    return languageSet.has(normalizeLanguageCode(key)) || isIndexVariantBucket(value[key]);
+  });
+}
+
+function isUnifiedTabsEntry(value, languageSet) {
+  if (!isPlainObject(value)) return false;
+  if (Object.prototype.hasOwnProperty.call(value, 'default')) return true;
+  if (Object.prototype.hasOwnProperty.call(value, 'location') || Object.prototype.hasOwnProperty.call(value, 'path')) return false;
+  return Object.keys(value).some(key => languageSet.has(normalizeLanguageCode(key)));
+}
+
+function normalizeIndexDefaultValue(key, value) {
+  if (isPlainObject(value) && value.title == null && key) {
+    return { title: key, ...deepClone(value) };
+  }
+  return deepClone(value);
+}
+
+function normalizeTabsDefaultValue(key, value) {
+  return normalizeLegacyTabsValue(key, value);
+}
+
+function cloneRawConfig(raw, options = {}) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { __order: [] };
+  const base = options.base === 'tabs' ? 'tabs' : 'index';
+  const defaultLang = normalizeLanguageCode(options.defaultLang || 'en') || 'en';
+  const languageSet = new Set(getLegacyContentLanguageCandidates(options));
+  const cloned = deepClone(raw) || {};
+  if (!Array.isArray(cloned.__order)) {
+    cloned.__order = Object.keys(cloned).filter(key => key !== '__order');
+  }
+  Object.keys(cloned).forEach((key) => {
+    if (key === '__order') return;
+    const value = cloned[key];
+    if (base === 'tabs') {
+      if (!isUnifiedTabsEntry(value, languageSet)) {
+        cloned[key] = { [defaultLang]: normalizeTabsDefaultValue(key, value) };
+      }
+      return;
+    }
+    if (!isUnifiedIndexEntry(value, languageSet)) {
+      cloned[key] = { [defaultLang]: normalizeIndexDefaultValue(key, value) };
+    }
+  });
+  return cloned;
+}
+
+function addOrderedKey(raw, key) {
+  if (!key) return;
+  if (!Array.isArray(raw.__order)) raw.__order = [];
+  if (!raw.__order.includes(key)) raw.__order.push(key);
+}
+
+function orderedLegacyEntries(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+  const order = Array.isArray(parsed.__order) ? parsed.__order.filter(key => typeof key === 'string' && key) : [];
+  const seen = new Set();
+  const keys = [];
+  order.forEach((key) => {
+    if (key === '__order' || seen.has(key)) return;
+    seen.add(key);
+    keys.push(key);
+  });
+  Object.keys(parsed).forEach((key) => {
+    if (key === '__order' || seen.has(key)) return;
+    seen.add(key);
+    keys.push(key);
+  });
+  return keys.map(key => [key, parsed[key]]);
+}
+
+function ensureUnifiedEntry(raw, key) {
+  if (!raw[key] || typeof raw[key] !== 'object' || Array.isArray(raw[key])) raw[key] = {};
+  addOrderedKey(raw, key);
+  return raw[key];
+}
+
+function getIndexValueLocation(value) {
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const location = getIndexValueLocation(item);
+      if (location) return location;
+    }
+    return '';
+  }
+  if (isPlainObject(value)) return safeString(value.location != null ? value.location : value.path).trim();
+  return '';
+}
+
+function getTabsValueLocation(value) {
+  if (typeof value === 'string') return value.trim();
+  if (isPlainObject(value)) return safeString(value.location != null ? value.location : value.path).trim();
+  return '';
+}
+
+function findExistingKeyByLocation(raw, location, getLocation) {
+  const target = safeString(location).trim();
+  if (!target) return '';
+  const orderedKeys = Array.isArray(raw.__order) ? raw.__order : [];
+  for (const key of orderedKeys) {
+    if (key === '__order' || !raw[key] || typeof raw[key] !== 'object') continue;
+    for (const value of Object.values(raw[key])) {
+      if (getLocation(value) === target) return key;
+    }
+  }
+  return '';
+}
+
+function findExistingKeyByPosition(raw, position) {
+  const orderedKeys = Array.isArray(raw.__order) ? raw.__order.filter(key => key && key !== '__order') : [];
+  return orderedKeys[position] || '';
+}
+
+function chooseMergeKey(raw, key, value, position, getLocation) {
+  if (raw[key] && typeof raw[key] === 'object' && !Array.isArray(raw[key])) return key;
+  return findExistingKeyByLocation(raw, getLocation(value), getLocation)
+    || findExistingKeyByPosition(raw, position)
+    || key;
+}
+
+function normalizeLegacyIndexValue(stableKey, sourceKey, value) {
+  if (isPlainObject(value)) {
+    const out = deepClone(value) || {};
+    if (sourceKey !== stableKey && out.title == null) out.title = sourceKey;
+    return out;
+  }
+  if (sourceKey !== stableKey) {
+    return {
+      title: sourceKey,
+      location: safeString(value)
+    };
+  }
+  return deepClone(value);
+}
+
+function mergeLegacyIndex(raw, lang, parsed) {
+  orderedLegacyEntries(parsed).forEach(([key, value], position) => {
+    const stableKey = chooseMergeKey(raw, key, value, position, getIndexValueLocation);
+    const entry = ensureUnifiedEntry(raw, stableKey);
+    if (Object.prototype.hasOwnProperty.call(entry, lang)) return;
+    entry[lang] = normalizeLegacyIndexValue(stableKey, key, value);
+  });
+}
+
+function normalizeLegacyTabsValue(key, value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const title = safeString(value.title || key);
+    const location = safeString(value.location != null ? value.location : value.path);
+    return { title, location };
+  }
+  return {
+    title: safeString(key),
+    location: safeString(value)
+  };
+}
+
+function mergeLegacyTabs(raw, lang, parsed) {
+  orderedLegacyEntries(parsed).forEach(([key, value], position) => {
+    const stableKey = chooseMergeKey(raw, key, value, position, getTabsValueLocation);
+    const entry = ensureUnifiedEntry(raw, stableKey);
+    if (Object.prototype.hasOwnProperty.call(entry, lang)) return;
+    entry[lang] = normalizeLegacyTabsValue(key, value);
+  });
+}
+
+function legacyFileEntry(path) {
+  const label = path.split('/').pop() || path;
+  return {
+    kind: CONTENT_MODEL_MIGRATION_KIND,
+    category: 'legacy-content-model',
+    label,
+    path,
+    state: 'deleted',
+    deleted: true
+  };
+}
+
+async function fetchYamlObject(fetchImpl, path) {
+  try {
+    const response = await fetchImpl(path, { cache: 'no-store' });
+    if (!response || !response.ok) return { found: false, value: {} };
+    const text = await response.text();
+    const parsed = parseYAML(text);
+    return {
+      found: true,
+      value: parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+    };
+  } catch (_) {
+    return { found: false, value: {} };
+  }
+}
+
+export async function loadLegacyContentModelMigration(options = {}) {
+  const fetchImpl = typeof options.fetchImpl === 'function' ? options.fetchImpl : null;
+  const contentRoot = normalizeContentRoot(options.contentRoot);
+  const registeredLanguages = await loadRegisteredLanguages(fetchImpl, options.languageManifestPath);
+  const languageOptions = {
+    languages: options.languages,
+    registeredLanguages,
+    currentLang: options.currentLang,
+    defaultLang: options.defaultLang
+  };
+  const indexRaw = cloneRawConfig(options.indexRaw, { ...languageOptions, base: 'index' });
+  const tabsRaw = cloneRawConfig(options.tabsRaw, { ...languageOptions, base: 'tabs' });
+  const legacyFiles = [];
+  if (!fetchImpl) {
+    return {
+      hasLegacyContentModel: false,
+      contentRoot,
+      indexRaw,
+      tabsRaw,
+      legacyFiles
+    };
+  }
+
+  for (const candidate of listLegacyContentModelPaths({
+    contentRoot,
+    ...languageOptions
+  })) {
+    const result = await fetchYamlObject(fetchImpl, candidate.path);
+    if (!result.found) continue;
+    legacyFiles.push(legacyFileEntry(candidate.path));
+    if (candidate.base === 'tabs') mergeLegacyTabs(tabsRaw, candidate.lang, result.value);
+    else mergeLegacyIndex(indexRaw, candidate.lang, result.value);
+  }
+
+  return {
+    hasLegacyContentModel: legacyFiles.length > 0,
+    contentRoot,
+    indexRaw,
+    tabsRaw,
+    legacyFiles
+  };
+}
+
+export function getLegacyContentModelMigrationFiles(migration) {
+  const files = Array.isArray(migration && migration.legacyFiles)
+    ? migration.legacyFiles
+    : (Array.isArray(migration && migration.files) ? migration.files : []);
+  return files
+    .filter(file => file && file.path)
+    .map(file => ({
+      ...file,
+      kind: file.kind || CONTENT_MODEL_MIGRATION_KIND,
+      category: file.category || 'legacy-content-model',
+      state: 'deleted',
+      deleted: true,
+      path: safeString(file.path).replace(/[\\]/g, '/').replace(/^\/+/, '')
+    }));
+}

--- a/assets/js/press-version.js
+++ b/assets/js/press-version.js
@@ -76,6 +76,14 @@ export function normalizeThemeContractUpgrade(input) {
   };
 }
 
+export function normalizeContentModelUpgrade(input) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    requiresUnifiedIndexTabs: source.requiresUnifiedIndexTabs === true,
+    message: String(source.message || '')
+  };
+}
+
 export function normalizePressSystemManifest(input) {
   if (!input || typeof input !== 'object') throw new Error('Press system manifest is missing.');
   if (Number(input.schemaVersion) !== 1 || input.type !== 'press-system') {
@@ -92,7 +100,8 @@ export function normalizePressSystemManifest(input) {
     version,
     tag,
     upgradeFrom: normalizeUpgradeFrom(input.upgradeFrom),
-    themeContractUpgrade: normalizeThemeContractUpgrade(input.themeContractUpgrade)
+    themeContractUpgrade: normalizeThemeContractUpgrade(input.themeContractUpgrade),
+    contentModelUpgrade: normalizeContentModelUpgrade(input.contentModelUpgrade)
   };
 }
 

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -10,6 +10,7 @@ import { parseYAML } from './yaml.js';
 import {
   isUpgradeAllowed,
   loadPressSystemManifest,
+  normalizeContentModelUpgrade,
   normalizeThemeContractUpgrade,
   normalizePressSystemManifest,
   normalizeSemver,
@@ -17,6 +18,10 @@ import {
   semverToTag
 } from './press-version.js';
 import { isPressSystemUpdatePath } from './press-system-surface.mjs';
+import {
+  getLegacyContentModelMigrationFiles,
+  loadLegacyContentModelMigration
+} from './content-model-migration.js';
 import { normalizeThemeRegistry, sanitizeThemeSlug } from './theme-package-core.js';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
@@ -32,6 +37,7 @@ const RELEASE_API_URL = PRESS_GITHUB_PROVIDER.latestReleaseApiUrl;
 const RELEASE_MANIFEST_URL = PRESS_GITHUB_PROVIDER.systemReleaseUrl;
 const THEME_PACK_STORAGE_KEYS = ['themePackPending', 'themePack'];
 const SITE_CONFIG_THEME_PACK_PATHS = ['site.yaml', 'site.yml'];
+const LEGACY_CONTENT_SIDECAR_PATTERN = /(^|\/)(?:index|tabs)\.[a-z0-9][a-z0-9-]*\.ya?ml$/i;
 
 function createSystemUpdateElements() {
   return {
@@ -85,6 +91,9 @@ function createSystemUpdatesRuntime(options = {}) {
   const getStagedThemeCommitFiles = typeof options.getStagedThemeCommitFiles === 'function'
     ? options.getStagedThemeCommitFiles
     : null;
+  const getStagedContentCommitFiles = typeof options.getStagedContentCommitFiles === 'function'
+    ? options.getStagedContentCommitFiles
+    : null;
   const getCurrentThemePack = typeof options.getCurrentThemePack === 'function'
     ? options.getCurrentThemePack
     : null;
@@ -104,6 +113,9 @@ function createSystemUpdatesRuntime(options = {}) {
     },
     getStagedThemeCommitFiles() {
       return getStagedThemeCommitFiles ? getStagedThemeCommitFiles() : [];
+    },
+    getStagedContentCommitFiles() {
+      return getStagedContentCommitFiles ? getStagedContentCommitFiles() : [];
     },
     getCurrentThemePack() {
       return getCurrentThemePack ? getCurrentThemePack() : null;
@@ -378,6 +390,7 @@ function normalizeReleaseCache(data) {
     notes: data.body || '',
     upgradeFrom: normalizeUpgradeFrom(data.upgradeFrom),
     themeContractUpgrade: normalizeThemeContractUpgrade(data.themeContractUpgrade),
+    contentModelUpgrade: normalizeContentModelUpgrade(data.contentModelUpgrade),
     htmlUrl: data.html_url || '',
     asset: asset ? { ...asset, fetchable: false } : asset
   };
@@ -419,6 +432,7 @@ export function normalizeSystemReleaseManifest(manifest) {
     notes,
     upgradeFrom: normalizeUpgradeFrom(manifest.upgradeFrom),
     themeContractUpgrade: normalizeThemeContractUpgrade(manifest.themeContractUpgrade),
+    contentModelUpgrade: normalizeContentModelUpgrade(manifest.contentModelUpgrade),
     htmlUrl,
     asset: {
       ...asset,
@@ -611,6 +625,99 @@ function getStagedThemeCommitFilesForUpgrade(runtime) {
     }) : [];
   } catch (_) {
     return [];
+  }
+}
+
+function getStagedContentCommitFilesForUpgrade(runtime) {
+  if (!runtime || typeof runtime.getStagedContentCommitFiles !== 'function') return [];
+  try {
+    const files = runtime.getStagedContentCommitFiles();
+    return Array.isArray(files) ? files.filter((file) => {
+      const path = String(file && file.path || '').replace(/[\\]/g, '/').replace(/^\/+/, '');
+      if (!path) return false;
+      if (file && file.kind === 'content-model-migration') return true;
+      return LEGACY_CONTENT_SIDECAR_PATTERN.test(path);
+    }) : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function normalizeContentRootForUpgrade(value) {
+  const root = String(value || 'wwwroot')
+    .replace(/[\\]/g, '/')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\/+/g, '/');
+  return root || 'wwwroot';
+}
+
+async function resolveContentRootForUpgrade(runtime) {
+  const fetchImpl = runtime.getFetch();
+  for (const path of SITE_CONFIG_THEME_PACK_PATHS) {
+    let response = null;
+    try {
+      response = await fetchImpl(path, { cache: 'no-store' });
+    } catch (_) {
+      response = null;
+    }
+    if (!response || !response.ok) continue;
+    try {
+      const config = parseYAML(await response.text());
+      if (!config || typeof config !== 'object' || Array.isArray(config)) continue;
+      return normalizeContentRootForUpgrade(config.contentRoot || 'wwwroot');
+    } catch (_) {
+      continue;
+    }
+  }
+  return 'wwwroot';
+}
+
+function createContentModelUpgradeError(targetVersion, requirement, files = [], reason = '') {
+  const paths = (Array.isArray(files) ? files : [])
+    .map(file => String(file && file.path || '').replace(/[\\]/g, '/').replace(/^\/+/, ''))
+    .filter(Boolean)
+    .slice(0, 6);
+  const pathText = paths.length ? paths.join(', ') : 'legacy content YAML';
+  let message = requirement.message || t('editor.systemUpdates.errors.contentModelUpgradeBlocked', {
+    target: versionLabel(targetVersion),
+    paths: pathText
+  });
+  if (!requirement.message && message === 'editor.systemUpdates.errors.contentModelUpgradeBlocked') {
+    message = `Publish the content model migration before updating to ${versionLabel(targetVersion)}. Legacy YAML: ${pathText}.`;
+  }
+  if (reason === 'staged') {
+    const detail = `Staged content model migration is not published yet: ${pathText}.`;
+    message = requirement.message ? `${message} ${detail}` : `Publish the staged content model migration before updating to ${versionLabel(targetVersion)}. ${detail}`;
+  } else if (requirement.message && paths.length) {
+    message = `${message} Legacy YAML: ${pathText}.`;
+  }
+  const error = new Error(message);
+  error.pressContentModelUpgradeBlocked = true;
+  throw error;
+}
+
+async function assertContentModelCompatibility(runtime, release, archiveSystem) {
+  const targetVersion = normalizeSemver(
+    (archiveSystem && archiveSystem.version) || (release && (release.version || release.tag)) || ''
+  );
+  const archiveRequirement = normalizeContentModelUpgrade(archiveSystem && archiveSystem.contentModelUpgrade);
+  const releaseRequirement = normalizeContentModelUpgrade(release && release.contentModelUpgrade);
+  const requirement = archiveRequirement.requiresUnifiedIndexTabs ? archiveRequirement : releaseRequirement;
+  if (!requirement.requiresUnifiedIndexTabs) return;
+
+  const stagedContentFiles = getStagedContentCommitFilesForUpgrade(runtime);
+  if (stagedContentFiles.length) {
+    createContentModelUpgradeError(targetVersion, requirement, stagedContentFiles, 'staged');
+  }
+
+  const contentRoot = await resolveContentRootForUpgrade(runtime);
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot,
+    fetchImpl: runtime.getFetch()
+  });
+  const legacyFiles = getLegacyContentModelMigrationFiles(migration);
+  if (legacyFiles.length) {
+    createContentModelUpgradeError(targetVersion, requirement, legacyFiles, 'legacy');
   }
 }
 
@@ -1011,11 +1118,13 @@ async function analyzeArchiveWithRuntime(runtime, buffer, filename) {
     await refreshCurrentPressSystem(runtime);
     assertSystemUpdateCompatibility(runtime, release, archiveSystem);
     await assertInstalledThemeContractCompatibility(runtime, release, archiveSystem);
+    await assertContentModelCompatibility(runtime, release, archiveSystem);
     files = await processArchiveEntries(runtime, entries);
   } catch (err) {
     console.error('Failed to unpack system update archive', err);
     if (err && err.pressUpgradeBlocked) throw err;
     if (err && err.pressThemeContractUpgradeBlocked) throw err;
+    if (err && err.pressContentModelUpgradeBlocked) throw err;
     if (err && err.message && /upgrade|version|Press/i.test(err.message)) throw err;
     throw new Error(t('editor.systemUpdates.errors.invalidArchive'));
   }

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.123",
-  "tag": "v3.4.123",
+  "version": "3.4.124",
+  "tag": "v3.4.124",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.122 <3.4.123"
+      ">=3.4.123 <3.4.124"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.122 first."
+    "message": "Update to v3.4.123 first."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 2,
-    "message": "Update installed themes to contract v2 before installing v3.4.123."
+    "message": "Update installed themes to contract v2 before installing v3.4.124."
   }
 }

--- a/scripts/dispatch-system-release.js
+++ b/scripts/dispatch-system-release.js
@@ -109,6 +109,7 @@ function buildPayload(release) {
     tag,
     version: String(system.version || '').trim(),
     upgrade_from: system.upgradeFrom || {},
+    content_model_upgrade: system.contentModelUpgrade || {},
     asset_name: assetName,
     asset_size: Number.isFinite(assetSize) ? assetSize : 0,
     asset_sha256: assetSha256,

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -352,6 +352,9 @@ function normalizeSystemRelease(input) {
     themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
       ? source.themeContractUpgrade
       : {},
+    contentModelUpgrade: source.contentModelUpgrade && typeof source.contentModelUpgrade === 'object'
+      ? source.contentModelUpgrade
+      : {},
     runtime: {
       manifestPath: String(runtime.manifestPath || '').trim(),
       type: String(runtime.type || '').trim(),
@@ -528,7 +531,8 @@ function buildDesiredState({ sources, systemRelease, systemSource, releaseIntent
       version: target.version,
       tag: target.tag,
       asset: systemRelease.asset,
-      runtime: systemRelease.runtime
+      runtime: systemRelease.runtime,
+      contentModelUpgrade: systemRelease.contentModelUpgrade
     },
     downstream: Object.fromEntries((sources.downstream || []).map((source) => {
       return [source.key, downstreamTarget(source, target.version)];
@@ -560,7 +564,8 @@ function buildObservedState(state, checkedAt) {
       version: state.pressSystem.version,
       tag: state.pressSystem.tag,
       runtime: state.pressSystem.runtime,
-      asset: state.pressSystem.asset
+      asset: state.pressSystem.asset,
+      contentModelUpgrade: state.pressSystem.contentModelUpgrade
     },
     releaseIntent: clone(state.releaseIntent),
     downstream: clone(state.downstream),

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -39,6 +39,21 @@ function themeContractUpgradesMatch(left, right) {
     && a.message === b.message;
 }
 
+function normalizeContentModelUpgrade(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    requiresUnifiedIndexTabs: source.requiresUnifiedIndexTabs === true,
+    message: String(source.message || '').trim()
+  };
+}
+
+function contentModelUpgradesMatch(left, right) {
+  const a = normalizeContentModelUpgrade(left);
+  const b = normalizeContentModelUpgrade(right);
+  return a.requiresUnifiedIndexTabs === b.requiresUnifiedIndexTabs
+    && a.message === b.message;
+}
+
 function readJsonFile(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
@@ -72,6 +87,9 @@ function normalizeSystemRelease(input = {}) {
     upgradeFrom: source.upgradeFrom && typeof source.upgradeFrom === 'object' ? source.upgradeFrom : {},
     themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
       ? source.themeContractUpgrade
+      : {},
+    contentModelUpgrade: source.contentModelUpgrade && typeof source.contentModelUpgrade === 'object'
+      ? source.contentModelUpgrade
       : {},
     runtime: {
       manifestPath: String(runtime.manifestPath || '').trim(),
@@ -150,7 +168,8 @@ function buildReleaseIntent(options = {}) {
       asset: systemRelease.asset,
       runtime: systemRelease.runtime,
       upgradeFrom: systemRelease.upgradeFrom,
-      themeContractUpgrade: systemRelease.themeContractUpgrade
+      themeContractUpgrade: systemRelease.themeContractUpgrade,
+      contentModelUpgrade: systemRelease.contentModelUpgrade
     },
     targets
   };
@@ -201,6 +220,9 @@ function normalizeReleaseIntent(input = {}) {
         : {},
       themeContractUpgrade: pressSystem.themeContractUpgrade && typeof pressSystem.themeContractUpgrade === 'object'
         ? pressSystem.themeContractUpgrade
+        : {},
+      contentModelUpgrade: pressSystem.contentModelUpgrade && typeof pressSystem.contentModelUpgrade === 'object'
+        ? pressSystem.contentModelUpgrade
         : {}
     },
     targets: targets.map((target) => {
@@ -296,6 +318,9 @@ function validateReleaseIntent(intentInput, options = {}) {
     }
     if (!themeContractUpgradesMatch(systemRelease.themeContractUpgrade, intent.pressSystem.themeContractUpgrade)) {
       failures.push('release intent themeContractUpgrade must match system-release.json');
+    }
+    if (!contentModelUpgradesMatch(systemRelease.contentModelUpgrade, intent.pressSystem.contentModelUpgrade)) {
+      failures.push('release intent contentModelUpgrade must match system-release.json');
     }
   }
   return failures;

--- a/scripts/test-composer-bootstrap.js
+++ b/scripts/test-composer-bootstrap.js
@@ -8,7 +8,8 @@ import {
   bindComposerWorkspaceUi,
   createComposerBootstrapFeatures,
   initializeComposerApp,
-  initializeComposerOnDomReady
+  initializeComposerOnDomReady,
+  loadInitialComposerState
 } from '../assets/js/composer-bootstrap.js';
 
 class FakeClassList {
@@ -196,6 +197,91 @@ class FakeDocument {
   assert.equal(calls.some(call => call[0] === 'add' && call[1] === 'tabs'), true);
   assert.equal(calls.some(call => call[0] === 'diff' && call[1] === 'tabs'), true);
   assert.equal(calls.some(call => call[0] === 'verify'), true);
+}
+
+{
+  const remoteBaseline = {};
+  const calls = [];
+  const state = await loadInitialComposerState({
+    t: key => key,
+    fetchTrackedSiteConfig: async () => ({ contentRoot: 'docs', siteTitle: 'Legacy' }),
+    applyEffectiveSiteConfig: site => ({ ...site, contentRoot: site.contentRoot || 'wwwroot' }),
+    fetchConfigWithYamlFallback: async (paths) => {
+      calls.push(['fetchConfig', paths]);
+      return {};
+    },
+    loadContentModelMigration: async ({ contentRoot, indexRaw, tabsRaw }) => {
+      calls.push(['contentMigration', contentRoot, indexRaw, tabsRaw]);
+      return {
+        hasLegacyContentModel: true,
+        indexRaw: {
+          Guide: {
+            en: 'posts/guide.md'
+          }
+        },
+        tabsRaw: {
+          Docs: {
+            en: {
+              title: 'Docs',
+              location: 'docs/index.md'
+            }
+          }
+        },
+        legacyFiles: [
+          {
+            kind: 'content-model-migration',
+            path: 'docs/index.en.yaml',
+            deleted: true
+          }
+        ]
+      };
+    },
+    prepareSiteState: value => ({ ...value, preparedSite: true }),
+    prepareIndexState: value => ({ ...value, preparedIndex: true }),
+    prepareTabsState: value => ({ ...value, preparedTabs: true }),
+    cloneSiteState: value => ({ ...value, clonedSite: true }),
+    deepClone: value => JSON.parse(JSON.stringify(value || {})),
+    setRemoteBaseline: (kind, value) => {
+      remoteBaseline[kind] = value;
+    },
+    updateMarkdownPushButton: () => {}
+  });
+
+  assert.deepEqual(
+    calls.find(call => call[0] === 'contentMigration'),
+    ['contentMigration', 'docs', {}, {}],
+    'composer bootstrap should offer the remote unified YAML as migration input'
+  );
+  assert.deepEqual(remoteBaseline.index, { preparedIndex: true });
+  assert.deepEqual(state.index, {
+    Guide: {
+      en: 'posts/guide.md'
+    },
+    preparedIndex: true
+  });
+  assert.deepEqual(state.tabs, {
+    Docs: {
+      en: {
+        title: 'Docs',
+        location: 'docs/index.md'
+      }
+    },
+    preparedTabs: true
+  });
+  assert.equal(
+    Object.keys(state).includes('__contentModelMigration'),
+    false,
+    'content migration metadata should not be enumerable editor state'
+  );
+  assert.deepEqual(state.__contentModelMigration.legacyFiles, [
+    {
+      category: 'legacy-content-model',
+      state: 'deleted',
+      kind: 'content-model-migration',
+      path: 'docs/index.en.yaml',
+      deleted: true
+    }
+  ]);
 }
 
 {

--- a/scripts/test-composer-content-staging.js
+++ b/scripts/test-composer-content-staging.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+import { createContentCommitStagingProvider } from '../assets/js/composer-content-staging.js';
+
+{
+  const provider = createContentCommitStagingProvider({
+    getStateSlice(kind) {
+      if (kind === 'site') return { contentRoot: 'docs' };
+      if (kind === 'index') {
+        return {
+          __order: ['Guide'],
+          Guide: {
+            en: 'posts/guide.md'
+          }
+        };
+      }
+      if (kind === 'tabs') {
+        return {
+          __order: ['Docs'],
+          Docs: {
+            en: {
+              title: 'Docs',
+              location: 'docs/index.md'
+            }
+          }
+        };
+      }
+      return {};
+    },
+    getRemoteBaseline: () => ({
+      site: { contentRoot: 'docs' },
+      index: { __order: [] },
+      tabs: { __order: [] }
+    }),
+    getComposerDiffCache: () => ({
+      index: { hasChanges: true },
+      tabs: { hasChanges: true }
+    }),
+    collectCurrentRepositoryMarkdownAssetReferences: async () => ({ refs: new Set(), failures: [] }),
+    getContentModelMigrationFiles: () => [
+      {
+        kind: 'content-model-migration',
+        label: 'index.en.yaml',
+        path: 'docs/index.en.yaml',
+        deleted: true,
+        state: 'deleted'
+      },
+      {
+        kind: 'content-model-migration',
+        label: 'tabs.en.yaml',
+        path: 'docs/tabs.en.yaml',
+        deleted: true,
+        state: 'deleted'
+      }
+    ],
+    toIndexYaml: () => 'Guide:\n  en: posts/guide.md\n',
+    toTabsYaml: () => 'Docs:\n  en:\n    title: Docs\n    location: docs/index.md\n',
+    enrichIndexStateForPublish: async state => state
+  });
+
+  const files = await provider.getCommitFiles({ cleanupUnusedAssets: false });
+  const byPath = new Map(files.map(file => [file.path, file]));
+  assert.deepEqual(
+    Array.from(byPath.keys()).sort(),
+    [
+      'docs/index.en.yaml',
+      'docs/index.yaml',
+      'docs/tabs.en.yaml',
+      'docs/tabs.yaml'
+    ],
+    'content staging should publish unified YAML and delete legacy sidecars in the same commit'
+  );
+  assert.equal(byPath.get('docs/index.en.yaml').deleted, true);
+  assert.equal(byPath.get('docs/tabs.en.yaml').deleted, true);
+}
+
+console.log('composer content staging tests passed');

--- a/scripts/test-composer-post-commit-state.js
+++ b/scripts/test-composer-post-commit-state.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+
+import { createPostCommitStateApplier } from '../assets/js/composer-post-commit-state.js';
+
+{
+  let cleared = 0;
+  let summaryUpdates = 0;
+  const applier = createPostCommitStateApplier({
+    clearContentModelMigration: () => {
+      cleared += 1;
+    },
+    updateUnsyncedSummary: () => {
+      summaryUpdates += 1;
+    }
+  });
+
+  applier.apply([
+    {
+      kind: 'content-model-migration',
+      path: 'docs/index.en.yaml',
+      deleted: true
+    }
+  ]);
+
+  assert.equal(cleared, 1, 'post-commit state should clear completed content model migration metadata');
+  assert.equal(summaryUpdates, 1);
+}
+
+console.log('composer post-commit state tests passed');

--- a/scripts/test-content-model-migration.js
+++ b/scripts/test-content-model-migration.js
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+
+const {
+  getLegacyContentModelMigrationFiles,
+  loadLegacyContentModelMigration
+} = await import('../assets/js/content-model-migration.js');
+
+function textResponse(text, options = {}) {
+  return {
+    ok: options.ok !== false,
+    status: options.status || (options.ok === false ? 404 : 200),
+    text: async () => String(text || '')
+  };
+}
+
+{
+  const responses = new Map([
+    ['docs/index.en.yaml', 'Guide: posts/guide.md\nLegacy Only:\n  location: posts/legacy.md\n  summary: Kept\n'],
+    ['docs/index.chs.yaml', 'Guide: posts/guide-zh.md\n'],
+    ['docs/tabs.en.yaml', 'Docs: docs/index.md\n'],
+    ['docs/tabs.chs.yaml', 'Docs:\n  title: Docs Zh\n  location: docs/index-zh.md\n']
+  ]);
+  const requests = [];
+
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'chs',
+    languages: ['en', 'chs'],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      requests.push(url);
+      return responses.has(url) ? textResponse(responses.get(url)) : textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.equal(migration.hasLegacyContentModel, true);
+  assert.deepEqual(migration.indexRaw.__order, ['Guide', 'Legacy Only']);
+  assert.deepEqual(migration.indexRaw.Guide, {
+    en: 'posts/guide.md',
+    chs: 'posts/guide-zh.md'
+  });
+  assert.deepEqual(migration.indexRaw['Legacy Only'], {
+    en: {
+      location: 'posts/legacy.md',
+      summary: 'Kept'
+    }
+  });
+  assert.deepEqual(migration.tabsRaw.Docs, {
+    en: {
+      title: 'Docs',
+      location: 'docs/index.md'
+    },
+    chs: {
+      title: 'Docs Zh',
+      location: 'docs/index-zh.md'
+    }
+  });
+  assert.deepEqual(
+    getLegacyContentModelMigrationFiles(migration).map(file => [file.path, file.deleted]),
+    [
+      ['docs/index.en.yaml', true],
+      ['docs/index.chs.yaml', true],
+      ['docs/tabs.en.yaml', true],
+      ['docs/tabs.chs.yaml', true]
+    ]
+  );
+  assert.equal(requests.includes('docs/index.ja.yaml'), true, 'registered/default sidecar languages should still be probed');
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'en',
+    languages: ['en', 'chs'],
+    indexRaw: {
+      __order: ['Guide'],
+      Guide: {
+        en: 'posts/unified.md'
+      }
+    },
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.en.yaml') return textResponse('Guide: posts/legacy-en.md\n');
+      if (url === 'docs/index.chs.yaml') return textResponse('Guide: posts/legacy-zh.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.deepEqual(
+    migration.indexRaw.Guide,
+    {
+      en: 'posts/unified.md',
+      chs: 'posts/legacy-zh.md'
+    },
+    'existing unified language values should win while legacy files fill missing variants'
+  );
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'en',
+    languages: ['en'],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.chs.yaml') return textResponse('指南: posts/guide-zh.md\n');
+      if (url === 'docs/tabs.ja.yaml') return textResponse('案内: docs/guide-ja.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.deepEqual(migration.indexRaw['指南'].chs, 'posts/guide-zh.md');
+  assert.deepEqual(migration.tabsRaw['案内'].ja, {
+    title: '案内',
+    location: 'docs/guide-ja.md'
+  });
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'en',
+    languages: ['en'],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/i18n/languages.json') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ value: 'en' }, { value: 'fr' }]
+        };
+      }
+      if (url === 'docs/index.fr.yaml') return textResponse('Guide FR: posts/guide-fr.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.deepEqual(migration.indexRaw['Guide FR'].fr, 'posts/guide-fr.md');
+  assert.equal(
+    getLegacyContentModelMigrationFiles(migration).some(file => file.path === 'docs/index.fr.yaml'),
+    true,
+    'registered custom language sidecars should be migrated'
+  );
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'chs',
+    defaultLang: 'en',
+    indexRaw: {
+      __order: ['Guide'],
+      Guide: 'posts/guide.md'
+    },
+    tabsRaw: {
+      __order: ['Docs'],
+      Docs: 'docs/index.md'
+    },
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.chs.yaml') return textResponse('指南: posts/guide-zh.md\n');
+      if (url === 'docs/tabs.chs.yaml') return textResponse('文档: docs/index-zh.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.deepEqual(migration.indexRaw.__order, ['Guide']);
+  assert.deepEqual(migration.indexRaw.Guide, {
+    en: 'posts/guide.md',
+    chs: {
+      title: '指南',
+      location: 'posts/guide-zh.md'
+    }
+  });
+  assert.deepEqual(migration.tabsRaw.__order, ['Docs']);
+  assert.deepEqual(migration.tabsRaw.Docs, {
+    en: {
+      title: 'Docs',
+      location: 'docs/index.md'
+    },
+    chs: {
+      title: '文档',
+      location: 'docs/index-zh.md'
+    }
+  });
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'chs',
+    defaultLang: 'en',
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.en.yaml') return textResponse('Guide: posts/guide.md\n');
+      if (url === 'docs/index.chs.yaml') return textResponse('指南: posts/guide.md\n');
+      if (url === 'docs/tabs.en.yaml') return textResponse('Docs: docs/index.md\n');
+      if (url === 'docs/tabs.chs.yaml') return textResponse('文档: docs/index.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.deepEqual(migration.indexRaw.__order, ['Guide']);
+  assert.deepEqual(migration.indexRaw.Guide, {
+    en: 'posts/guide.md',
+    chs: {
+      title: '指南',
+      location: 'posts/guide.md'
+    }
+  });
+  assert.deepEqual(migration.tabsRaw.__order, ['Docs']);
+  assert.deepEqual(migration.tabsRaw.Docs, {
+    en: {
+      title: 'Docs',
+      location: 'docs/index.md'
+    },
+    chs: {
+      title: '文档',
+      location: 'docs/index.md'
+    }
+  });
+}
+
+console.log('content model migration tests passed');

--- a/scripts/test-dispatch-system-release.js
+++ b/scripts/test-dispatch-system-release.js
@@ -93,6 +93,7 @@ test('buildPayload includes release artifact and compatibility metadata', () => 
   assert.equal(payload.asset_size, 1234);
   assert.equal(payload.asset_sha256, 'abc123');
   assert.deepEqual(payload.upgrade_from, system.upgradeFrom);
+  assert.deepEqual(payload.content_model_upgrade, system.contentModelUpgrade || {});
   assert.equal(payload.release_intent.type, 'press-release-intent');
   assert.equal(payload.release_intent.source, `https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/${system.tag}/release-intent.json`);
   assert.equal(payload.release_intent.target_count, 1);

--- a/scripts/test-press-version-runtime.js
+++ b/scripts/test-press-version-runtime.js
@@ -62,12 +62,19 @@ const guardedManifest = normalizePressSystemManifest({
   themeContractUpgrade: {
     requiresInstalledThemeContractVersion: 2,
     message: 'Update installed themes to contract v2 first.'
+  },
+  contentModelUpgrade: {
+    requiresUnifiedIndexTabs: true,
+    message: 'Publish content model migration first.'
   }
 });
 assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 2);
 assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v2 first.');
+assert.equal(guardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, true);
+assert.equal(guardedManifest.contentModelUpgrade.message, 'Publish content model migration first.');
 
 const unguardedManifest = normalizePressSystemManifest(manifest('3.4.122'));
 assert.equal(unguardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 0);
+assert.equal(unguardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, false);
 
 console.log('ok - press system manifest loader state is explicit per instance');

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -485,11 +485,15 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   assert.equal(shouldFailCheck(state, { requireConverged: true }), false);
 });
 
-test('buildProductState preserves theme contract upgrade metadata for release intent validation', async () => {
+test('buildProductState preserves release upgrade metadata for release intent validation', async () => {
   const release = systemRelease();
   release.themeContractUpgrade = {
     requiresInstalledThemeContractVersion: 2,
     message: 'Update installed themes to contract v2 first.'
+  };
+  release.contentModelUpgrade = {
+    requiresUnifiedIndexTabs: true,
+    message: 'Publish content model migration first.'
   };
   const fixtures = makeFixtures({
     'fixture:system': release,
@@ -504,6 +508,7 @@ test('buildProductState preserves theme contract upgrade metadata for release in
 
   assert.equal(state.status, 'ok');
   assert.equal(state.releaseIntent.status, 'ok');
+  assert.deepEqual(state.desired.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
 });
 
 test('buildProductState preserves legacy theme-starter reconciler fallback', async () => {

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -25,6 +25,10 @@ function systemRelease(version = '3.4.62') {
       requiresInstalledThemeContractVersion: 2,
       message: 'Update installed themes to contract v2 first.'
     },
+    contentModelUpgrade: {
+      requiresUnifiedIndexTabs: true,
+      message: 'Publish content model migration first.'
+    },
     runtime: {
       manifestPath: 'assets/press-runtime-manifest.json',
       type: 'press-runtime-assets',
@@ -70,6 +74,7 @@ test('buildReleaseIntent freezes Press release targets and artifact metadata', (
   assert.equal(intent.systemRelease.path, 'system-release.json');
   assert.equal(intent.systemRelease.digest, 'sha256:system');
   assert.deepEqual(intent.pressSystem.themeContractUpgrade, release.themeContractUpgrade);
+  assert.deepEqual(intent.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
   assert.deepEqual(intent.targets.map((target) => target.key), getReleaseTargets().map((target) => target.key));
   assert.equal(intent.targets[0].expected.version, '3.4.62');
   assert.equal(intent.targets[0].observed.source, 'https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json');
@@ -98,6 +103,17 @@ test('validateReleaseIntent compares theme upgrade metadata structurally', () =>
   intent.pressSystem.themeContractUpgrade = {
     message: 'Update installed themes to contract v2 first.',
     requiresInstalledThemeContractVersion: 2
+  };
+
+  assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);
+});
+
+test('validateReleaseIntent compares content-model upgrade metadata structurally', () => {
+  const release = systemRelease();
+  const intent = buildReleaseIntent({ systemRelease: release });
+  intent.pressSystem.contentModelUpgrade = {
+    message: 'Publish content model migration first.',
+    requiresUnifiedIndexTabs: true
   };
 
   assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -383,6 +383,11 @@ if ! grep -F '"themeContractUpgrade": system.get("themeContractUpgrade") or {}' 
   exit 1
 fi
 
+if ! grep -F '"contentModelUpgrade": system.get("contentModelUpgrade") or {}' "${workflow}" >/dev/null; then
+  echo "system release manifest must publish content model upgrade metadata" >&2
+  exit 1
+fi
+
 if ! grep -F '"runtime": {' "${workflow}" >/dev/null || ! grep -F '"edgeCount": len(runtime_edges)' "${workflow}" >/dev/null; then
   echo "system release manifest must publish runtime asset graph summary metadata" >&2
   exit 1
@@ -572,6 +577,11 @@ fi
 
 if ! grep -F 'upgrade_from: system.upgradeFrom || {}' scripts/dispatch-system-release.js >/dev/null; then
   echo "release dispatch orchestrator must pass upgrade compatibility metadata to targets" >&2
+  exit 1
+fi
+
+if ! grep -F 'content_model_upgrade: system.contentModelUpgrade || {}' scripts/dispatch-system-release.js >/dev/null; then
+  echo "release dispatch orchestrator must pass content model upgrade metadata to targets" >&2
   exit 1
 fi
 

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -79,6 +79,21 @@ function jsonResponse(data, options = {}) {
   };
 }
 
+function textResponse(text, options = {}) {
+  const {
+    ok = true,
+    status = ok ? 200 : 404
+  } = options;
+  return {
+    ok,
+    status,
+    headers: { get: () => null },
+    json: async () => ({}),
+    text: async () => String(text || ''),
+    arrayBuffer: async () => new ArrayBuffer(0)
+  };
+}
+
 function arrayBufferResponse(buffer, options = {}) {
   const {
     ok = true,
@@ -1432,6 +1447,147 @@ await run('blocks guarded system updates when theme changes are staged for the s
   await assert.rejects(
     () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
     /staged theme changes|contract v2|v3\.4\.123/i
+  );
+  assert.deepEqual(controller.getCommitFiles(), []);
+  setPressSystemManifestForTests(null);
+});
+
+await run('blocks content-model guarded system updates while legacy sidecar YAML files still exist', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.124',
+    tag: 'v3.4.124',
+    upgradeFrom: { ranges: ['>=3.4.123 <3.4.124'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.125/index.html': '<!doctype html><p>clean content model</p>',
+    'press-system-v3.4.125/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.125',
+      tag: 'v3.4.125',
+      upgradeFrom: {
+        ranges: ['>=3.4.124 <3.4.125'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      contentModelUpgrade: {
+        requiresUnifiedIndexTabs: true,
+        message: 'Open v3.4.124, publish the content model migration, then install v3.4.125.'
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'site.yaml') return textResponse('contentRoot: docs\n');
+      if (url === 'docs/index.en.yaml') return textResponse('Guide: posts/guide.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  await assert.rejects(
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.125.zip'),
+    /content model|publish|index\.en\.yaml|v3\.4\.125/i
+  );
+  assert.deepEqual(controller.getCommitFiles(), []);
+  setPressSystemManifestForTests(null);
+});
+
+await run('blocks content-model guarded system updates for registered custom language sidecars', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.124',
+    tag: 'v3.4.124',
+    upgradeFrom: { ranges: ['>=3.4.123 <3.4.124'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.125/index.html': '<!doctype html><p>clean content model</p>',
+    'press-system-v3.4.125/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.125',
+      tag: 'v3.4.125',
+      upgradeFrom: {
+        ranges: ['>=3.4.124 <3.4.125'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      contentModelUpgrade: {
+        requiresUnifiedIndexTabs: true,
+        message: ''
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'site.yaml') return textResponse('contentRoot: docs\n');
+      if (url === 'assets/i18n/languages.json') {
+        return jsonResponse([{ value: 'en' }, { value: 'fr' }]);
+      }
+      if (url === 'docs/index.fr.yaml') return textResponse('Guide FR: posts/guide-fr.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  await assert.rejects(
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.125.zip'),
+    /content model|publish|index\.fr\.yaml|v3\.4\.125/i
+  );
+  assert.deepEqual(controller.getCommitFiles(), []);
+  setPressSystemManifestForTests(null);
+});
+
+await run('blocks content-model guarded system updates while migrated sidecar deletions are staged but unpublished', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.124',
+    tag: 'v3.4.124',
+    upgradeFrom: { ranges: ['>=3.4.123 <3.4.124'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.125/index.html': '<!doctype html><p>clean content model</p>',
+    'press-system-v3.4.125/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.125',
+      tag: 'v3.4.125',
+      upgradeFrom: {
+        ranges: ['>=3.4.124 <3.4.125'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      contentModelUpgrade: {
+        requiresUnifiedIndexTabs: true,
+        message: ''
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    getStagedContentCommitFiles: () => [
+      {
+        kind: 'content-model-migration',
+        path: 'docs/index.en.yaml',
+        deleted: true
+      }
+    ],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'site.yaml') return textResponse('contentRoot: docs\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  await assert.rejects(
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.125.zip'),
+    /content model|publish|staged|v3\.4\.125/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);


### PR DESCRIPTION
## Summary
- add a temporary legacy content-model migration path that reads index/tabs sidecar YAML and stages unified index.yaml/tabs.yaml plus sidecar deletions
- add contentModelUpgrade metadata plumbing for Press system manifests, release intent, dispatch payloads, product-state, and system-update guards
- bump the transition release manifest to v3.4.124 with upgradeFrom restricted to v3.4.123

## Release rhythm
This PR is the v3.4.124 transition release. It keeps runtime legacy YAML fallback available, but the editor now normalizes legacy sidecars and requires one publish before a future clean release can remove the fallback.

## Verification
- node scripts/test-content-model-migration.js
- node scripts/test-composer-bootstrap.js
- node scripts/test-composer-content-staging.js
- node scripts/test-composer-post-commit-state.js
- node --experimental-default-type=module scripts/test-system-updates.js
- node scripts/test-press-version-runtime.js
- node scripts/test-release-intent.js
- node scripts/test-dispatch-system-release.js
- node scripts/test-product-state-ledger.js
- bash scripts/test-system-release-workflow.sh
- node scripts/test-composer-publish-state-service.js
- node scripts/test-composer-identity-grid.js
- node scripts/test-press-system-surface.mjs
- node scripts/sync-runtime-cache-keys.mjs --check
- bash scripts/test-system-release-package.sh
- Browser smoke: http://127.0.0.1:8000/index_editor.html loaded, composer panels present, current page console error count 0

## Impact
- system release package surface includes the new content-model migration module
- future v3.4.125 can declare contentModelUpgrade.requiresUnifiedIndexTabs to block sites that have not published the migration
