### PR TITLE
Retire legacy content YAML fallback

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -6,7 +6,6 @@
 // - Content i18n supports a single unified YAML with per-language entries and default fallback.
 //   Prefer using one `wwwroot/index.yaml` that stores, per post, a `default` block and optional language blocks
 //   (e.g., `en`, `chs`, `ja`) describing `title` and `location`. Missing languages fall back to `default`.
-//   Legacy per-language files like `index.<lang>.yaml` and `tabs.<lang>.yaml` are also supported.
 // - Friendly language names come from assets/i18n/languages.json (or the language module's metadata).
 
 import { parseFrontMatter } from './content.js';
@@ -614,7 +613,7 @@ function tWithRuntime(runtime, path, vars) {
 
 // (language switcher helpers are defined near the end of the file)
 
-// --- Content loading (unified JSON with fallback, plus legacy support) ---
+// --- Content loading (unified YAML with language fallback) ---
 
 const NORMALIZED_LANG_ALIASES = new Map([
   ['english', 'en'],
@@ -865,8 +864,8 @@ async function loadContentFromFrontMatter(runtime, obj, lang) {
 }
 
 
-// Try to load unified YAML (`base.yaml`) first; if not unified or missing, fallback to legacy
-// per-language files (base.<currentLang>.yaml -> base.<default>.yaml -> base.yaml)
+// Load unified YAML (`base.yaml`) or simplified content mappings. Legacy
+// per-language sidecars are intentionally retired by the content-model clean release.
 async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
   // YAML only (unified or simplified)
   let raw = null;
@@ -914,12 +913,10 @@ async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
         setContentLangs(runtime, availableLangs);
         return { entries, raw };
       }
-      // Not unified; fall through to legacy handling below
     }
-  } catch (_) { /* fall back */ }
+  } catch (_) { /* return empty content */ }
 
-  // Legacy per-language YAML chain
-  return { entries: await loadLangJsonWithRuntime(runtime, basePath, baseName), raw };
+  return { entries: {}, raw };
 }
 
 async function loadContentJsonWithRuntime(runtime, basePath, baseName) {
@@ -970,7 +967,8 @@ function transformUnifiedTabs(runtime, obj, lang) {
   return { entries: out, availableLangs: Array.from(langsSeen).sort() };
 }
 
-// Load tabs in unified format first, then fall back to legacy per-language files
+// Load tabs in unified format only. Legacy per-language sidecars are migrated by
+// the transition editor release and are not read by the clean runtime.
 async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
   try {
     const obj = await fetchConfigWithYamlFallbackForRuntime(runtime, [
@@ -993,8 +991,8 @@ async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
         return entries;
       }
     }
-  } catch (_) { /* fall through */ }
-  return loadLangJsonWithRuntime(runtime, basePath, baseName);
+  } catch (_) { /* return empty tabs */ }
+  return {};
 }
 
 // Ensure lang param is included when generating internal links
@@ -1009,25 +1007,6 @@ function withLangParamWithRuntime(runtime, urlStr) {
     // Fallback: naive append
     const joiner = urlStr.includes('?') ? '&' : '?';
     return `${urlStr}${joiner}lang=${encodeURIComponent(state.currentLang)}`;
-  }
-}
-
-// Try to load JSON for a given base name with lang suffix, falling back in order:
-// base.<currentLang>.json -> base.<default>.json -> base.json
-async function loadLangJsonWithRuntime(runtime, basePath, baseName) {
-  const state = runtime.state;
-  const attempts = [
-    `${basePath}/${baseName}.${state.currentLang}.yaml`,
-    `${basePath}/${baseName}.${state.currentLang}.yml`,
-    `${basePath}/${baseName}.${DEFAULT_LANG}.yaml`,
-    `${basePath}/${baseName}.${DEFAULT_LANG}.yml`,
-    `${basePath}/${baseName}.yaml`,
-    `${basePath}/${baseName}.yml`
-  ];
-  try {
-    return await fetchConfigWithYamlFallbackForRuntime(runtime, attempts);
-  } catch (_) {
-    return {};
   }
 }
 
@@ -1140,9 +1119,6 @@ export function createI18nController(options = {}) {
     withLangParam(urlStr) {
       return withLangParamWithRuntime(runtime, urlStr);
     },
-    loadLangJson(basePath, baseName) {
-      return loadLangJsonWithRuntime(runtime, basePath, baseName);
-    },
     getAvailableLangs() {
       return getAvailableLangsWithRuntime(runtime);
     },
@@ -1196,10 +1172,6 @@ export function loadTabsJson(basePath, baseName) {
 
 export function withLangParam(urlStr) {
   return defaultI18nController.withLangParam(urlStr);
-}
-
-export function loadLangJson(basePath, baseName) {
-  return defaultI18nController.loadLangJson(basePath, baseName);
 }
 
 export function getAvailableLangs() {

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -884,6 +884,10 @@ async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
       // Check if it's a simplified format (just path mappings) or unified format
       for (const k of keys) {
         const v = obj[k];
+        if (isIndexVariantBucket(v)) {
+          isSimplified = true;
+          break;
+        }
         if (v && typeof v === 'object' && !Array.isArray(v)) {
           // Check for simplified/enriched format (language -> path or metadata mapping)
           const innerKeys = Object.keys(v);
@@ -974,7 +978,7 @@ function isFlatTabsEntry(value) {
 
 function transformFlatTabs(obj) {
   const out = {};
-  for (const [title, value] of Object.entries(obj || {})) {
+  for (const [title, value] of Object.entries(obj)) {
     if (typeof value === 'string') {
       const location = value.trim();
       if (location) out[title] = location;

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -967,8 +967,35 @@ function transformUnifiedTabs(runtime, obj, lang) {
   return { entries: out, availableLangs: Array.from(langsSeen).sort() };
 }
 
-// Load tabs in unified format only. Legacy per-language sidecars are migrated by
-// the transition editor release and are not read by the clean runtime.
+function isFlatTabsEntry(value) {
+  if (typeof value === 'string') return !!String(value).trim();
+  return isPlainObject(value) && (value.location != null || value.path != null);
+}
+
+function transformFlatTabs(obj) {
+  const out = {};
+  for (const [title, value] of Object.entries(obj || {})) {
+    if (typeof value === 'string') {
+      const location = value.trim();
+      if (location) out[title] = location;
+      continue;
+    }
+    if (isPlainObject(value)) {
+      const location = value.location != null ? value.location : value.path;
+      if (location == null || !String(location).trim()) continue;
+      out[title] = {
+        ...value,
+        location: String(location).trim()
+      };
+      delete out[title].path;
+    }
+  }
+  return out;
+}
+
+// Load unified tabs YAML and the supported base flat tabs shape. Legacy
+// per-language sidecars are migrated by the transition editor release and are
+// not read by the clean runtime.
 async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
   try {
     const obj = await fetchConfigWithYamlFallbackForRuntime(runtime, [
@@ -978,6 +1005,7 @@ async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
     if (obj && typeof obj === 'object') {
       let isUnified = false;
       for (const [k, v] of Object.entries(obj || {})) {
+        if (isFlatTabsEntry(v)) continue;
         if (v && typeof v === 'object' && !Array.isArray(v)) {
           if ('default' in v) { isUnified = true; break; }
           const inner = Object.keys(v);
@@ -990,6 +1018,7 @@ async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
         setContentLangs(runtime, availableLangs);
         return entries;
       }
+      return transformFlatTabs(obj);
     }
   } catch (_) { /* return empty tabs */ }
   return {};

--- a/assets/main.js
+++ b/assets/main.js
@@ -17,7 +17,6 @@ import {
   initI18n,
   t,
   withLangParam,
-  loadLangJson,
   loadContentJsonWithRaw,
   loadTabsJson,
   getCurrentLang,

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,17 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.124",
-  "tag": "v3.4.124",
+  "version": "3.4.125",
+  "tag": "v3.4.125",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.123 <3.4.124"
+      ">=3.4.124 <3.4.125"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.123 first."
+    "message": "Update to v3.4.124 first and publish the content model migration before installing v3.4.125."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 2,
-    "message": "Update installed themes to contract v2 before installing v3.4.124."
+    "message": "Update installed themes to contract v2 before installing v3.4.125."
+  },
+  "contentModelUpgrade": {
+    "requiresUnifiedIndexTabs": true,
+    "message": "Open v3.4.124, publish the content model migration, then install v3.4.125."
   }
 }

--- a/scripts/test-i18n-content-raw.js
+++ b/scripts/test-i18n-content-raw.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const i18nSource = readFileSync(resolve(here, '../assets/js/i18n.js'), 'utf8');
+const mainSource = readFileSync(resolve(here, '../assets/main.js'), 'utf8');
 
 [
   ['base default language', /^let\s+baseDefaultLang\b/m],
@@ -39,6 +40,11 @@ assert.match(
   i18nSource,
   /async function fetchConfigWithYamlFallbackForRuntime\(runtime, names\)[\s\S]*runtime\.getFetch\(\)\(name, \{ cache: 'no-store' \}\)/,
   'i18n content YAML loading should use the runtime fetch adapter'
+);
+assert.doesNotMatch(
+  mainSource,
+  /\bloadLangJson\b/,
+  'main runtime should not import the retired legacy sidecar loader'
 );
 
 globalThis.document = globalThis.document || {
@@ -169,6 +175,18 @@ globalThis.fetch = async (url) => {
       ].join('\n')
     };
   }
+  if (textUrl.endsWith('/flat-tabs.yaml')) {
+    return {
+      ok: true,
+      text: async () => [
+        'Docs: docs/index.md',
+        'About:',
+        '  location: about.md',
+        '  title: About',
+        ''
+      ].join('\n')
+    };
+  }
   if (textUrl.endsWith('/post/demo.md')) {
     return {
       ok: true,
@@ -256,6 +274,18 @@ assert.equal(
   requests.slice(beforeLegacyTabsRequests).some(url => /legacy-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
   false,
   'clean content runtime should not probe legacy per-language tabs YAML sidecars'
+);
+
+const beforeFlatTabsRequests = requests.length;
+const flatTabs = await loadTabsJson('wwwroot', 'flat-tabs');
+assert.deepEqual(flatTabs, {
+  Docs: 'docs/index.md',
+  About: { location: 'about.md', title: 'About' }
+});
+assert.equal(
+  requests.slice(beforeFlatTabsRequests).some(url => /flat-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
+  false,
+  'clean content runtime should keep base flat tabs without probing legacy per-language tabs YAML sidecars'
 );
 
 const enrichedEntries = await metadataReady;

--- a/scripts/test-i18n-content-raw.js
+++ b/scripts/test-i18n-content-raw.js
@@ -217,6 +217,7 @@ globalThis.fetch = async (url) => {
 const {
   createI18nController,
   initI18n,
+  loadTabsJson,
   loadContentJsonWithRaw,
   getAvailableLangs,
   getContentLangs,
@@ -238,6 +239,24 @@ assert.equal(result.entries.demo.location, 'post/demo.md');
 assert.equal(result.entries.secret.location, 'post/secret.md');
 assert.deepEqual(getContentLangs(), ['en']);
 assert.deepEqual(getAvailableLangs(), ['en', 'chs', 'cht-tw', 'cht-hk', 'ja']);
+
+const beforeLegacyContentRequests = requests.length;
+const legacyContent = await loadContentJsonWithRaw('wwwroot', 'legacy-only');
+assert.deepEqual(legacyContent.entries, {});
+assert.equal(
+  requests.slice(beforeLegacyContentRequests).some(url => /legacy-only\.[a-z0-9-]+\.ya?ml$/i.test(url)),
+  false,
+  'clean content runtime should not probe legacy per-language index YAML sidecars'
+);
+
+const beforeLegacyTabsRequests = requests.length;
+const legacyTabs = await loadTabsJson('wwwroot', 'legacy-tabs');
+assert.deepEqual(legacyTabs, {});
+assert.equal(
+  requests.slice(beforeLegacyTabsRequests).some(url => /legacy-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
+  false,
+  'clean content runtime should not probe legacy per-language tabs YAML sidecars'
+);
 
 const enrichedEntries = await metadataReady;
 assert.equal(enrichedEntries['Secret Title'].protected, true);

--- a/scripts/test-i18n-content-raw.js
+++ b/scripts/test-i18n-content-raw.js
@@ -187,6 +187,15 @@ globalThis.fetch = async (url) => {
       ].join('\n')
     };
   }
+  if (textUrl.endsWith('/flat-index.yaml')) {
+    return {
+      ok: true,
+      text: async () => [
+        'Guide: post/flat.md',
+        ''
+      ].join('\n')
+    };
+  }
   if (textUrl.endsWith('/post/demo.md')) {
     return {
       ok: true,
@@ -196,6 +205,19 @@ globalThis.fetch = async (url) => {
         'date: 2026-04-27',
         '---',
         'Demo body.',
+        ''
+      ].join('\n')
+    };
+  }
+  if (textUrl.endsWith('/post/flat.md')) {
+    return {
+      ok: true,
+      text: async () => [
+        '---',
+        'title: Flat Guide',
+        'date: 2026-05-01',
+        '---',
+        'Flat body.',
         ''
       ].join('\n')
     };
@@ -286,6 +308,16 @@ assert.equal(
   requests.slice(beforeFlatTabsRequests).some(url => /flat-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
   false,
   'clean content runtime should keep base flat tabs without probing legacy per-language tabs YAML sidecars'
+);
+
+const beforeFlatIndexRequests = requests.length;
+const flatIndex = await loadContentJsonWithRaw('wwwroot', 'flat-index');
+assert.deepEqual(flatIndex.raw, { Guide: 'post/flat.md' });
+assert.equal(flatIndex.entries.Guide.location, 'post/flat.md');
+assert.equal(
+  requests.slice(beforeFlatIndexRequests).some(url => /flat-index\.[a-z0-9-]+\.ya?ml$/i.test(url)),
+  false,
+  'clean content runtime should keep base flat index string entries without probing legacy per-language index YAML sidecars'
 );
 
 const enrichedEntries = await metadataReady;


### PR DESCRIPTION
## Summary
- bump the Press system manifest to v3.4.125 with `upgradeFrom` limited to v3.4.124
- add the clean content-model upgrade guard requiring unified index/tabs content before install
- remove runtime fallback reads of legacy per-language `index.<lang>.yaml` and `tabs.<lang>.yaml` sidecars

## Verification
- `node scripts/test-i18n-content-raw.js`
- `node scripts/test-content-model-migration.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node scripts/test-press-version-runtime.js`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node scripts/test-press-system-surface.mjs`
- `node scripts/test-product-state-ledger.js`

## Release impact
- Press system release: yes, v3.4.125 clean content-model release
- Upgrade path: users must install v3.4.124 first and publish the content model migration before v3.4.125
- Starter/theme sync: normal Press system release dispatch after merge
