### PR TITLE
Harden Annotate grants and profile links

### DIFF
--- a/assets/js/annotate.js
+++ b/assets/js/annotate.js
@@ -1,6 +1,6 @@
 const ANNOTATE_SECTION_ID = 'press-annotate-comments';
 const STYLE_ID = 'press-annotate-style';
-const GRANT_STORAGE_PREFIX = 'press_annotate_grant_v1:';
+const GRANT_STORAGE_PREFIX = 'press_annotate_grant_v2:';
 
 function asObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
@@ -138,14 +138,25 @@ export function buildAnnotateCommentsUrl(config, context) {
   });
 }
 
-function getGrantStorageKey(config) {
-  const repo = (config && config.repository) || {};
-  return `${GRANT_STORAGE_PREFIX}${repo.owner || ''}/${repo.name || ''}`;
+function resolveAnnotateSourceKey(windowRef) {
+  try {
+    const href = windowRef && windowRef.location && windowRef.location.href;
+    const url = new URL(href);
+    url.hash = '';
+    return url.href;
+  } catch (_) {
+    return '';
+  }
 }
 
-function readStoredGrant(windowRef, config) {
+function getGrantStorageKey(config, sourceKey = '') {
+  const repo = (config && config.repository) || {};
+  return `${GRANT_STORAGE_PREFIX}${repo.owner || ''}/${repo.name || ''}:${sourceKey || 'unknown-source'}`;
+}
+
+function readStoredGrant(windowRef, config, sourceKey = '') {
   try {
-    const raw = windowRef.localStorage.getItem(getGrantStorageKey(config));
+    const raw = windowRef.localStorage.getItem(getGrantStorageKey(config, sourceKey));
     if (!raw) return '';
     const parsed = JSON.parse(raw);
     return normalizeGrantToken(parsed && parsed.grant);
@@ -154,22 +165,63 @@ function readStoredGrant(windowRef, config) {
   }
 }
 
-function writeStoredGrant(windowRef, config, grant) {
+function writeStoredGrant(windowRef, config, grant, sourceKey = '') {
   try {
     const token = normalizeGrantToken(grant);
     if (!token) return;
-    windowRef.localStorage.setItem(getGrantStorageKey(config), JSON.stringify({ grant: token, savedAt: Date.now() }));
+    windowRef.localStorage.setItem(getGrantStorageKey(config, sourceKey), JSON.stringify({ grant: token, savedAt: Date.now() }));
   } catch (_) {}
 }
 
-function clearStoredGrant(windowRef, config) {
-  try { windowRef.localStorage.removeItem(getGrantStorageKey(config)); } catch (_) {}
+function clearStoredGrant(windowRef, config, sourceKey = '') {
+  try { windowRef.localStorage.removeItem(getGrantStorageKey(config, sourceKey)); } catch (_) {}
+}
+
+function annotateRequestInit(init = {}, grant = '') {
+  const headers = {
+    ...(init.headers || {})
+  };
+  const token = normalizeGrantToken(grant);
+  if (token) headers.authorization = `Bearer ${token}`;
+  return {
+    ...init,
+    headers,
+    referrerPolicy: 'unsafe-url'
+  };
 }
 
 export function normalizeGrantToken(grant) {
   if (typeof grant === 'string') return grant.trim();
   if (asObject(grant)) return asTrimmedString(grant.token);
   return '';
+}
+
+async function responseErrorCode(response) {
+  try {
+    if (!response || typeof response.json !== 'function') return '';
+    const data = await response.json();
+    return asTrimmedString(data && data.error && data.error.code);
+  } catch (_) {
+    return '';
+  }
+}
+
+function shouldRetryAnnotateReadWithoutGrant(response, code) {
+  if (!response) return false;
+  if (response.status === 401) return true;
+  if ([400, 403].includes(response.status)) {
+    return ['invalid_source', 'source_mismatch', 'origin_mismatch'].includes(code);
+  }
+  return false;
+}
+
+function shouldClearAnnotateGrant(response, code) {
+  if (!response) return false;
+  if (response.status === 401) return true;
+  if ([400, 403].includes(response.status)) {
+    return ['invalid_source', 'source_mismatch', 'origin_mismatch'].includes(code);
+  }
+  return false;
 }
 
 function injectAnnotateStyle(documentRef) {
@@ -198,10 +250,23 @@ function injectAnnotateStyle(documentRef) {
   } catch (_) {}
 }
 
+function disposeAnnotateSection(section) {
+  try {
+    if (!section || typeof section.__pressAnnotateDispose !== 'function') return;
+    const dispose = section.__pressAnnotateDispose;
+    section.__pressAnnotateDispose = null;
+    dispose();
+  } catch (_) {}
+}
+
 function removeExistingSection(container) {
   try {
+    disposeAnnotateSection(container);
     const existing = container.querySelector(`#${ANNOTATE_SECTION_ID}`);
-    if (existing) existing.remove();
+    if (existing) {
+      disposeAnnotateSection(existing);
+      existing.remove();
+    }
   } catch (_) {}
 }
 
@@ -273,6 +338,7 @@ export function mountAnnotateComments(options = {}) {
   if (!context.articleKey || !context.location) return null;
   const fetchImpl = options.fetchImpl || windowRef.fetch;
   if (typeof fetchImpl !== 'function') return null;
+  const sourceKey = resolveAnnotateSourceKey(windowRef);
 
   injectAnnotateStyle(documentRef);
   const section = documentRef.createElement('section');
@@ -300,7 +366,7 @@ export function mountAnnotateComments(options = {}) {
   section.appendChild(list);
 
   const state = {
-    grant: readStoredGrant(windowRef, config),
+    grant: readStoredGrant(windowRef, config, sourceKey),
     comments: []
   };
 
@@ -326,13 +392,23 @@ export function mountAnnotateComments(options = {}) {
         'content-type': 'application/json',
         authorization: `Bearer ${state.grant}`
       },
+      referrerPolicy: 'unsafe-url',
       body: JSON.stringify(payload)
     });
     if (response.status === 401) {
-      clearStoredGrant(windowRef, config);
+      clearStoredGrant(windowRef, config, sourceKey);
       state.grant = '';
       setStatus('Session expired. Sign in again.');
       return false;
+    }
+    if (!response.ok) {
+      const code = await responseErrorCode(response);
+      if (shouldClearAnnotateGrant(response, code)) {
+        clearStoredGrant(windowRef, config, sourceKey);
+        state.grant = '';
+        setStatus('Sign in again from this page.');
+        return false;
+      }
     }
     if (!response.ok) {
       setStatus('Comment failed to post.');
@@ -370,7 +446,23 @@ export function mountAnnotateComments(options = {}) {
   async function loadComments() {
     setStatus('Loading comments...');
     try {
-      const response = await fetchImpl(buildAnnotateCommentsUrl(config, context), { method: 'GET' });
+      let response = await fetchImpl(
+        buildAnnotateCommentsUrl(config, context),
+        annotateRequestInit({ method: 'GET' }, state.grant)
+      );
+      if (state.grant && !response.ok) {
+        const code = await responseErrorCode(response);
+        if (shouldRetryAnnotateReadWithoutGrant(response, code)) {
+          clearStoredGrant(windowRef, config, sourceKey);
+          state.grant = '';
+          response = await fetchImpl(buildAnnotateCommentsUrl(config, context), annotateRequestInit({ method: 'GET' }));
+        }
+      }
+      if (response.status === 401 && state.grant) {
+        clearStoredGrant(windowRef, config, sourceKey);
+        state.grant = '';
+        response = await fetchImpl(buildAnnotateCommentsUrl(config, context), annotateRequestInit({ method: 'GET' }));
+      }
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = await response.json();
       state.comments = Array.isArray(data && data.comments) ? data.comments : [];
@@ -391,13 +483,27 @@ export function mountAnnotateComments(options = {}) {
       category: config.discussionCategory,
       articleKey: context.articleKey
     });
-    const popup = windowRef.open(url, 'press-annotate-login', 'popup,width=520,height=720');
+    const popupName = 'press-annotate-login';
+    const popup = windowRef.open('', popupName, 'popup,width=520,height=720');
     if (!popup) setStatus('Allow popups to sign in with GitHub.');
+    else if (documentRef && typeof documentRef.createElement === 'function' && documentRef.body) {
+      const link = documentRef.createElement('a');
+      link.href = url;
+      link.target = popupName;
+      link.referrerPolicy = 'unsafe-url';
+      link.rel = 'opener';
+      try { link.style.display = 'none'; } catch (_) {}
+      documentRef.body.appendChild(link);
+      link.click();
+      link.remove();
+    } else {
+      try { popup.location.href = url; } catch (_) {}
+    }
   });
 
   refreshButton.addEventListener('click', () => { loadComments(); });
 
-  windowRef.addEventListener('message', (event) => {
+  function handleGrantMessage(event) {
     const expected = config.connectBaseUrl;
     if (event.origin !== expected) return;
     const data = event.data || {};
@@ -408,9 +514,23 @@ export function mountAnnotateComments(options = {}) {
       return;
     }
     state.grant = grantToken;
-    writeStoredGrant(windowRef, config, state.grant);
+    writeStoredGrant(windowRef, config, state.grant, sourceKey);
     setStatus('Signed in with GitHub.');
-  });
+  }
+
+  windowRef.addEventListener('message', handleGrantMessage);
+  let disposed = false;
+  const disposeAnnotateListener = () => {
+    if (disposed) return;
+    disposed = true;
+    try { windowRef.removeEventListener('message', handleGrantMessage); } catch (_) {}
+    try {
+      if (section.__pressAnnotateDispose === disposeAnnotateListener) section.__pressAnnotateDispose = null;
+      if (container.__pressAnnotateDispose === disposeAnnotateListener) container.__pressAnnotateDispose = null;
+    } catch (_) {}
+  };
+  section.__pressAnnotateDispose = disposeAnnotateListener;
+  container.__pressAnnotateDispose = disposeAnnotateListener;
 
   section.appendChild(renderForm(''));
   container.appendChild(section);

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.128",
-  "tag": "v3.4.128",
+  "version": "3.4.129",
+  "tag": "v3.4.129",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.127 <3.4.128"
+      ">=3.4.128 <3.4.129"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.127 before installing v3.4.128."
+    "message": "Update to v3.4.128 before installing v3.4.129."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 3,
-    "message": "Update installed themes to contract v3 before installing v3.4.128."
+    "message": "Update installed themes to contract v3 before installing v3.4.129."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.127 and publish the content model migration before installing v3.4.128."
+    "message": "Install v3.4.128 and publish the content model migration before installing v3.4.129."
   }
 }

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1,5 +1,5 @@
 import { installLightbox } from '../../../js/lightbox.js';
-import { sanitizeImageUrl, setSafeHtml } from '../../../js/safe-html.js';
+import { sanitizeImageUrl, sanitizeUrl, setSafeHtml } from '../../../js/safe-html.js';
 import { slugifyTab, escapeHtml, getQueryVariable, renderTags, cardImageSrc, fallbackCover, formatDisplayDate, formatBytes, renderSkeletonArticle } from '../../../js/utils.js';
 import { attachHoverTooltip } from '../../../js/tags.js';
 import { prefersReducedMotion, getArticleTitleFromMain } from '../../../js/dom-utils.js';
@@ -1149,9 +1149,9 @@ function renderSiteLinksNative(params = {}, documentRef = defaultDocument) {
   if (Array.isArray(linksVal)) {
     items = linksVal
       .filter(x => x && x.href && x.label)
-      .map(x => ({ href: String(x.href), label: String(x.label) }));
+      .map(x => ({ href: sanitizeUrl(x.href), label: String(x.label) }));
   } else if (linksVal && typeof linksVal === 'object') {
-    items = Object.entries(linksVal).map(([label, href]) => ({ label: String(label), href: String(href) }));
+    items = Object.entries(linksVal).map(([label, href]) => ({ label: String(label), href: sanitizeUrl(href) }));
   }
   if (!items.length) { root.innerHTML = ''; return true; }
   const sep = '<span class="link-sep">•</span>';

--- a/scripts/test-annotate.js
+++ b/scripts/test-annotate.js
@@ -21,6 +21,7 @@ class FakeElement {
     this.className = '';
     this.id = '';
     this.value = '';
+    this.style = {};
   }
 
   appendChild(child) {
@@ -28,6 +29,12 @@ class FakeElement {
     child.parentNode = this;
     this.children.push(child);
     return child;
+  }
+
+  replaceChildren(...children) {
+    this.children.forEach(child => { child.parentNode = null; });
+    this.children = [];
+    children.forEach(child => this.appendChild(child));
   }
 
   insertBefore(child, before) {
@@ -59,6 +66,17 @@ class FakeElement {
     this.eventListeners[type] = handler;
   }
 
+  click() {
+    if (this.ownerDocument && Array.isArray(this.ownerDocument.clickedLinks)) {
+      this.ownerDocument.clickedLinks.push({
+        href: this.href || '',
+        target: this.target || '',
+        rel: this.rel || '',
+        referrerPolicy: this.referrerPolicy || ''
+      });
+    }
+  }
+
   querySelector(selector) {
     if (!selector || selector[0] !== '#') return null;
     const wanted = selector.slice(1);
@@ -78,6 +96,8 @@ class FakeElement {
 class FakeDocument {
   constructor() {
     this.head = new FakeElement('head', this);
+    this.body = new FakeElement('body', this);
+    this.clickedLinks = [];
   }
 
   createElement(tagName) {
@@ -89,17 +109,53 @@ class FakeDocument {
   }
 }
 
-function createWindow() {
-  const store = new Map();
+const defaultAnnotateHref = 'https://ekilyhq.github.io/demo/?id=post%2Fdoc%2Fv2.1.0%2Fdoc_chs.md';
+const defaultGrantStorageKey = `press_annotate_grant_v2:EkilyHQ/Press:${defaultAnnotateHref}`;
+
+async function flushMicrotasks(times = 5) {
+  for (let i = 0; i < times; i += 1) await Promise.resolve();
+}
+
+function createWindow(initialStorage = {}) {
+  const store = new Map(Object.entries(initialStorage));
+  const opened = [];
+  const listeners = new Map();
   return {
-    location: { origin: 'https://ekilyhq.github.io' },
+    location: {
+      origin: 'https://ekilyhq.github.io',
+      href: defaultAnnotateHref,
+      pathname: '/demo/',
+      search: '?id=post%2Fdoc%2Fv2.1.0%2Fdoc_chs.md'
+    },
+    opened,
     localStorage: {
       getItem: key => (store.has(key) ? store.get(key) : null),
       setItem: (key, value) => { store.set(key, String(value)); },
       removeItem: key => { store.delete(key); }
     },
-    addEventListener() {},
-    open() {}
+    addEventListener(type, handler) {
+      const bucket = listeners.get(type) || new Set();
+      bucket.add(handler);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type, handler) {
+      const bucket = listeners.get(type);
+      if (bucket) bucket.delete(handler);
+    },
+    dispatchEvent(event) {
+      const bucket = listeners.get(event && event.type);
+      if (!bucket) return;
+      [...bucket].forEach(handler => handler(event));
+    },
+    listenerCount(type) {
+      const bucket = listeners.get(type);
+      return bucket ? bucket.size : 0;
+    },
+    open(url = '', target = '', features = '') {
+      const popup = { location: { href: String(url || '') } };
+      opened.push({ url, target, features, popup });
+      return popup;
+    }
   };
 }
 
@@ -204,11 +260,203 @@ assert.match(url, /articleKey=pressDocs/);
       return { ok: true, json: async () => ({ comments: [] }) };
     }
   });
-  await Promise.resolve();
+  await flushMicrotasks();
   assert.equal(section && section.id, 'press-annotate-comments');
   assert.equal(container.children.includes(section), true);
   assert.equal(requests.length, 1);
   assert.equal(requests[0].init.method, 'GET');
+  assert.equal(requests[0].init.referrerPolicy, 'unsafe-url');
+  assert.equal(Object.prototype.hasOwnProperty.call(requests[0].init.headers, 'authorization'), false);
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow({
+    [defaultGrantStorageKey]: JSON.stringify({ grant: 'stored-grant' })
+  });
+  const container = document.createElement('main');
+  const requests = [];
+  const section = mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async (requestUrl, init = {}) => {
+      requests.push({ url: requestUrl, init });
+      return { ok: true, json: async () => ({ comments: [] }) };
+    }
+  });
+  await flushMicrotasks();
+  assert.equal(section && section.id, 'press-annotate-comments');
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].init.method, 'GET');
+  assert.equal(requests[0].init.referrerPolicy, 'unsafe-url');
+  assert.equal(requests[0].init.headers.authorization, 'Bearer stored-grant');
+
+  const form = section.children.find(child => child.className === 'press-annotate__form');
+  const textarea = form.children[0];
+  textarea.value = 'Comment body';
+  await form.eventListeners.submit({ preventDefault() {} });
+  assert.equal(requests.length, 3);
+  assert.equal(requests[1].init.method, 'POST');
+  assert.equal(requests[1].init.referrerPolicy, 'unsafe-url');
+  assert.equal(requests[1].init.headers.authorization, 'Bearer stored-grant');
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow({
+    [defaultGrantStorageKey]: JSON.stringify({ grant: 'expired-grant' })
+  });
+  const container = document.createElement('main');
+  const requests = [];
+  const section = mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async (requestUrl, init = {}) => {
+      requests.push({ url: requestUrl, init });
+      return requests.length === 1
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : { ok: true, status: 200, json: async () => ({ comments: [] }) };
+    }
+  });
+  await flushMicrotasks();
+  assert.equal(section && section.id, 'press-annotate-comments');
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].init.headers.authorization, 'Bearer expired-grant');
+  assert.equal(Object.prototype.hasOwnProperty.call(requests[1].init.headers, 'authorization'), false);
+  assert.equal(window.localStorage.getItem(defaultGrantStorageKey), null);
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow({
+    [defaultGrantStorageKey]: JSON.stringify({ grant: 'wrong-source-grant' })
+  });
+  const container = document.createElement('main');
+  const requests = [];
+  const section = mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async (requestUrl, init = {}) => {
+      requests.push({ url: requestUrl, init });
+      return requests.length === 1
+        ? { ok: false, status: 403, json: async () => ({ error: { code: 'source_mismatch' } }) }
+        : { ok: true, status: 200, json: async () => ({ comments: [] }) };
+    }
+  });
+  await flushMicrotasks();
+  assert.equal(section && section.id, 'press-annotate-comments');
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].init.headers.authorization, 'Bearer wrong-source-grant');
+  assert.equal(Object.prototype.hasOwnProperty.call(requests[1].init.headers, 'authorization'), false);
+  assert.equal(window.localStorage.getItem(defaultGrantStorageKey), null);
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow({
+    [defaultGrantStorageKey]: JSON.stringify({ grant: 'wrong-source-grant' })
+  });
+  const container = document.createElement('main');
+  const requests = [];
+  const section = mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async (requestUrl, init = {}) => {
+      requests.push({ url: requestUrl, init });
+      return requests.length === 1
+        ? { ok: true, status: 200, json: async () => ({ comments: [] }) }
+        : { ok: false, status: 403, json: async () => ({ error: { code: 'source_mismatch' } }) };
+    }
+  });
+  await flushMicrotasks();
+  const form = section.children.find(child => child.className === 'press-annotate__form');
+  const textarea = form.children[0];
+  textarea.value = 'Comment body';
+  await form.eventListeners.submit({ preventDefault() {} });
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].init.method, 'POST');
+  assert.equal(window.localStorage.getItem(defaultGrantStorageKey), null);
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow();
+  const container = document.createElement('main');
+  const section = mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async () => ({ ok: true, json: async () => ({ comments: [] }) })
+  });
+  await flushMicrotasks();
+  const loginButton = section.children[0].children[1].children[0];
+  loginButton.eventListeners.click();
+  assert.equal(window.opened.length, 1);
+  assert.equal(window.opened[0].url, '');
+  assert.equal(window.opened[0].target, 'press-annotate-login');
+  assert.equal(document.clickedLinks.length, 1);
+  assert.match(document.clickedLinks[0].href, /^https:\/\/connect\.example\.com\/github\/annotate\/start\?/);
+  assert.equal(document.clickedLinks[0].target, 'press-annotate-login');
+  assert.equal(document.clickedLinks[0].referrerPolicy, 'unsafe-url');
+}
+
+{
+  const document = new FakeDocument();
+  const window = createWindow();
+  const container = document.createElement('main');
+  mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context,
+    fetchImpl: async () => ({ ok: true, json: async () => ({ comments: [] }) })
+  });
+  await flushMicrotasks();
+  assert.equal(window.listenerCount('message'), 1);
+
+  const firstSourceKey = defaultGrantStorageKey;
+  const secondHref = 'https://ekilyhq.github.io/demo/?id=post%2Fsecurity%2Fscope.md';
+  const secondSourceKey = `press_annotate_grant_v2:EkilyHQ/Press:${secondHref}`;
+  container.replaceChildren();
+  window.location.href = secondHref;
+  window.location.search = '?id=post%2Fsecurity%2Fscope.md';
+  mountAnnotateComments({
+    container,
+    document,
+    window,
+    siteConfig,
+    context: { ...context, articleKey: 'securityScope', location: 'post/security/scope.md' },
+    fetchImpl: async () => ({ ok: true, json: async () => ({ comments: [] }) })
+  });
+  await flushMicrotasks();
+  assert.equal(window.listenerCount('message'), 1);
+  window.dispatchEvent({
+    type: 'message',
+    origin: 'https://connect.example.com',
+    data: {
+      source: 'ekily-connect',
+      type: 'press-annotate-grant',
+      ok: true,
+      grant: 'grant-for-current-page'
+    }
+  });
+  assert.equal(window.localStorage.getItem(firstSourceKey), null);
+  assert.match(window.localStorage.getItem(secondSourceKey), /grant-for-current-page/);
 }
 
 console.log('ok - annotate runtime');

--- a/scripts/test-site-features.js
+++ b/scripts/test-site-features.js
@@ -637,4 +637,28 @@ assert.ok(searchTab, 'native search tab should render search tab chrome');
 assert.match(searchTab.getAttribute('href') || '', /q=foo/, 'native search tab should preserve q when a stale tag is ignored');
 assert.doesNotMatch(`${searchTab.getAttribute('href') || ''} ${searchTab.textContent || ''}`, /tag=bar|ui\.tagSearch:bar/, 'native search tab should ignore stale tag chrome when tags are disabled');
 
+const profileLinksProbe = new ElementProbe();
+const nativeLinksApi = mountNativeTheme({
+  document: {
+    querySelector: (selector) => (selector === '.site-card .social-links' ? profileLinksProbe : null),
+    createElement: (tagName) => new ElementProbe(tagName),
+    body: new ElementProbe()
+  },
+  window: {},
+  features: createSiteFeatureContext({}),
+  i18n: { t: (key) => key }
+});
+nativeLinksApi.effects.renderSiteLinks({
+  config: {
+    profileLinks: [
+      { label: 'Unsafe', href: 'javascript:alert(1)' },
+      { label: 'Mail', href: 'mailto:hello@example.test' }
+    ]
+  },
+  features: createSiteFeatureContext({})
+});
+assert.match(profileLinksProbe.innerHTML, /href="#"/, 'native profile links should replace unsafe URL schemes');
+assert.match(profileLinksProbe.innerHTML, /href="mailto:hello@example.test"/, 'native profile links should preserve safe URL schemes');
+assert.doesNotMatch(profileLinksProbe.innerHTML, /javascript:/i, 'native profile links should not render javascript URLs');
+
 console.log('ok - site feature controls resolve and serialize');


### PR DESCRIPTION
## Summary
- send full-page Referrer for Annotate authorization, reads, and writes with `referrerPolicy: unsafe-url`
- scope browser-stored Annotate grants by repo plus full source URL, with stale/source-mismatched grants cleared and retried where reads can remain public
- sanitize native theme profile links and bump Press system metadata to `v3.4.129`

## Verification
- `~/.local/bin/mise exec node@22.18.0 -- node scripts/test-annotate.js`
- `~/.local/bin/mise exec node@22.18.0 -- node scripts/test-markdown-security.js`
- `~/.local/bin/mise exec node@22.18.0 -- node scripts/test-remove-site-navigation-links.js`
- `~/.local/bin/mise exec node@22.18.0 -- node scripts/test-site-features.js`
- `~/.local/bin/mise exec node@22.18.0 -- node --experimental-default-type=module scripts/test-system-updates.js`
- `~/.local/bin/mise exec node@22.18.0 -- node scripts/sync-runtime-cache-keys.mjs --check`
- `~/.local/bin/mise exec node@22.18.0 -- bash scripts/test-system-release-package.sh`
- `~/.local/bin/mise exec node@22.18.0 -- bash scripts/test-system-release-workflow.sh`
- local editor smoke at `http://127.0.0.1:8000/index_editor.html`: shell and file tree loaded, no pageerror; console showed only expected local optional-content probe 404s for `site.local.*` and legacy sidecars

## Review
- Subagent pre-review found the first repo-scoped browser grant version was too broad; fixed by keying grants by source URL.
- Subagent re-review found no P0/P1/P2 blockers after the fix.

## Release impact
- This is intended to publish Press system release `v3.4.129` after merge.
- Downstream YAP sync should already include the symlink ZIP guard before this PR is merged.
- Connect's stricter backend source validation should merge only after `v3.4.129` is available.