### PR TITLE
Introduce theme contract v3 transition

### DIFF
--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -238,6 +238,60 @@ function applyPreviewLangHints(container) {
   });
 }
 
+function previewFeatureEnabled(features, key) {
+  if (features && typeof features.isEnabled === 'function') {
+    try { return features.isEnabled(key) !== false; } catch (_) {}
+  }
+  const flags = features && features.flags && typeof features.flags === 'object' ? features.flags : features;
+  if (flags && typeof flags === 'object' && Object.prototype.hasOwnProperty.call(flags, key)) {
+    return flags[key] !== false;
+  }
+  return true;
+}
+
+function previewPostsEnabled(features) {
+  return previewFeatureEnabled(features, 'allPosts');
+}
+
+function previewSearchEnabled(features) {
+  return previewFeatureEnabled(features, 'search');
+}
+
+function resolvePreviewTabsBySlug(payload = {}) {
+  const source = payload.tabsBySlug && typeof payload.tabsBySlug === 'object' && !Array.isArray(payload.tabsBySlug)
+    ? payload.tabsBySlug
+    : {};
+  return source;
+}
+
+function resolvePreviewLandingSlug(payload = {}) {
+  const siteConfig = payload.siteConfig && typeof payload.siteConfig === 'object' ? payload.siteConfig : {};
+  const tabsBySlug = resolvePreviewTabsBySlug(payload);
+  const wanted = String(siteConfig.landingTab || siteConfig.landing || siteConfig.homeTab || siteConfig.home || '').trim().toLowerCase();
+  if (!wanted) return '';
+  if (tabsBySlug[wanted]) return wanted;
+  for (const [slug, info] of Object.entries(tabsBySlug)) {
+    const title = String((info && info.title) || '').trim().toLowerCase();
+    if (title && title === wanted) return slug;
+  }
+  return '';
+}
+
+function getPreviewHomeSlug(payload, features) {
+  const explicit = resolvePreviewLandingSlug(payload);
+  if (explicit) return explicit;
+  if (previewPostsEnabled(features)) return 'posts';
+  return Object.keys(resolvePreviewTabsBySlug(payload))[0] || '';
+}
+
+function getPreviewHomeLabel(payload, features) {
+  const slug = getPreviewHomeSlug(payload, features);
+  if (slug === 'posts') return t('ui.allPosts');
+  if (slug === 'search') return t('ui.searchTab');
+  const tabsBySlug = resolvePreviewTabsBySlug(payload);
+  return (tabsBySlug[slug] && tabsBySlug[slug].title) || slug;
+}
+
 function createRuntimeContext({ payload, containers, content, features }) {
   const layout = themeLayout.getThemeLayoutContext();
   return {
@@ -248,6 +302,10 @@ function createRuntimeContext({ payload, containers, content, features }) {
     router: {
       getRouteKey: () => (payload.currentPath ? `post:${payload.currentPath}` : 'editor-preview'),
       withLangParam,
+      getHomeSlug: () => getPreviewHomeSlug(payload, features),
+      getHomeLabel: () => getPreviewHomeLabel(payload, features),
+      postsEnabled: () => previewPostsEnabled(features),
+      searchEnabled: () => previewSearchEnabled(features),
       navigate() { return false; }
     },
     i18n: createThemeI18nContext(),
@@ -264,7 +322,10 @@ function createRuntimeContext({ payload, containers, content, features }) {
       applyLazyLoadingIn,
       applyLangHints: applyPreviewLangHints,
       renderPostTOC: () => {},
-      renderTagSidebar: renderPreviewTagSidebar,
+      renderTagSidebar: (...args) => {
+        if (!previewFeatureEnabled(features, 'tags') || !previewSearchEnabled(features)) return false;
+        return renderPreviewTagSidebar(...args);
+      },
       setupAnchors: setupPreviewAnchors,
       setupTOC: setupPreviewTOC,
       ensureAutoHeight: (el) => {
@@ -331,6 +392,11 @@ async function renderPreview(payload = {}) {
       ctx,
       content,
       features,
+      getHomeSlug: () => getPreviewHomeSlug(payload, features),
+      getHomeLabel: () => getPreviewHomeLabel(payload, features),
+      postsEnabled: () => previewPostsEnabled(features),
+      searchEnabled: () => previewSearchEnabled(features),
+      withLangParam,
       markdownHtml: output.post,
       tocHtml: output.toc,
       rawMarkdown: markdown,
@@ -355,7 +421,10 @@ async function renderPreview(payload = {}) {
         applyLazyLoadingIn,
         applyLangHints: applyPreviewLangHints,
         renderPostTOC: () => {},
-        renderTagSidebar: renderPreviewTagSidebar,
+        renderTagSidebar: (...args) => {
+          if (!previewFeatureEnabled(features, 'tags') || !previewSearchEnabled(features)) return false;
+          return renderPreviewTagSidebar(...args);
+        },
         getArticleTitleFromMain,
         setupAnchors: setupPreviewAnchors,
         setupTOC: setupPreviewTOC,

--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -14,7 +14,7 @@ const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
 ]);
 const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
 const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([2]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([2, 3]);
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
   '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
   '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'
@@ -24,7 +24,7 @@ const THEME_TEXT_EXTENSIONS = Object.freeze(['.css', '.js', '.json', '.mjs', '.s
 export const PRESS_THEME_CONTRACT = Object.freeze({
   schemaVersion: 1,
   type: 'press-theme-contract',
-  contractVersion: 2,
+  contractVersion: 3,
   supportedContractVersions: SUPPORTED_THEME_CONTRACT_VERSIONS,
   manifestSchemaPath: 'assets/schema/theme.json',
   manifest: Object.freeze({

--- a/assets/main.js
+++ b/assets/main.js
@@ -733,6 +733,27 @@ function getHomeLabel() {
   try { return (tabsBySlug && tabsBySlug[slug] && tabsBySlug[slug].title) || slug; } catch (_) { return slug; }
 }
 
+function createThemeRouterContext() {
+  return {
+    getRouteKey: getCurrentRouteKey,
+    withLangParam,
+    getQueryVariable,
+    getHomeSlug: () => getHomeSlug(),
+    getHomeLabel: () => getHomeLabel(),
+    postsEnabled: () => postsEnabled(),
+    searchEnabled: () => searchEnabled(),
+    navigate(href) {
+      try {
+        history.pushState({}, '', String(href || ''));
+        routeAndRender();
+        return true;
+      } catch (_) {
+        return false;
+      }
+    }
+  };
+}
+
 // Expose a minimal API that other modules can consult if needed
 try { window.__press_get_home_slug = () => getHomeSlug(); } catch (_) {}
 try { window.__press_posts_enabled = () => postsEnabled(); } catch (_) {}
@@ -746,12 +767,16 @@ async function loadSiteConfig() {
 
 function renderSiteLinks(cfg) {
   try {
+    const ctx = createThemeRuntimeContext({ view: 'chrome' });
     callThemeEffect('renderSiteLinks', {
       config: cfg,
+      ctx,
       features: getSiteFeatureContext(),
       getHomeSlug: () => getHomeSlug(),
       getHomeLabel: () => getHomeLabel(),
       postsEnabled: () => postsEnabled(),
+      searchEnabled: () => searchEnabled(),
+      withLangParam,
       document,
       window
     });
@@ -760,9 +785,16 @@ function renderSiteLinks(cfg) {
 
 function renderSiteIdentity(cfg) {
   try {
+    const ctx = createThemeRuntimeContext({ view: 'chrome' });
     callThemeEffect('renderSiteIdentity', {
       config: cfg,
+      ctx,
       features: getSiteFeatureContext(),
+      getHomeSlug: () => getHomeSlug(),
+      getHomeLabel: () => getHomeLabel(),
+      postsEnabled: () => postsEnabled(),
+      searchEnabled: () => searchEnabled(),
+      withLangParam,
       document,
       window
     });
@@ -943,9 +975,11 @@ function enhanceIndexLayout(params = {}) {
 // RenderOutdatedCard moved to ./js/templates.js
 
 function renderTabs(activeSlug, searchQuery) {
+  const ctx = createThemeRuntimeContext({ view: activeSlug || 'nav' });
   callThemeEffect('renderTabs', {
     activeSlug,
     searchQuery,
+    ctx,
     tabsBySlug,
     getHomeSlug: () => getHomeSlug(),
     getHomeLabel: () => getHomeLabel(),
@@ -961,7 +995,9 @@ function renderTabs(activeSlug, searchQuery) {
 
 // Render footer navigation: Home (All Posts) + custom tabs
 function renderFooterNav() {
+  const ctx = createThemeRuntimeContext({ view: 'footer' });
   callThemeEffect('renderFooterNav', {
+    ctx,
     tabsBySlug,
     getHomeSlug: () => getHomeSlug(),
     getHomeLabel: () => getHomeLabel(),
@@ -991,20 +1027,7 @@ function createThemeRuntimeContext({
       key: getCurrentRouteKey(),
       ...route
     },
-    router: {
-      getRouteKey: getCurrentRouteKey,
-      withLangParam,
-      getQueryVariable,
-      navigate(href) {
-        try {
-          history.pushState({}, '', String(href || ''));
-          routeAndRender();
-          return true;
-        } catch (_) {
-          return false;
-        }
-      }
-    },
+    router: createThemeRouterContext(),
     i18n: createThemeI18nContext(),
     features: getSiteFeatureContext(),
     content,
@@ -1372,6 +1395,11 @@ function displayPost(postname, options = {}) {
       postId: postname,
       siteConfig,
       features: getSiteFeatureContext(),
+      getHomeSlug: () => getHomeSlug(),
+      getHomeLabel: () => getHomeLabel(),
+      postsEnabled: () => postsEnabled(),
+      searchEnabled: () => searchEnabled(),
+      withLangParam,
       postsIndex: postsIndexCache,
       postsByLocationTitle,
       allowedLocations,
@@ -1633,7 +1661,9 @@ function displayIndex(parsed) {
     withLangParam,
     translate: t,
     getHomeSlug: () => getHomeSlug(),
+    getHomeLabel: () => getHomeLabel(),
     postsEnabled: () => postsEnabled(),
+    searchEnabled: () => searchEnabled(),
     window,
     document
   });
@@ -1784,7 +1814,9 @@ function displaySearch(query) {
     withLangParam,
     translate: t,
     getHomeSlug: () => getHomeSlug(),
+    getHomeLabel: () => getHomeLabel(),
     postsEnabled: () => postsEnabled(),
+    searchEnabled: () => searchEnabled(),
     window,
     document
   });
@@ -1891,6 +1923,11 @@ function displayStaticTab(slug) {
         slug,
         siteConfig,
         features: getSiteFeatureContext(),
+        getHomeSlug: () => getHomeSlug(),
+        getHomeLabel: () => getHomeLabel(),
+        postsEnabled: () => postsEnabled(),
+        searchEnabled: () => searchEnabled(),
+        withLangParam,
         postsByLocationTitle,
         allowedLocations,
         locationAliasMap,

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.126",
-  "tag": "v3.4.126",
+  "version": "3.4.127",
+  "tag": "v3.4.127",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.125 <3.4.126"
+      ">=3.4.126 <3.4.127"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.125 before installing v3.4.126."
+    "message": "Update to v3.4.126 before installing v3.4.127."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 2,
-    "message": "Update installed themes to contract v2 before installing v3.4.126."
+    "message": "Update installed themes to contract v2 before installing v3.4.127."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.125 and publish the content model migration before installing v3.4.126."
+    "message": "Install v3.4.126 and publish the content model migration before installing v3.4.127."
   }
 }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -23,8 +23,8 @@
     },
     "contractVersion": {
       "type": "integer",
-      "enum": [2],
-      "description": "Press theme contract version this manifest targets. Contract v2 is the current component contract."
+      "enum": [2, 3],
+      "description": "Press theme contract version this manifest targets. Contract v3 is the current public chrome/runtime helper contract; v2 remains accepted during the v3 transition release."
     },
     "engines": {
       "type": "object",

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1361,7 +1361,7 @@ function renderPostViewNative(params = {}, documentRef = defaultDocument, window
     try {
       const titleForMeta = metadataTitle || fallbackTitle;
       topMeta = renderMetaFn(titleForMeta, metadata, markdown, {
-        showTags: featureEnabled(params, runtimeState, 'tags')
+        showTags: featureEnabled(params, runtimeState, 'tags') && featureEnabled(params, runtimeState, 'search')
       }) || '';
       if (topMeta) bottomMeta = topMeta.replace('post-meta-card', 'post-meta-card post-meta-bottom');
     } catch (_) {
@@ -1625,7 +1625,7 @@ function renderIndexViewNative(params = {}, documentRef = defaultDocument, windo
   const translate = getTranslator(params, runtimeState);
   const makeLangUrl = getLangUrlFactory(params, runtimeState, documentRef, windowRef);
   const siteConfig = params.siteConfig || {};
-  const showTags = featureEnabled(params, runtimeState, 'tags');
+  const showTags = featureEnabled(params, runtimeState, 'tags') && featureEnabled(params, runtimeState, 'search');
   const showPostMeta = featureEnabled(params, runtimeState, 'postMeta');
 
   let html = '<div class="index">';

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -25,6 +25,17 @@ function featureEnabled(params = {}, runtimeState = null, key) {
   );
 }
 
+function getRuntimeRouter(params = {}, runtimeState = null) {
+  return (params && params.ctx && params.ctx.router)
+    || (runtimeState && runtimeState.router)
+    || {};
+}
+
+function getRuntimeRouterFunction(params = {}, runtimeState = null, name) {
+  const router = getRuntimeRouter(params, runtimeState);
+  return router && typeof router[name] === 'function' ? router[name] : null;
+}
+
 function getRuntimeLinkCardsCache(runtimeState = null) {
   return runtimeState && typeof runtimeState === 'object' ? runtimeState.linkCards : null;
 }
@@ -177,9 +188,11 @@ function withLangParam(urlStr, runtimeState = null, documentRef = defaultDocumen
 }
 
 function getLangUrlFactory(params = {}, runtimeState = null, documentRef = defaultDocument, windowRef = defaultWindow) {
-  return typeof params.withLangParam === 'function'
+  const routerWithLang = getRuntimeRouterFunction(params, runtimeState, 'withLangParam');
+  return routerWithLang
+    || (typeof params.withLangParam === 'function'
     ? params.withLangParam
-    : (url) => withLangParam(url, runtimeState, documentRef, windowRef);
+    : (url) => withLangParam(url, runtimeState, documentRef, windowRef));
 }
 
 function createNativeInteractionsRuntimeState(context = {}) {
@@ -188,6 +201,7 @@ function createNativeInteractionsRuntimeState(context = {}) {
     i18n: context && context.i18n && typeof context.i18n === 'object' ? context.i18n : null,
     regions: context && context.regions && typeof context.regions === 'object' ? context.regions : null,
     features: context && context.features && typeof context.features === 'object' ? context.features : null,
+    router: context && context.router && typeof context.router === 'object' ? context.router : null,
     hasInitiallyRendered: false,
     pendingHighlightRaf: 0,
     tabsResizeTimer: 0,
@@ -1224,15 +1238,18 @@ function renderFooterNavNative(params = {}, documentRef = defaultDocument, windo
   try { nav.hidden = false; } catch (_) {}
   try { nav.removeAttribute('aria-hidden'); } catch (_) {}
   const tabs = params.tabsBySlug || {};
-  const getHome = typeof params.getHomeSlug === 'function'
+  const getHome = getRuntimeRouterFunction(params, runtimeState, 'getHomeSlug')
+    || (typeof params.getHomeSlug === 'function'
     ? params.getHomeSlug
-    : () => getHomeSlug(tabs, windowRef);
-  const getLabel = typeof params.getHomeLabel === 'function'
+    : () => getHomeSlug(tabs, windowRef));
+  const getLabel = getRuntimeRouterFunction(params, runtimeState, 'getHomeLabel')
+    || (typeof params.getHomeLabel === 'function'
     ? params.getHomeLabel
-    : () => computeHomeLabel(getHome(), tabs, runtimeState);
-  const postsEnabledFn = typeof params.postsEnabled === 'function'
+    : () => computeHomeLabel(getHome(), tabs, runtimeState));
+  const postsEnabledFn = getRuntimeRouterFunction(params, runtimeState, 'postsEnabled')
+    || (typeof params.postsEnabled === 'function'
     ? params.postsEnabled
-    : () => postsEnabled(windowRef);
+    : () => postsEnabled(windowRef));
   const queryGetter = typeof params.getQueryVariable === 'function'
     ? params.getQueryVariable
     : (name) => getQueryVariable(name, windowRef);
@@ -2053,23 +2070,26 @@ function renderTabsNative(params = {}, runtimeState = createNativeInteractionsRu
   const searchQuery = params.searchQuery;
   const translate = getTranslator(params, runtimeState);
 
-  const getHomeFn = typeof params.getHomeSlug === 'function'
+  const getHomeFn = getRuntimeRouterFunction(params, runtimeState, 'getHomeSlug')
+    || (typeof params.getHomeSlug === 'function'
     ? params.getHomeSlug
-    : () => getHomeSlug(tabs, windowRef);
+    : () => getHomeSlug(tabs, windowRef));
   let homeSlugRaw;
   try { homeSlugRaw = getHomeFn(); } catch (_) { homeSlugRaw = getHomeSlug(tabs, windowRef); }
   const safeHome = slugifyTab(homeSlugRaw);
-  const postsEnabledFn = typeof params.postsEnabled === 'function'
+  const postsEnabledFn = getRuntimeRouterFunction(params, runtimeState, 'postsEnabled')
+    || (typeof params.postsEnabled === 'function'
     ? params.postsEnabled
-    : () => postsEnabled(windowRef);
+    : () => postsEnabled(windowRef));
   const homeSlug = safeHome || homeSlugRaw || (postsEnabledFn() ? 'posts' : '');
   if (!homeSlug) {
     setTrackHtml(nav, '', documentRef, windowRef, searchQuery, runtimeState);
     return;
   }
-  const getHomeLabelFn = typeof params.getHomeLabel === 'function'
+  const getHomeLabelFn = getRuntimeRouterFunction(params, runtimeState, 'getHomeLabel')
+    || (typeof params.getHomeLabel === 'function'
     ? params.getHomeLabel
-    : () => computeHomeLabel(homeSlugRaw || homeSlug, tabs, runtimeState);
+    : () => computeHomeLabel(homeSlugRaw || homeSlug, tabs, runtimeState));
   let homeLabel;
   try { homeLabel = getHomeLabelFn(); } catch (_) { homeLabel = computeHomeLabel(homeSlugRaw || homeSlug, tabs, runtimeState); }
   if (!homeLabel) homeLabel = computeHomeLabel(homeSlugRaw || homeSlug, tabs, runtimeState);

--- a/assets/themes/native/theme.json
+++ b/assets/themes/native/theme.json
@@ -1,10 +1,10 @@
 {
   "$schema": "../../schema/theme.json",
   "name": "Native",
-  "version": "3.4.1",
-  "contractVersion": 2,
+  "version": "3.4.2",
+  "contractVersion": 3,
   "engines": {
-    "press": ">=3.4.123 <4.0.0"
+    "press": ">=3.4.127 <4.0.0"
   },
   "styles": [
     "theme.css"

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -2,10 +2,10 @@
   {
     "value": "native",
     "label": "Native",
-    "version": "3.4.1",
-    "contractVersion": 2,
+    "version": "3.4.2",
+    "contractVersion": 3,
     "engines": {
-      "press": ">=3.4.123 <4.0.0"
+      "press": ">=3.4.127 <4.0.0"
     },
     "builtIn": true,
     "removable": false,
@@ -13,7 +13,7 @@
       "type": "builtin"
     },
     "release": {
-      "tag": "v3.4.1"
+      "tag": "v3.4.2"
     },
     "files": [
       "base.css",

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -26,7 +26,7 @@ const SIGNED_URL_QUERY_KEYS = [
   'x-goog-signature'
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([2]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([2, 3]);
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,
   downstream: DEFAULT_RELEASE_SOURCES.downstream,

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -27,6 +27,7 @@ const SIGNED_URL_QUERY_KEYS = [
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
 const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([2, 3]);
+const CURRENT_THEME_CONTRACT_VERSION = 3;
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,
   downstream: DEFAULT_RELEASE_SOURCES.downstream,
@@ -837,7 +838,7 @@ async function buildProductState(options = {}) {
       label: String(entry.label || entry.value || '').trim(),
       repository: String(entry.repo || '').trim(),
       manifestUrl: String(entry.manifestUrl || '').trim(),
-      expectedContractVersion: 1,
+      expectedContractVersion: CURRENT_THEME_CONTRACT_VERSION,
       expectedPressVersion: pressVersion
     }));
     if (!themes.length) {

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -465,7 +465,7 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   assert.equal(state.desired.themeDemos.arcus.reconciler.kind, 'theme-demo-runtime-sync');
   assert.equal(state.desired.themes.catalog.expectedCount, 1);
   assert.equal(state.desired.themes.entries[0].expectedPressVersion, '3.4.51');
-  assert.equal(state.desired.themes.entries[0].expectedContractVersion, 1);
+  assert.equal(state.desired.themes.entries[0].expectedContractVersion, 3);
   assert.equal(state.downstream.yap.status, 'ok');
   assert.equal(state.themeDemos.arcus.status, 'ok');
   assert.equal(state.themes.catalog.status, 'ok');

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -795,6 +795,19 @@ test('buildProductState accepts supported theme contract versions', async () => 
   const state = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
+      'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 3)
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.themes.entries[0].contractVersion, 3);
+  assert.notEqual(state.themes.entries[0].status, 'drift');
+});
+
+test('buildProductState accepts transition theme contract v2', async () => {
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
       'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 2)
     })),
     generatedAt: '2026-05-25T00:00:00Z'

--- a/scripts/test-site-features.js
+++ b/scripts/test-site-features.js
@@ -163,13 +163,13 @@ assert.match(
 const nativeThemeSource = read('assets/themes/native/modules/interactions.js');
 assert.match(
   nativeThemeSource,
-  /const showTags = featureEnabled\(params, runtimeState, 'tags'\);[\s\S]*const tag = showTags && value \? renderTags\(value\.tag\) : '';/,
-  'native index cards should hide tag chips when tags are disabled'
+  /const showTags = featureEnabled\(params, runtimeState, 'tags'\) && featureEnabled\(params, runtimeState, 'search'\);[\s\S]*const tag = showTags && value \? renderTags\(value\.tag\) : '';/,
+  'native index cards should hide tag chips when tags or search are disabled'
 );
 assert.match(
   nativeThemeSource,
-  /renderMetaFn\(titleForMeta, metadata, markdown, \{[\s\S]*showTags: featureEnabled\(params, runtimeState, 'tags'\)/,
-  'native post meta cards should pass the tags feature gate into shared meta rendering'
+  /renderMetaFn\(titleForMeta, metadata, markdown, \{[\s\S]*showTags: featureEnabled\(params, runtimeState, 'tags'\) && featureEnabled\(params, runtimeState, 'search'\)/,
+  'native post meta cards should pass the tags and search feature gates into shared meta rendering'
 );
 assert.match(
   nativeThemeSource,

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -161,11 +161,18 @@ const themeLayoutSource = read(path.join(root, 'assets', 'js', 'theme-layout.js'
 const themeManagerSource = read(path.join(root, 'assets', 'js', 'theme-manager.js'));
 const themePackageCoreSource = read(path.join(root, 'assets', 'js', 'theme-package-core.js'));
 const mainSource = read(path.join(root, 'assets', 'main.js'));
+const editorPreviewRuntimeSource = read(path.join(root, 'assets', 'js', 'editor-preview-runtime.js'));
 const contentModelSource = read(path.join(root, 'assets', 'js', 'content-model.js'));
 const themeContractSource = read(path.join(root, 'wwwroot', 'post', 'theme-contract', 'theme-contract_en.md'));
 
 if (PRESS_THEME_CONTRACT.schemaVersion !== 1 || PRESS_THEME_CONTRACT.type !== 'press-theme-contract') {
   fail('assets/js/theme-contract-surface.mjs must declare the press-theme-contract surface');
+}
+if (PRESS_THEME_CONTRACT.contractVersion !== 3) {
+  fail('assets/js/theme-contract-surface.mjs must declare contractVersion 3 as the current theme contract');
+}
+if (JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions) !== JSON.stringify([2, 3])) {
+  fail('the v3 transition release must support theme contract versions [2, 3]');
 }
 if (PRESS_THEME_CONTRACT.manifestSchemaPath !== 'assets/schema/theme.json') {
   fail('theme contract surface must point at assets/schema/theme.json');
@@ -240,6 +247,29 @@ if (!mainSource.includes('getThemeApiHandler')) {
 if (!/i18n:\s*createThemeI18nContext\(\)/.test(mainSource)) {
   fail('assets/main.js must pass the standard ctx.i18n shape to theme view handlers');
 }
+[
+  ['getHomeSlug', /function createThemeRouterContext\(\)[\s\S]*getHomeSlug:\s*\(\)\s*=>\s*getHomeSlug\(\)/],
+  ['getHomeLabel', /function createThemeRouterContext\(\)[\s\S]*getHomeLabel:\s*\(\)\s*=>\s*getHomeLabel\(\)/],
+  ['postsEnabled', /function createThemeRouterContext\(\)[\s\S]*postsEnabled:\s*\(\)\s*=>\s*postsEnabled\(\)/],
+  ['searchEnabled', /function createThemeRouterContext\(\)[\s\S]*searchEnabled:\s*\(\)\s*=>\s*searchEnabled\(\)/],
+  ['withLangParam', /function createThemeRouterContext\(\)[\s\S]*withLangParam/]
+].forEach(([name, re]) => {
+  if (!re.test(mainSource)) fail(`assets/main.js must expose ctx.router.${name} for contract v3 themes`);
+});
+if (!/router:\s*createThemeRouterContext\(\)/.test(mainSource)) {
+  fail('assets/main.js createThemeRuntimeContext must use the shared v3 router helper context');
+}
+if (!/function renderSiteIdentity[\s\S]*\bctx,?[\s\S]*getHomeSlug:\s*\(\)\s*=>\s*getHomeSlug\(\)[\s\S]*postsEnabled:\s*\(\)\s*=>\s*postsEnabled\(\)[\s\S]*searchEnabled:\s*\(\)\s*=>\s*searchEnabled\(\)/.test(mainSource)) {
+  fail('assets/main.js renderSiteIdentity must pass v3 home/posts/search helpers to theme effects');
+}
+[
+  ['getHomeSlug', /router:\s*\{[\s\S]*getHomeSlug:\s*\(\)\s*=>\s*getPreviewHomeSlug\(payload,\s*features\)/],
+  ['getHomeLabel', /router:\s*\{[\s\S]*getHomeLabel:\s*\(\)\s*=>\s*getPreviewHomeLabel\(payload,\s*features\)/],
+  ['postsEnabled', /router:\s*\{[\s\S]*postsEnabled:\s*\(\)\s*=>\s*previewPostsEnabled\(features\)/],
+  ['searchEnabled', /router:\s*\{[\s\S]*searchEnabled:\s*\(\)\s*=>\s*previewSearchEnabled\(features\)/]
+].forEach(([name, re]) => {
+  if (!re.test(editorPreviewRuntimeSource)) fail(`assets/js/editor-preview-runtime.js must expose ctx.router.${name} for contract v3 themes`);
+});
 if (!/renderPostView[\s\S]*content,[\s\S]*rawMarkdown/.test(mainSource)) {
   fail('assets/main.js must pass the structured content model into post view rendering');
 }

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -73,7 +73,7 @@ async function sha256(buffer) {
 function makeThemeManifest({
   name = 'Test',
   version = '1.0.0',
-  contractVersion = 2,
+  contractVersion = 3,
   engines = { press: '>=3.4.0 <4.0.0' },
   styles = ['theme.css'],
   modules = ['modules/layout.js'],
@@ -110,7 +110,7 @@ function makeThemeManifest({
   };
 }
 
-function makeThemeZip({ slug = 'test', name = 'Test', version = '1.0.0', contractVersion = 2, files = {} } = {}) {
+function makeThemeZip({ slug = 'test', name = 'Test', version = '1.0.0', contractVersion = 3, files = {} } = {}) {
   const manifest = makeThemeManifest({ name, version, contractVersion });
   return makeZip({
     [`press-theme-${slug}/theme.json`]: JSON.stringify(manifest, null, 2),
@@ -520,7 +520,11 @@ await run('normalizes registry and catalog metadata', async () => {
 
 await run('keeps Press repository installed registry native-only', async () => {
   const packs = JSON.parse(readFileSync(new URL('../assets/themes/packs.json', import.meta.url), 'utf8'));
+  const nativeManifest = JSON.parse(readFileSync(new URL('../assets/themes/native/theme.json', import.meta.url), 'utf8'));
   assert.deepEqual(packs.map((entry) => entry.value), ['native']);
+  assert.equal(packs[0].version, nativeManifest.version);
+  assert.equal(packs[0].contractVersion, nativeManifest.contractVersion);
+  assert.equal(packs[0].engines.press, nativeManifest.engines.press);
 });
 
 await run('loads official theme catalog from the remote catalog URL', async () => {
@@ -699,7 +703,7 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
     value: 'arcus',
     label: 'Arcus',
     version: '1.2.3',
-    contractVersion: 2,
+    contractVersion: 3,
     engines: { press: '>=3.4.0 <4.0.0' },
     release: { tag: 'v1.2.3' },
     asset: {
@@ -712,9 +716,10 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
   });
   assert.equal(manifest.value, 'arcus');
   assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
-  assert.equal(manifest.contractVersion, 2);
+  assert.equal(manifest.contractVersion, 3);
+  assert.equal(normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }).contractVersion, 2);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 1 }), /contractVersion/i);
-  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 3 }), /contractVersion/i);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 4 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, engines: {} }), /engines\.press/i);
 });
 
@@ -760,7 +765,7 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
     /contractVersion/i
   );
   assert.throws(
-    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })),
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 4 })),
     /contractVersion/i
   );
 });
@@ -1222,7 +1227,7 @@ await run('failed replacement staging keeps uninstall fallback active', async ()
   assert.equal(themePack, 'native');
   assert(getThemeManagerCommitFiles().some((file) => file.path === 'assets/themes/test/theme.json' && file.deleted));
   await assert.rejects(
-    () => analyzeThemeArchive(makeThemeZip({ slug: 'replacement', contractVersion: 3 }), 'press-theme-replacement-v1.0.0.zip'),
+    () => analyzeThemeArchive(makeThemeZip({ slug: 'replacement', contractVersion: 4 }), 'press-theme-replacement-v1.0.0.zip'),
     /contractVersion/i
   );
   assert.equal(themePack, 'native');
@@ -1250,7 +1255,7 @@ await run('failed import keeps existing uninstall staging active', async () => {
   try {
     await handleImportFile({
       name: 'press-theme-bad-v1.0.0.zip',
-      arrayBuffer: async () => makeThemeZip({ slug: 'bad', contractVersion: 3 })
+      arrayBuffer: async () => makeThemeZip({ slug: 'bad', contractVersion: 4 })
     });
   } finally {
     console.error = originalError;

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -40,9 +40,9 @@ content shapes, and archive file-type rules.
 {
   "$schema": "../../schema/theme.json",
   "name": "Native",
-  "version": "3.4.1",
-  "contractVersion": 2,
-  "engines": { "press": ">=3.4.123 <4.0.0" },
+  "version": "3.4.2",
+  "contractVersion": 3,
+  "engines": { "press": ">=3.4.127 <4.0.0" },
   "styles": ["theme.css"],
   "modules": ["modules/layout.js", "modules/interactions.js", "modules/views.js"],
   "views": {
@@ -71,11 +71,10 @@ content shapes, and archive file-type rules.
 ```
 
 - `name` and `version`: Human-facing theme identity.
-- `contractVersion`: Press runtime contract version. The current and only
-  supported value is `2`. Contract v2 uses the `<press-theme-controls>`
-  component contract. Sites with older contract v1 themes must pass through
-  Press v3.4.122, update installed themes to contract v2, and then install
-  Press v3.4.123 or later.
+- `contractVersion`: Press runtime contract version. Contract v3 is the current
+  public chrome/runtime helper contract. The v3 transition release still accepts
+  v2 themes so sites can install v3-compatible themes before the clean release
+  requires installed themes to declare contract v3.
 - `engines.press`: Press system SemVer range the theme supports. Theme Manager
   rejects official and manually imported themes outside the current Press
   version.
@@ -105,8 +104,8 @@ changes to it through Publish, and Press system updates do not overwrite it.
   "value": "arcus",
   "label": "Arcus",
   "version": "3.4.0",
-  "contractVersion": 2,
-  "engines": { "press": ">=3.4.123 <4.0.0" },
+  "contractVersion": 3,
+  "engines": { "press": ">=3.4.127 <4.0.0" },
   "builtIn": false,
   "removable": true,
   "source": {
@@ -144,9 +143,9 @@ Official theme repositories publish a root `theme-release.json`:
   "type": "press-theme",
   "value": "arcus",
   "label": "Arcus",
-  "version": "3.4.0",
-  "contractVersion": 2,
-  "engines": { "press": ">=3.4.123 <4.0.0" },
+  "version": "3.4.5",
+  "contractVersion": 3,
+  "engines": { "press": ">=3.4.127 <4.0.0" },
   "release": {
     "tag": "v3.4.0",
     "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.0",
@@ -227,7 +226,8 @@ no global adapter object or fixed-ID compatibility layer.
 View render calls receive `ctx` alongside the view payload:
 
 - `ctx.document` and `ctx.window`
-- `ctx.router` with route key, query, language-aware links, and navigation
+- `ctx.router` with route key, query, language-aware links, navigation,
+  `getHomeSlug()`, `getHomeLabel()`, `postsEnabled()`, and `searchEnabled()`
 - `ctx.i18n` with `t`, `withLangParam`, `getCurrentLang`,
   `switchLanguage`, `ensureLanguageBundle`, `getAvailableLangs`,
   `getLanguageLabel`, and current `lang`
@@ -242,6 +242,11 @@ Theme modules must read translation state from `ctx.i18n`. Do not import
 `assets/js/i18n.js` directly from a theme module, with or without a cache
 version query; doing so creates a separate ES module instance and splits the
 runtime language state.
+
+Contract v3 themes must also respect `ctx.features.isEnabled(key)` for public
+chrome. Use runtime helpers for home/posts/search links instead of hard-coding
+article-site assumptions such as a brand link to `?tab=posts`. When search is
+disabled, tag navigation is disabled too.
 
 ## Region Registry
 Theme modules register DOM handles through the registry:

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -147,14 +147,14 @@ Official theme repositories publish a root `theme-release.json`:
   "contractVersion": 3,
   "engines": { "press": ">=3.4.127 <4.0.0" },
   "release": {
-    "tag": "v3.4.0",
-    "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.0",
+    "tag": "v3.4.5",
+    "htmlUrl": "https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.5",
     "publishedAt": "2026-05-07T00:00:00Z",
     "notes": ""
   },
   "asset": {
-    "name": "press-theme-arcus-v3.4.0.zip",
-    "url": "https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/release-artifacts/v3.4.0/press-theme-arcus-v3.4.0.zip",
+    "name": "press-theme-arcus-v3.4.5.zip",
+    "url": "https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/release-artifacts/v3.4.5/press-theme-arcus-v3.4.5.zip",
     "size": 12345,
     "digest": "sha256:..."
   },


### PR DESCRIPTION
## Summary
- Promote the Press theme contract surface to v3 while keeping the transition runtime compatible with v2 and v3 themes.
- Add v3 router/feature helper parity across runtime, editor preview, render hooks, native theme, Theme Manager, and validation surfaces.
- Update native theme metadata, schema, Product State expectations, docs, and release metadata for Press v3.4.127.

## Release sequencing
This is the transition Press release. It must merge and publish before the official v3 theme PRs are merged, because theme release workflows validate against Press main/default contract data.

A follow-up cleanup release should then switch supported contracts to v3-only and raise `themeContractUpgrade.requiresInstalledThemeContractVersion` to `3` after official v3 themes are available.

## Verification
- `node scripts/test-theme-contracts.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node scripts/test-theme-runtime.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node scripts/test-product-state-ledger.js`
- `node scripts/test-site-features.js`
- `node scripts/test-ui-components.js`
- `node scripts/test-search-runtime.js`
- `node scripts/test-official-theme-public-chrome-behavior.mjs`
- `node scripts/test-press-version-runtime.js`
- `node scripts/test-press-system-surface.mjs`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node scripts/sync-runtime-cache-keys.mjs --check`
- Browser smoke: temporary local Press preview with Arcus v3 and all public chrome disabled; no console errors and no visible disabled chrome remnants.
- Subagent review: final Press and official-theme re-review found no actionable findings.