### PR TITLE
[codex] Require theme contract v3 for cleanup release

### DIFF
--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -628,6 +628,93 @@ function getStagedThemeCommitFilesForUpgrade(runtime) {
   }
 }
 
+function isDeletedCommitFile(file) {
+  return !!(file && (file.deleted || file.state === 'deleted' || file.state === 'removed'));
+}
+
+function readStagedCommitFileText(file) {
+  if (!file || isDeletedCommitFile(file) || file.content == null) return '';
+  if (typeof file.content === 'string') return file.content;
+  if (file.content instanceof Uint8Array) return strFromU8(file.content);
+  try {
+    return String(file.content);
+  } catch (_) {
+    return '';
+  }
+}
+
+function stagedThemeSlugFromPath(path) {
+  const match = String(path || '').match(/^assets\/themes\/([^/]+)\/theme\.json$/);
+  return match ? normalizeExternalThemePackSlug(match[1]) : '';
+}
+
+function parseStagedThemeRegistryForUpgrade(stagedThemeFiles, targetVersion, requirement) {
+  const file = (Array.isArray(stagedThemeFiles) ? stagedThemeFiles : [])
+    .find((item) => String(item && item.path || '') === 'assets/themes/packs.json');
+  if (!file) return null;
+  if (isDeletedCommitFile(file)) {
+    createThemeContractUpgradeError(targetVersion, requirement, [], 'registry');
+  }
+  try {
+    const rawRegistry = JSON.parse(readStagedCommitFileText(file));
+    if (!Array.isArray(rawRegistry)) {
+      createThemeContractUpgradeError(targetVersion, requirement, [], 'registry');
+    }
+    return rawRegistry;
+  } catch (_) {
+    createThemeContractUpgradeError(targetVersion, requirement, [], 'registry');
+  }
+}
+
+function collectStagedThemeManifestOverrides(stagedThemeFiles) {
+  const overrides = new Map();
+  for (const file of Array.isArray(stagedThemeFiles) ? stagedThemeFiles : []) {
+    const slug = stagedThemeSlugFromPath(file && file.path);
+    if (!slug) continue;
+    const fallbackLabel = themePackLabelFromSlug(slug) || slug;
+    if (isDeletedCommitFile(file)) {
+      overrides.set(slug, {
+        value: slug,
+        label: fallbackLabel,
+        contractVersion: 0,
+        deleted: true,
+        rawEntry: { value: slug, label: fallbackLabel, contractVersion: 0 }
+      });
+      continue;
+    }
+    let manifest = null;
+    try {
+      manifest = JSON.parse(readStagedCommitFileText(file));
+    } catch (_) {
+      manifest = null;
+    }
+    const label = String((manifest && (manifest.name || manifest.label)) || fallbackLabel).trim() || fallbackLabel;
+    const contractVersion = readContractVersion(manifest && manifest.contractVersion);
+    overrides.set(slug, {
+      value: slug,
+      label,
+      contractVersion,
+      deleted: false,
+      rawEntry: {
+        ...(manifest && typeof manifest === 'object' ? manifest : {}),
+        value: slug,
+        label,
+        contractVersion
+      }
+    });
+  }
+  return overrides;
+}
+
+function collectRemovedStagedThemeSlugs(stagedThemeManifests, rawRegistry) {
+  const removed = new Set();
+  for (const entry of stagedThemeManifests.values()) {
+    if (!entry.deleted) continue;
+    if (!getRawRegistryEntry(rawRegistry, entry.value)) removed.add(entry.value);
+  }
+  return removed;
+}
+
 function getStagedContentCommitFilesForUpgrade(runtime) {
   if (!runtime || typeof runtime.getStagedContentCommitFiles !== 'function') return [];
   try {
@@ -832,27 +919,41 @@ async function assertInstalledThemeContractCompatibility(runtime, release, archi
   if (!requiredVersion) return;
 
   const stagedThemeFiles = getStagedThemeCommitFilesForUpgrade(runtime);
-  if (stagedThemeFiles.length) {
-    createThemeContractUpgradeError(targetVersion, requirement, [{
-      value: 'staged-theme-changes',
-      label: 'staged theme changes',
-      contractVersion: 0
-    }]);
+  let { rawRegistry, registry } = await loadInstalledThemeRegistryForUpgrade(runtime, targetVersion, requirement);
+  const stagedRawRegistry = parseStagedThemeRegistryForUpgrade(stagedThemeFiles, targetVersion, requirement);
+  if (stagedRawRegistry) {
+    rawRegistry = stagedRawRegistry;
+    registry = normalizeThemeRegistry(stagedRawRegistry);
   }
-
-  const { rawRegistry, registry } = await loadInstalledThemeRegistryForUpgrade(runtime, targetVersion, requirement);
+  const stagedThemeManifests = collectStagedThemeManifestOverrides(stagedThemeFiles);
+  const removedStagedThemeSlugs = collectRemovedStagedThemeSlugs(stagedThemeManifests, rawRegistry);
   const candidates = new Map();
   for (const entry of registry) {
     if (!entry || entry.builtIn || entry.value === 'native') continue;
     addThemeContractCandidate(candidates, entry, getRawRegistryEntry(rawRegistry, entry.value));
   }
+  for (const entry of stagedThemeManifests.values()) {
+    if (removedStagedThemeSlugs.has(entry.value)) continue;
+    candidates.set(entry.value, {
+      value: entry.value,
+      label: entry.label,
+      rawEntry: entry.rawEntry,
+      source: 'staged'
+    });
+  }
   collectStoredThemePackCandidates(runtime, candidates);
   await collectConfiguredThemePackCandidates(runtime, candidates);
+  for (const slug of removedStagedThemeSlugs) candidates.delete(slug);
 
   const incompatible = [];
   for (const entry of candidates.values()) {
-    const rawEntry = entry.rawEntry || getRawRegistryEntry(rawRegistry, entry.value);
-    const resolution = await resolveInstalledThemeContractVersion(runtime, entry, rawEntry);
+    const stagedEntry = stagedThemeManifests.get(entry.value);
+    const rawEntry = stagedEntry && !stagedEntry.deleted
+      ? stagedEntry.rawEntry
+      : entry.rawEntry || getRawRegistryEntry(rawRegistry, entry.value);
+    const resolution = stagedEntry
+      ? { installed: true, contractVersion: stagedEntry.deleted ? 0 : stagedEntry.contractVersion }
+      : await resolveInstalledThemeContractVersion(runtime, entry, rawEntry);
     if (!resolution.installed && !rawEntry) continue;
     const contractVersion = resolution.contractVersion;
     if (!contractVersion || contractVersion < requiredVersion) {

--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -14,7 +14,7 @@ const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
 ]);
 const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
 const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([2, 3]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([3]);
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
   '.avif', '.css', '.gif', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
   '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.127",
-  "tag": "v3.4.127",
+  "version": "3.4.128",
+  "tag": "v3.4.128",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.126 <3.4.127"
+      ">=3.4.127 <3.4.128"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.126 before installing v3.4.127."
+    "message": "Update to v3.4.127 before installing v3.4.128."
   },
   "themeContractUpgrade": {
-    "requiresInstalledThemeContractVersion": 2,
-    "message": "Update installed themes to contract v2 before installing v3.4.127."
+    "requiresInstalledThemeContractVersion": 3,
+    "message": "Update installed themes to contract v3 before installing v3.4.128."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.126 and publish the content model migration before installing v3.4.127."
+    "message": "Install v3.4.127 and publish the content model migration before installing v3.4.128."
   }
 }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -23,8 +23,8 @@
     },
     "contractVersion": {
       "type": "integer",
-      "enum": [2, 3],
-      "description": "Press theme contract version this manifest targets. Contract v3 is the current public chrome/runtime helper contract; v2 remains accepted during the v3 transition release."
+      "enum": [3],
+      "description": "Press theme contract version this manifest targets. Contract v3 is the current public chrome/runtime helper contract."
     },
     "engines": {
       "type": "object",

--- a/scripts/link-local-themes.sh
+++ b/scripts/link-local-themes.sh
@@ -47,7 +47,7 @@ const entries = themes.map((slug) => {
     value: slug,
     label: manifest.name || slug,
     version: manifest.version || 'local',
-    contractVersion: manifest.contractVersion || 2,
+    contractVersion: manifest.contractVersion || 3,
     source: {
       type: 'local-dev',
       symlink: `../../Press-Theme-${manifest.name || slug}/theme`

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -26,7 +26,7 @@ const SIGNED_URL_QUERY_KEYS = [
   'x-goog-signature'
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([2, 3]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([3]);
 const CURRENT_THEME_CONTRACT_VERSION = 3;
 const DEFAULT_SOURCES = {
   systemRelease: `${DEFAULT_RAW_ROOT}/${DEFAULT_PRESS_REPOSITORY}/release-artifacts/system-release.json`,

--- a/scripts/test-press-version-runtime.js
+++ b/scripts/test-press-version-runtime.js
@@ -60,16 +60,16 @@ assert.equal((await loadPressSystemManifest({ manifestLoader: secondLoader })).v
 const guardedManifest = normalizePressSystemManifest({
   ...manifest('3.4.123'),
   themeContractUpgrade: {
-    requiresInstalledThemeContractVersion: 2,
-    message: 'Update installed themes to contract v2 first.'
+    requiresInstalledThemeContractVersion: 3,
+    message: 'Update installed themes to contract v3 first.'
   },
   contentModelUpgrade: {
     requiresUnifiedIndexTabs: true,
     message: 'Publish content model migration first.'
   }
 });
-assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 2);
-assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v2 first.');
+assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 3);
+assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v3 first.');
 assert.equal(guardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, true);
 assert.equal(guardedManifest.contentModelUpgrade.message, 'Publish content model migration first.');
 

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -85,7 +85,7 @@ function pressManifest(version = '3.4.51') {
   };
 }
 
-function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 2) {
+function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 3) {
   return {
     schemaVersion: 1,
     type: 'press-theme',
@@ -488,8 +488,8 @@ test('buildProductState reports ok when all declared and observed facts agree', 
 test('buildProductState preserves release upgrade metadata for release intent validation', async () => {
   const release = systemRelease();
   release.themeContractUpgrade = {
-    requiresInstalledThemeContractVersion: 2,
-    message: 'Update installed themes to contract v2 first.'
+    requiresInstalledThemeContractVersion: 3,
+    message: 'Update installed themes to contract v3 first.'
   };
   release.contentModelUpgrade = {
     requiresUnifiedIndexTabs: true,
@@ -804,7 +804,7 @@ test('buildProductState accepts supported theme contract versions', async () => 
   assert.notEqual(state.themes.entries[0].status, 'drift');
 });
 
-test('buildProductState accepts transition theme contract v2', async () => {
+test('buildProductState rejects transition theme contract v2 after cleanup', async () => {
   const state = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
@@ -814,7 +814,9 @@ test('buildProductState accepts transition theme contract v2', async () => {
   });
 
   assert.equal(state.themes.entries[0].contractVersion, 2);
-  assert.notEqual(state.themes.entries[0].status, 'drift');
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themes.entries[0].status, 'drift');
+  assert.match(state.themes.entries[0].problems.join('\n'), /supported contractVersion/);
 });
 
 test('buildProductState rejects legacy theme contract versions', async () => {

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -22,8 +22,8 @@ function systemRelease(version = '3.4.62') {
       allowUnknownSource: false
     },
     themeContractUpgrade: {
-      requiresInstalledThemeContractVersion: 2,
-      message: 'Update installed themes to contract v2 first.'
+      requiresInstalledThemeContractVersion: 3,
+      message: 'Update installed themes to contract v3 first.'
     },
     contentModelUpgrade: {
       requiresUnifiedIndexTabs: true,
@@ -101,8 +101,8 @@ test('validateReleaseIntent compares theme upgrade metadata structurally', () =>
   const release = systemRelease();
   const intent = buildReleaseIntent({ systemRelease: release });
   intent.pressSystem.themeContractUpgrade = {
-    message: 'Update installed themes to contract v2 first.',
-    requiresInstalledThemeContractVersion: 2
+    message: 'Update installed themes to contract v3 first.',
+    requiresInstalledThemeContractVersion: 3
   };
 
   assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -914,25 +914,25 @@ await run('blocks system updates that require newer installed theme contracts', 
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
-        message: 'Update installed themes to contract v2 before installing v3.4.123.'
+        requiresInstalledThemeContractVersion: 3,
+        message: 'Update installed themes to contract v3 before installing v3.4.128.'
       }
     })
   });
@@ -946,15 +946,15 @@ await run('blocks system updates that require newer installed theme contracts', 
         ]);
       }
       if (url === 'assets/themes/arcus/theme.json') {
-        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 1 });
+        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 2 });
       }
       return { ok: false, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /contract v2|Arcus|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /contract v3|Arcus|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
@@ -965,25 +965,25 @@ await run('allows guarded system updates after installed themes reach the requir
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
-        message: 'Update installed themes to contract v2 before installing v3.4.123.'
+        requiresInstalledThemeContractVersion: 3,
+        message: 'Update installed themes to contract v3 before installing v3.4.128.'
       }
     })
   });
@@ -993,14 +993,14 @@ await run('allows guarded system updates after installed themes reach the requir
       if (url === 'assets/themes/packs.json') {
         return jsonResponse([
           { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-          { value: 'arcus', label: 'Arcus', version: '3.4.3', contractVersion: 2, files: ['theme.json'] }
+          { value: 'arcus', label: 'Arcus', version: '3.4.3', contractVersion: 3, files: ['theme.json'] }
         ]);
       }
       return { ok: false, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
-  await controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip');
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip');
   assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
     'assets/press-system.json',
     'index.html'
@@ -1013,24 +1013,24 @@ await run('ignores stale stored theme packs that are no longer installed', async
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1052,7 +1052,7 @@ await run('ignores stale stored theme packs that are no longer installed', async
     }
   });
 
-  await controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip');
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip');
   assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
     'assets/press-system.json',
     'index.html'
@@ -1065,24 +1065,24 @@ await run('uses current staged site theme pack instead of persisted site yaml fo
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1105,13 +1105,13 @@ await run('uses current staged site theme pack instead of persisted site yaml fo
         };
       }
       if (url === 'assets/themes/arcus/theme.json') {
-        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 1 });
+        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 2 });
       }
       return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
-  await controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip');
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip');
   assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
     'assets/press-system.json',
     'index.html'
@@ -1124,24 +1124,24 @@ await run('blocks guarded system updates when current staged site theme is legac
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1164,15 +1164,15 @@ await run('blocks guarded system updates when current staged site theme is legac
         };
       }
       if (url === 'assets/themes/arcus/theme.json') {
-        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 1 });
+        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 2 });
       }
       return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /Arcus|contract v1|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /Arcus|contract v2|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
@@ -1183,19 +1183,19 @@ await run('uses release theme contract guard when archive manifest omits it', as
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       }
@@ -1204,24 +1204,24 @@ await run('uses release theme contract guard when archive manifest omits it', as
   const digest = await sha256(buffer);
   const releaseManifest = {
     schemaVersion: 1,
-    name: 'v3.4.123',
-    tag: 'v3.4.123',
-    version: '3.4.123',
+    name: 'v3.4.128',
+    tag: 'v3.4.128',
+    version: '3.4.128',
     publishedAt: '2026-06-06T16:00:00Z',
     notes: 'Release notes',
     upgradeFrom: {
-      ranges: ['>=3.4.122 <3.4.123'],
+      ranges: ['>=3.4.127 <3.4.128'],
       allowUnknownSource: false,
       message: ''
     },
     themeContractUpgrade: {
-      requiresInstalledThemeContractVersion: 2,
+      requiresInstalledThemeContractVersion: 3,
       message: ''
     },
-    htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.4.123',
+    htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.4.128',
     asset: {
-      name: 'press-system-v3.4.123.zip',
-      url: 'https://github.com/EkilyHQ/Press/releases/download/v3.4.123/press-system-v3.4.123.zip',
+      name: 'press-system-v3.4.128.zip',
+      url: 'https://github.com/EkilyHQ/Press/releases/download/v3.4.128/press-system-v3.4.128.zip',
       size: buffer.byteLength,
       digest: `sha256:${digest}`
     }
@@ -1233,7 +1233,7 @@ await run('uses release theme contract guard when archive manifest omits it', as
       if (url === 'assets/themes/packs.json') {
         return jsonResponse([
           { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
-          { value: 'arcus', label: 'Arcus', version: '3.4.2', contractVersion: 1, files: ['theme.json'] }
+          { value: 'arcus', label: 'Arcus', version: '3.4.2', contractVersion: 2, files: ['theme.json'] }
         ]);
       }
       return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
@@ -1241,8 +1241,8 @@ await run('uses release theme contract guard when archive manifest omits it', as
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /Arcus|contract v1|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /Arcus|contract v2|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
@@ -1253,24 +1253,24 @@ await run('blocks guarded system updates when installed theme registry is malfor
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1286,8 +1286,8 @@ await run('blocks guarded system updates when installed theme registry is malfor
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /verify installed themes|packs\.json|contract v2/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /verify installed themes|packs\.json|contract v3/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
@@ -1298,24 +1298,24 @@ await run('blocks guarded system updates when active external theme is missing f
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1337,15 +1337,15 @@ await run('blocks guarded system updates when active external theme is missing f
         };
       }
       if (url === 'assets/themes/arcus/theme.json') {
-        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 1 });
+        return jsonResponse({ name: 'Arcus', version: '3.4.2', contractVersion: 2 });
       }
       return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /Arcus|contract v1|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /Arcus|contract v2|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
@@ -1356,24 +1356,24 @@ await run('blocks guarded system updates when pending external theme is missing 
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1392,43 +1392,43 @@ await run('blocks guarded system updates when pending external theme is missing 
         ]);
       }
       if (url === 'assets/themes/solstice/theme.json') {
-        return jsonResponse({ name: 'Solstice', version: '3.4.2', contractVersion: 1 });
+        return jsonResponse({ name: 'Solstice', version: '3.4.2', contractVersion: 2 });
       }
       return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
     }
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /Solstice|contract v1|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /Solstice|contract v2|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
   setPressSystemManifestForTests(null);
 });
 
-await run('blocks guarded system updates when theme changes are staged for the same publish', async () => {
+await run('blocks guarded system updates when staged theme changes are below the required contract', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   setPressSystemManifestForTests({
     schemaVersion: 1,
     type: 'press-system',
-    version: '3.4.122',
-    tag: 'v3.4.122',
-    upgradeFrom: { ranges: ['>=3.4.121 <3.4.122'], allowUnknownSource: false, message: '' }
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
   });
   const buffer = makeZip({
-    'press-system-v3.4.123/index.html': '<!doctype html><p>guarded</p>',
-    'press-system-v3.4.123/assets/press-system.json': JSON.stringify({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
       schemaVersion: 1,
       type: 'press-system',
-      version: '3.4.123',
-      tag: 'v3.4.123',
+      version: '3.4.128',
+      tag: 'v3.4.128',
       upgradeFrom: {
-        ranges: ['>=3.4.122 <3.4.123'],
+        ranges: ['>=3.4.127 <3.4.128'],
         allowUnknownSource: false,
         message: ''
       },
       themeContractUpgrade: {
-        requiresInstalledThemeContractVersion: 2,
+        requiresInstalledThemeContractVersion: 3,
         message: ''
       }
     })
@@ -1437,18 +1437,155 @@ await run('blocks guarded system updates when theme changes are staged for the s
     getStagedThemeCommitFiles: () => [
       {
         path: 'assets/themes/test/theme.json',
-        content: JSON.stringify({ name: 'Test', version: '1.0.0', contractVersion: 1 }),
+        content: JSON.stringify({ name: 'Test', version: '1.0.0', contractVersion: 2 }),
         state: 'added'
       }
     ],
-    fetchImpl: async () => ({ ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) })
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/themes/packs.json') {
+        return jsonResponse([
+          { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] }
+        ]);
+      }
+      return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
+    }
   });
 
   await assert.rejects(
-    () => controller.analyzeArchive(buffer, 'press-system-v3.4.123.zip'),
-    /staged theme changes|contract v2|v3\.4\.123/i
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip'),
+    /Test|contract v2|v3\.4\.128/i
   );
   assert.deepEqual(controller.getCommitFiles(), []);
+  setPressSystemManifestForTests(null);
+});
+
+await run('allows guarded system updates when staged theme changes reach the required contract', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.128',
+      tag: 'v3.4.128',
+      upgradeFrom: {
+        ranges: ['>=3.4.127 <3.4.128'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      themeContractUpgrade: {
+        requiresInstalledThemeContractVersion: 3,
+        message: ''
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    getStagedThemeCommitFiles: () => [
+      {
+        path: 'assets/themes/test/theme.json',
+        content: JSON.stringify({ name: 'Test', version: '1.0.0', contractVersion: 3 }),
+        state: 'modified'
+      }
+    ],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/themes/packs.json') {
+        return jsonResponse([
+          { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
+          { value: 'test', label: 'Test', version: '0.9.0', contractVersion: 2, files: ['theme.json'] }
+        ]);
+      }
+      return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+  });
+
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip');
+  assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
+    'assets/press-system.json',
+    'index.html'
+  ]);
+  setPressSystemManifestForTests(null);
+});
+
+await run('allows guarded system updates when staged theme uninstall removes stale stored packs', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.127',
+    tag: 'v3.4.127',
+    upgradeFrom: { ranges: ['>=3.4.126 <3.4.127'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.128/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.128/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.128',
+      tag: 'v3.4.128',
+      upgradeFrom: {
+        ranges: ['>=3.4.127 <3.4.128'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      themeContractUpgrade: {
+        requiresInstalledThemeContractVersion: 3,
+        message: ''
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    localStorageRef: {
+      getItem(key) {
+        return key === 'themePack' || key === 'themePackPending' ? 'test' : '';
+      }
+    },
+    getStagedThemeCommitFiles: () => [
+      {
+        path: 'assets/themes/packs.json',
+        content: JSON.stringify([{ value: 'native', label: 'Native', builtIn: true, removable: false, files: [] }]),
+        state: 'modified'
+      },
+      {
+        path: 'assets/themes/test/theme.json',
+        content: '',
+        state: 'deleted',
+        deleted: true
+      }
+    ],
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/themes/packs.json') {
+        return jsonResponse([
+          { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
+          { value: 'test', label: 'Test', version: '0.9.0', contractVersion: 2, files: ['theme.json'] }
+        ]);
+      }
+      if (url === 'site.yaml') {
+        return {
+          ok: true,
+          text: async () => 'contentRoot: wwwroot\nthemePack: test\n',
+          json: async () => ({}),
+          arrayBuffer: async () => new ArrayBuffer(0)
+        };
+      }
+      return { ok: false, json: async () => ({}), text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+  });
+
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.128.zip');
+  assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
+    'assets/press-system.json',
+    'index.html'
+  ]);
   setPressSystemManifestForTests(null);
 });
 

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -171,8 +171,8 @@ if (PRESS_THEME_CONTRACT.schemaVersion !== 1 || PRESS_THEME_CONTRACT.type !== 'p
 if (PRESS_THEME_CONTRACT.contractVersion !== 3) {
   fail('assets/js/theme-contract-surface.mjs must declare contractVersion 3 as the current theme contract');
 }
-if (JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions) !== JSON.stringify([2, 3])) {
-  fail('the v3 transition release must support theme contract versions [2, 3]');
+if (JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions) !== JSON.stringify([3])) {
+  fail('the v3 cleanup release must support only theme contract version 3');
 }
 if (PRESS_THEME_CONTRACT.manifestSchemaPath !== 'assets/schema/theme.json') {
   fail('theme contract surface must point at assets/schema/theme.json');

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -664,10 +664,10 @@ await run('renders product-state release metadata for official themes', async ()
   assert.match(availableText, /release ok v1\.2\.3/);
 });
 
-await run('renders installed v1 themes as contract migration candidates', async () => {
+await run('renders installed legacy themes as contract migration candidates', async () => {
   const documentRef = makeThemeManagerDocument();
   mockFetchRegistry([
-    { value: 'native', label: 'Native', builtIn: true, removable: false, contractVersion: 2, files: [] },
+    { value: 'native', label: 'Native', builtIn: true, removable: false, contractVersion: 3, files: [] },
     { value: 'arcus', label: 'Arcus', version: '3.4.2', contractVersion: 1, files: ['theme.json'] },
     { value: 'legacy', label: 'Legacy', version: '0.9.0', files: ['theme.json'] },
     { value: 'cartograph', label: 'Cartograph', version: '3.4.3', contractVersion: 2, files: ['theme.json'] }
@@ -696,7 +696,7 @@ await run('renders installed v1 themes as contract migration candidates', async 
   assert.match(installedText, /contract v2/i);
 });
 
-await run('normalizes release manifests and rejects contract mismatch', async () => {
+await run('normalizes release manifests and rejects unsupported contracts', async () => {
   const manifest = normalizeThemeReleaseManifest({
     schemaVersion: 1,
     type: 'press-theme',
@@ -717,7 +717,7 @@ await run('normalizes release manifests and rejects contract mismatch', async ()
   assert.equal(manifest.value, 'arcus');
   assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
   assert.equal(manifest.contractVersion, 3);
-  assert.equal(normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }).contractVersion, 2);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 1 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 4 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, engines: {} }), /engines\.press/i);
@@ -730,21 +730,21 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      '../theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
+      '../theme.json': '{"name":"Test","version":"1.0.0","contractVersion":3}',
       '../theme.css': 'body{}'
     })),
     /unsafe/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      './theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
+      './theme.json': '{"name":"Test","version":"1.0.0","contractVersion":3}',
       './theme.css': 'body{}'
     })),
     /unsafe/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      'press-theme-test/theme.json': '{"name":"Test","version":"1.0.0","contractVersion":2}',
+      'press-theme-test/theme.json': '{"name":"Test","version":"1.0.0","contractVersion":3}',
       'press-theme-test/modules//layout.js': 'export {};'
     })),
     /unsafe/i
@@ -755,10 +755,14 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeZip({
-      'arcus/theme.json': '{"name":"Arcus","contractVersion":2}',
-      'solstice/theme.json': '{"name":"Solstice","contractVersion":2}'
+      'arcus/theme.json': '{"name":"Arcus","contractVersion":3}',
+      'solstice/theme.json': '{"name":"Solstice","contractVersion":3}'
     })),
     /theme\.json|single|root/i
+  );
+  assert.throws(
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 2 })),
+    /contractVersion/i
   );
   assert.throws(
     () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 1 })),
@@ -777,7 +781,7 @@ await run('rejects invalid theme manifests before staging', async () => {
       'press-theme-bad/theme.json': JSON.stringify({
         name: 'Bad',
         version: '1.0.0',
-        contractVersion: 2,
+        contractVersion: 3,
         styles: ['theme.css']
       }, null, 2),
       'press-theme-bad/theme.css': ':root{}'
@@ -854,7 +858,7 @@ await run('blocks official theme releases outside the current Press engine range
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 2,
+        contractVersion: 3,
         engines: { press: '>=4.0.0 <5.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
@@ -1167,7 +1171,7 @@ await run('filters catalog-inferred inventory to existing files during uninstall
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 2,
+        contractVersion: 3,
         engines: { press: '>=3.4.0 <4.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -170,7 +170,7 @@ function makeManifest(pack, modules) {
   return {
     name: pack,
     version: '1.0.0',
-    contractVersion: 2,
+    contractVersion: 3,
     styles: ['theme.css', 'extra.css'],
     modules,
     views: { post: {}, posts: {}, search: {}, tab: {} },

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -72,9 +72,8 @@ content shapes, and archive file-type rules.
 
 - `name` and `version`: Human-facing theme identity.
 - `contractVersion`: Press runtime contract version. Contract v3 is the current
-  public chrome/runtime helper contract. The v3 transition release still accepts
-  v2 themes so sites can install v3-compatible themes before the clean release
-  requires installed themes to declare contract v3.
+  and only supported public chrome/runtime helper contract. Press rejects new
+  imports and official releases that declare older contract versions.
 - `engines.press`: Press system SemVer range the theme supports. Theme Manager
   rejects official and manually imported themes outside the current Press
   version.


### PR DESCRIPTION
## Summary

- Make the Press theme contract cleanup release v3-only by changing the shared contract surface and schema to support only `contractVersion: 3`.
- Bump the Press system manifest to `v3.4.128`, requiring source `v3.4.127` and installed theme contract v3 before update.
- Keep the update guard usable for same-publish theme remediation: staged v3 theme updates can pass, and staged v2 theme uninstalls are not resurrected by stale browser theme state.
- Update Theme Manager, Product State, release-intent, runtime, docs, and focused tests for the v3-only cleanup contract.

## Release impact

This is the cleanup release after the v3 transition. Press will reject new v2 theme imports/releases and will block system updates when installed/current/pending/staged external themes remain below contract v3. Official v3 themes keep their existing `engines.press >=3.4.127 <4.0.0` compatibility floor.

## Review

Local subagent review found and then cleared P2 issues around staged v3 updates and staged v2 uninstalls with stale localStorage/site config. Final subagent review reported no actionable P1/P2 findings on commit `9ad9a741`.

## Verification

- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-theme-contracts.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-theme-manager.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-system-updates.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-press-version-runtime.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-intent.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-product-state-ledger.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-runtime.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-ui-components.js`
- `bash scripts/test-main-guard.sh`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-package.sh`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-workflow.sh`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/sync-runtime-cache-keys.mjs --check`
- `git diff --check`
