### PR TITLE
Prepare theme contract v4 cleanup release

### DIFF
--- a/assets/js/theme-contract-surface.mjs
+++ b/assets/js/theme-contract-surface.mjs
@@ -12,9 +12,19 @@ const REQUIRED_THEME_CONTENT_SHAPES = Object.freeze([
   'assets',
   'links'
 ]);
-const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze(['contractVersion', 'engines', 'content', 'modules']);
+const REQUIRED_THEME_MANIFEST_FIELDS = Object.freeze([
+  'contractVersion',
+  'engines',
+  'content',
+  'modules',
+  'views',
+  'regions',
+  'components',
+  'scrollContainer',
+  'configSchema'
+]);
 const DEFAULT_THEME_STYLES = Object.freeze(['theme.css']);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([3, 4]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = Object.freeze([4]);
 const THEME_ARCHIVE_ALLOWED_EXTENSIONS = Object.freeze([
   '.avif', '.css', '.gif', '.htm', '.html', '.ico', '.jpeg', '.jpg', '.js', '.json', '.mjs', '.otf',
   '.png', '.svg', '.ttf', '.txt', '.webp', '.woff', '.woff2'

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.130",
-  "tag": "v3.4.130",
+  "version": "3.4.131",
+  "tag": "v3.4.131",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.129 <3.4.130"
+      ">=3.4.130 <3.4.131"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.129 before installing v3.4.130."
+    "message": "Update to v3.4.130 before installing v3.4.131."
   },
   "themeContractUpgrade": {
-    "requiresInstalledThemeContractVersion": 3,
-    "message": "Update installed themes to contract v3 before installing v3.4.130."
+    "requiresInstalledThemeContractVersion": 4,
+    "message": "Update installed themes to contract v4 before installing v3.4.131."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.129 and publish the content model migration before installing v3.4.130."
+    "message": "Install v3.4.130 and publish the content model migration before installing v3.4.131."
   }
 }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -9,7 +9,12 @@
     "contractVersion",
     "engines",
     "content",
-    "modules"
+    "modules",
+    "views",
+    "regions",
+    "components",
+    "scrollContainer",
+    "configSchema"
   ],
   "additionalProperties": true,
   "properties": {
@@ -23,7 +28,7 @@
     },
     "contractVersion": {
       "type": "integer",
-      "enum": [3, 4],
+      "enum": [4],
       "description": "Press theme contract version this manifest targets. Contract v4 is the current route href helper contract."
     },
     "engines": {

--- a/packages/press-theme-contract/index.mjs
+++ b/packages/press-theme-contract/index.mjs
@@ -22,7 +22,7 @@ const { containsForbiddenV4RouteConstruction } = themePackageCore;
 export { PRESS_THEME_CONTRACT, containsForbiddenV4RouteConstruction };
 
 const ROUTE_HELPER_CONTRACT_VERSION = 4;
-const THEME_TEXT_EXTENSIONS = new Set(['.css', '.htm', '.html', '.js', '.mjs', '.cjs', '.svg']);
+const THEME_TEXT_EXTENSIONS = new Set(PRESS_THEME_CONTRACT.archive && PRESS_THEME_CONTRACT.archive.textExtensions);
 
 function safeString(value) {
   return value == null ? '' : String(value);

--- a/packages/press-theme-contract/package.json
+++ b/packages/press-theme-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekilyhq/press-theme-contract",
-  "version": "3.4.130",
+  "version": "3.4.131",
   "description": "Press theme contract helpers and packaged theme validation rules.",
   "type": "module",
   "license": "UNLICENSED",

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -26,7 +26,7 @@ const SIGNED_URL_QUERY_KEYS = [
   'x-goog-signature'
 ];
 const DEFAULT_RELEASE_SOURCES = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
-const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([3, 4]);
+const SUPPORTED_THEME_CONTRACT_VERSIONS = new Set([4]);
 const CURRENT_THEME_CONTRACT_VERSION = 4;
 const THEME_CONTRACT_V4_MIN_PRESS_VERSION = '3.4.130';
 const DEFAULT_SOURCES = {
@@ -598,6 +598,7 @@ function buildDesiredState({ sources, systemRelease, systemSource, releaseIntent
       tag: target.tag,
       asset: systemRelease.asset,
       runtime: systemRelease.runtime,
+      themeContractUpgrade: systemRelease.themeContractUpgrade,
       contentModelUpgrade: systemRelease.contentModelUpgrade
     },
     downstream: Object.fromEntries((sources.downstream || []).map((source) => {
@@ -631,6 +632,7 @@ function buildObservedState(state, checkedAt) {
       tag: state.pressSystem.tag,
       runtime: state.pressSystem.runtime,
       asset: state.pressSystem.asset,
+      themeContractUpgrade: state.pressSystem.themeContractUpgrade,
       contentModelUpgrade: state.pressSystem.contentModelUpgrade
     },
     releaseIntent: clone(state.releaseIntent),

--- a/scripts/test-press-version-runtime.js
+++ b/scripts/test-press-version-runtime.js
@@ -60,16 +60,16 @@ assert.equal((await loadPressSystemManifest({ manifestLoader: secondLoader })).v
 const guardedManifest = normalizePressSystemManifest({
   ...manifest('3.4.123'),
   themeContractUpgrade: {
-    requiresInstalledThemeContractVersion: 3,
-    message: 'Update installed themes to contract v3 first.'
+    requiresInstalledThemeContractVersion: 4,
+    message: 'Update installed themes to contract v4 first.'
   },
   contentModelUpgrade: {
     requiresUnifiedIndexTabs: true,
     message: 'Publish content model migration first.'
   }
 });
-assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 3);
-assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v3 first.');
+assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 4);
+assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v4 first.');
 assert.equal(guardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, true);
 assert.equal(guardedManifest.contentModelUpgrade.message, 'Publish content model migration first.');
 

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -40,7 +40,7 @@ function makeSources() {
   return sources;
 }
 
-function systemRelease(version = '3.4.51') {
+function systemRelease(version = '3.4.131') {
   return {
     schemaVersion: 1,
     name: `v${version}`,
@@ -48,7 +48,7 @@ function systemRelease(version = '3.4.51') {
     version,
     publishedAt: '2026-05-25T00:00:00Z',
     upgradeFrom: {
-      ranges: ['>=3.4.50 <3.4.51'],
+      ranges: ['>=3.4.130 <3.4.131'],
       allowUnknownSource: false
     },
     runtime: {
@@ -76,7 +76,7 @@ function systemRelease(version = '3.4.51') {
   };
 }
 
-function pressManifest(version = '3.4.51') {
+function pressManifest(version = '3.4.131') {
   return {
     schemaVersion: 1,
     type: 'press-system',
@@ -85,7 +85,7 @@ function pressManifest(version = '3.4.51') {
   };
 }
 
-function themeRelease(slug, version = '3.4.2', pressRange = '>=3.4.0 <4.0.0', contractVersion = 3) {
+function themeRelease(slug, version = '3.4.6', pressRange = '>=3.4.130 <4.0.0', contractVersion = 4) {
   return {
     schemaVersion: 1,
     type: 'press-theme',
@@ -306,7 +306,7 @@ test('loadJsonSource falls back to raw GitHub URLs when the Contents API is unav
     }
   });
 
-  assert.equal(payload.version, '3.4.51');
+  assert.equal(payload.version, '3.4.131');
   assert.equal(calls.length, 2);
   assert.equal(new URL(calls[0].url).origin, 'https://api.github.com');
   const fallbackUrl = new URL(calls[1].url);
@@ -449,22 +449,22 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   });
 
   assert.equal(state.status, 'ok');
-  assert.equal(state.pressSystem.version, '3.4.51');
+  assert.equal(state.pressSystem.version, '3.4.131');
   assert.equal(state.pressSystem.runtime.type, 'press-runtime-assets');
   assert.equal(state.pressSystem.runtime.edgeCount, 300);
   assert.equal(state.releaseIntent.status, 'ok');
   assert.equal(state.releaseIntent.targetCount, 6);
   assert.equal(state.desired.source, 'press-release-intent');
   assert.equal(state.desired.releaseIntent.source, 'fixture:intent');
-  assert.equal(state.desired.pressSystem.tag, 'v3.4.51');
+  assert.equal(state.desired.pressSystem.tag, 'v3.4.131');
   assert.equal(state.desired.pressSystem.asset.digest, 'sha256:abc123');
-  assert.equal(state.desired.downstream.yap.expectedVersion, '3.4.51');
+  assert.equal(state.desired.downstream.yap.expectedVersion, '3.4.131');
   assert.equal(state.desired.downstream.yap.reconciler.eventType, 'press-system-release');
   assert.equal(state.desired.downstream.yap.reconciler.idempotent, true);
   assert.equal(state.desired.downstream.themeStarter.reconciler.kind, 'theme-starter-marker-sync');
   assert.equal(state.desired.themeDemos.arcus.reconciler.kind, 'theme-demo-runtime-sync');
   assert.equal(state.desired.themes.catalog.expectedCount, 1);
-  assert.equal(state.desired.themes.entries[0].expectedPressVersion, '3.4.51');
+  assert.equal(state.desired.themes.entries[0].expectedPressVersion, '3.4.131');
   assert.equal(state.desired.themes.entries[0].expectedContractVersion, 4);
   assert.equal(state.downstream.yap.status, 'ok');
   assert.equal(state.themeDemos.arcus.status, 'ok');
@@ -488,8 +488,8 @@ test('buildProductState reports ok when all declared and observed facts agree', 
 test('buildProductState preserves release upgrade metadata for release intent validation', async () => {
   const release = systemRelease();
   release.themeContractUpgrade = {
-    requiresInstalledThemeContractVersion: 3,
-    message: 'Update installed themes to contract v3 first.'
+    requiresInstalledThemeContractVersion: 4,
+    message: 'Update installed themes to contract v4 first.'
   };
   release.contentModelUpgrade = {
     requiresUnifiedIndexTabs: true,
@@ -508,7 +508,10 @@ test('buildProductState preserves release upgrade metadata for release intent va
 
   assert.equal(state.status, 'ok');
   assert.equal(state.releaseIntent.status, 'ok');
+  assert.deepEqual(state.desired.pressSystem.themeContractUpgrade, release.themeContractUpgrade);
+  assert.deepEqual(state.observed.pressSystem.themeContractUpgrade, release.themeContractUpgrade);
   assert.deepEqual(state.desired.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
+  assert.deepEqual(state.observed.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
 });
 
 test('buildProductState preserves legacy theme-starter reconciler fallback', async () => {
@@ -551,9 +554,9 @@ test('buildProductState marks invalid release intent as drift', async () => {
 
 test('buildProductState records canonical release intent source even when loaded from a local file', async () => {
   const intent = releaseIntentFixture(systemRelease());
-  intent.source = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.51/release-intent.json';
+  intent.source = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.131/release-intent.json';
   intent.latestSource = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/release-intent.json';
-  intent.systemRelease.source = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.51/system-release.json';
+  intent.systemRelease.source = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.131/system-release.json';
 
   const state = await buildProductState({
     sources: makeSources(),
@@ -719,17 +722,17 @@ test('buildProductState marks downstream version lag as pending, not a new sourc
   const state = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
-      'fixture:yap': pressManifest('3.4.50')
+      'fixture:yap': pressManifest('3.4.130')
     })),
     generatedAt: '2026-05-25T00:00:00Z'
   });
 
   assert.equal(state.status, 'pending');
   assert.equal(state.downstream.yap.status, 'pending');
-  assert.equal(state.downstream.yap.expectedVersion, '3.4.51');
-  assert.equal(state.downstream.yap.observedVersion, '3.4.50');
-  assert.equal(state.desired.downstream.yap.expectedTag, 'v3.4.51');
-  assert.equal(state.observed.downstream.yap.observedVersion, '3.4.50');
+  assert.equal(state.downstream.yap.expectedVersion, '3.4.131');
+  assert.equal(state.downstream.yap.observedVersion, '3.4.130');
+  assert.equal(state.desired.downstream.yap.expectedTag, 'v3.4.131');
+  assert.equal(state.observed.downstream.yap.observedVersion, '3.4.130');
   assert.equal(state.verdict.status, 'pending');
   assert.equal(state.verdict.converged, false);
   assert.equal(state.verdict.counts.pending, 1);
@@ -741,7 +744,7 @@ test('buildProductState marks downstream version lag as pending, not a new sourc
 
 test('shouldFailCheck keeps pending and unknown allowances independent', async () => {
   const fixtures = makeFixtures({
-    'fixture:yap': pressManifest('3.4.50')
+    'fixture:yap': pressManifest('3.4.130')
   });
   delete fixtures['fixture:starter'];
   const state = await buildProductState({
@@ -791,7 +794,7 @@ test('buildProductState marks incompatible theme release manifests as drift', as
   assert.equal(shouldFailCheck(state, { allowPending: true, allowUnknown: true }), true);
 });
 
-test('buildProductState accepts supported transition theme contract versions', async () => {
+test('buildProductState rejects transition theme contract v3 after cleanup', async () => {
   const state = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
@@ -801,20 +804,22 @@ test('buildProductState accepts supported transition theme contract versions', a
   });
 
   assert.equal(state.themes.entries[0].contractVersion, 3);
-  assert.notEqual(state.themes.entries[0].status, 'drift');
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themes.entries[0].status, 'drift');
+  assert.match(state.themes.entries[0].problems.join('\n'), /supported contractVersion/);
 
-  const transitionRelease = systemRelease('3.4.130');
-  const transitionFixtures = {
-    'fixture:system': transitionRelease,
-    'fixture:intent': releaseIntentFixture(transitionRelease),
-    'fixture:yap': pressManifest('3.4.130'),
-    'fixture:starter': systemRelease('3.4.130'),
-    'fixture:arcus-demo': pressManifest('3.4.130')
+  const cleanupRelease = systemRelease('3.4.131');
+  const cleanupFixtures = {
+    'fixture:system': cleanupRelease,
+    'fixture:intent': releaseIntentFixture(cleanupRelease),
+    'fixture:yap': pressManifest('3.4.131'),
+    'fixture:starter': systemRelease('3.4.131'),
+    'fixture:arcus-demo': pressManifest('3.4.131')
   };
   const v4State = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
-      ...transitionFixtures,
+      ...cleanupFixtures,
       'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.130 <4.0.0', 4)
     })),
     generatedAt: '2026-05-25T00:00:00Z'
@@ -826,7 +831,7 @@ test('buildProductState accepts supported transition theme contract versions', a
   const tooWideV4State = await buildProductState({
     sources: makeSources(),
     loadJson: loader(makeFixtures({
-      ...transitionFixtures,
+      ...cleanupFixtures,
       'fixture:theme-arcus': themeRelease('arcus', '3.4.2', '>=3.4.0 <4.0.0', 4)
     })),
     generatedAt: '2026-05-25T00:00:00Z'

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -22,8 +22,8 @@ function systemRelease(version = '3.4.62') {
       allowUnknownSource: false
     },
     themeContractUpgrade: {
-      requiresInstalledThemeContractVersion: 3,
-      message: 'Update installed themes to contract v3 first.'
+      requiresInstalledThemeContractVersion: 4,
+      message: 'Update installed themes to contract v4 first.'
     },
     contentModelUpgrade: {
       requiresUnifiedIndexTabs: true,
@@ -101,8 +101,8 @@ test('validateReleaseIntent compares theme upgrade metadata structurally', () =>
   const release = systemRelease();
   const intent = buildReleaseIntent({ systemRelease: release });
   intent.pressSystem.themeContractUpgrade = {
-    message: 'Update installed themes to contract v3 first.',
-    requiresInstalledThemeContractVersion: 3
+    message: 'Update installed themes to contract v4 first.',
+    requiresInstalledThemeContractVersion: 4
   };
 
   assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -1008,6 +1008,102 @@ await run('allows guarded system updates after installed themes reach the requir
   setPressSystemManifestForTests(null);
 });
 
+await run('blocks v4 cleanup system updates while installed themes are still contract v3', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.130',
+    tag: 'v3.4.130',
+    upgradeFrom: { ranges: ['>=3.4.129 <3.4.130'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.131/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.131/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.131',
+      tag: 'v3.4.131',
+      upgradeFrom: {
+        ranges: ['>=3.4.130 <3.4.131'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      themeContractUpgrade: {
+        requiresInstalledThemeContractVersion: 4,
+        message: 'Update installed themes to contract v4 before installing v3.4.131.'
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/themes/packs.json') {
+        return jsonResponse([
+          { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
+          { value: 'arcus', label: 'Arcus', version: '3.4.5', contractVersion: 3, files: ['theme.json'] }
+        ]);
+      }
+      return { ok: false, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+  });
+
+  await assert.rejects(
+    () => controller.analyzeArchive(buffer, 'press-system-v3.4.131.zip'),
+    /contract v4|Arcus|contract v3|v3\.4\.131/i
+  );
+  assert.deepEqual(controller.getCommitFiles(), []);
+  setPressSystemManifestForTests(null);
+});
+
+await run('allows v4 cleanup system updates after installed themes reach contract v4', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  setPressSystemManifestForTests({
+    schemaVersion: 1,
+    type: 'press-system',
+    version: '3.4.130',
+    tag: 'v3.4.130',
+    upgradeFrom: { ranges: ['>=3.4.129 <3.4.130'], allowUnknownSource: false, message: '' }
+  });
+  const buffer = makeZip({
+    'press-system-v3.4.131/index.html': '<!doctype html><p>guarded</p>',
+    'press-system-v3.4.131/assets/press-system.json': JSON.stringify({
+      schemaVersion: 1,
+      type: 'press-system',
+      version: '3.4.131',
+      tag: 'v3.4.131',
+      upgradeFrom: {
+        ranges: ['>=3.4.130 <3.4.131'],
+        allowUnknownSource: false,
+        message: ''
+      },
+      themeContractUpgrade: {
+        requiresInstalledThemeContractVersion: 4,
+        message: 'Update installed themes to contract v4 before installing v3.4.131.'
+      }
+    })
+  });
+  const controller = createSystemUpdatesController({
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'assets/themes/packs.json') {
+        return jsonResponse([
+          { value: 'native', label: 'Native', builtIn: true, removable: false, files: [] },
+          { value: 'arcus', label: 'Arcus', version: '3.4.6', contractVersion: 4, files: ['theme.json'] }
+        ]);
+      }
+      return { ok: false, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+  });
+
+  await controller.analyzeArchive(buffer, 'press-system-v3.4.131.zip');
+  assert.deepEqual(controller.getCommitFiles().map((file) => file.path).sort(), [
+    'assets/press-system.json',
+    'index.html'
+  ]);
+  setPressSystemManifestForTests(null);
+});
+
 await run('ignores stale stored theme packs that are no longer installed', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   setPressSystemManifestForTests({

--- a/scripts/test-theme-contract-package.mjs
+++ b/scripts/test-theme-contract-package.mjs
@@ -10,7 +10,7 @@ const sourceManifest = JSON.parse(await fs.readFile(path.join(root, 'packages', 
 
 assert.equal(sourceManifest.name, '@ekilyhq/press-theme-contract');
 assert.equal(sourceManifest.version, system.version);
-assert.equal(system.version, '3.4.130');
+assert.equal(system.version, '3.4.131');
 assert.equal(system.tag, `v${system.version}`);
 assert.equal(sourceManifest.publishConfig && sourceManifest.publishConfig.registry, 'https://npm.pkg.github.com');
 
@@ -120,9 +120,10 @@ try {
     } from '@ekilyhq/press-theme-contract';
 
     assert.equal(PRESS_THEME_CONTRACT.contractVersion, 4);
-    assert.deepEqual(PRESS_THEME_CONTRACT.supportedContractVersions, [3, 4]);
+    assert.deepEqual(PRESS_THEME_CONTRACT.supportedContractVersions, [4]);
     assert.equal(typeof containsForbiddenV4RouteConstruction, 'function');
     assert.equal(typeof validateThemeRouteHelperContract, 'function');
+    assert.deepEqual(PRESS_THEME_CONTRACT.archive.textExtensions, ['.css', '.htm', '.html', '.js', '.json', '.mjs', '.svg', '.txt']);
     assert.equal(containsForbiddenV4RouteConstruction('export const href = "?id=post.md";', { path: 'modules/layout.js', files: [] }), true);
     assert.equal(containsForbiddenV4RouteConstruction('export const href = "https://example.test/products?id=sku";', { path: 'modules/layout.js', files: [] }), false);
     assert.equal(containsForbiddenV4RouteConstruction('<a href="?tab=posts">Posts</a>', { path: 'assets/link.html', files: [] }), true);

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -4436,8 +4436,8 @@ if (PRESS_THEME_CONTRACT.schemaVersion !== 1 || PRESS_THEME_CONTRACT.type !== 'p
 if (PRESS_THEME_CONTRACT.contractVersion !== 4) {
   fail('assets/js/theme-contract-surface.mjs must declare contractVersion 4 as the current theme contract');
 }
-if (JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions) !== JSON.stringify([3, 4])) {
-  fail('the v4 transition release must support theme contract versions 3 and 4');
+if (JSON.stringify(PRESS_THEME_CONTRACT.supportedContractVersions) !== JSON.stringify([4])) {
+  fail('the v4 cleanup release must support only theme contract version 4');
 }
 if (PRESS_THEME_CONTRACT.manifestSchemaPath !== 'assets/schema/theme.json') {
   fail('theme contract surface must point at assets/schema/theme.json');

--- a/scripts/test-theme-manager.js
+++ b/scripts/test-theme-manager.js
@@ -717,7 +717,7 @@ await run('normalizes release manifests and rejects unsupported contracts', asyn
   assert.equal(manifest.value, 'arcus');
   assert.equal(manifest.engines.press, '>=3.4.0 <4.0.0');
   assert.equal(manifest.contractVersion, 4);
-  assert.equal(normalizeThemeReleaseManifest({ ...manifest, contractVersion: 3 }).contractVersion, 3);
+  assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 3 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 2 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 1 }), /contractVersion/i);
   assert.throws(() => normalizeThemeReleaseManifest({ ...manifest, contractVersion: 5 }), /contractVersion/i);
@@ -766,6 +766,10 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
     /contractVersion/i
   );
   assert.throws(
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })),
+    /contractVersion/i
+  );
+  assert.throws(
     () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 1 })),
     /contractVersion/i
   );
@@ -776,12 +780,15 @@ await run('rejects unsafe and multi-theme ZIP archives', async () => {
 });
 
 await run('rejects v4 theme packages with public route literals', async () => {
-  assert.doesNotThrow(() => collectThemeArchiveEntries(makeThemeZip({
-    contractVersion: 3,
-    files: {
-      'modules/layout.js': 'export default { mount() { return "?tab=posts"; }, views: {}, components: {}, effects: {} };'
-    }
-  })));
+  assert.throws(
+    () => collectThemeArchiveEntries(makeThemeZip({
+      contractVersion: 3,
+      files: {
+        'modules/layout.js': 'export default { mount() { return "?tab=posts"; }, views: {}, components: {}, effects: {} };'
+      }
+    })),
+    /contractVersion/i
+  );
   assert.throws(
     () => collectThemeArchiveEntries(makeThemeZip({
       contractVersion: 4,
@@ -2669,7 +2676,10 @@ await run('rejects v4 theme packages with public route literals', async () => {
       'modules/layout.js': 'export default { mount() { const externalBase = "https://api.example.test"; const url = new URL(`${externalBase}/product`, window.location.href); url.searchParams.set("id", sku); return url.href; }, views: {}, components: {}, effects: {} };'
     }
   })));
-  assert.doesNotThrow(() => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })));
+  assert.throws(
+    () => collectThemeArchiveEntries(makeThemeZip({ contractVersion: 3 })),
+    /contractVersion/i
+  );
 });
 
 await run('rejects invalid theme manifests before staging', async () => {
@@ -2679,7 +2689,7 @@ await run('rejects invalid theme manifests before staging', async () => {
       'press-theme-bad/theme.json': JSON.stringify({
         name: 'Bad',
         version: '1.0.0',
-        contractVersion: 3,
+        contractVersion: 4,
         styles: ['theme.css']
       }, null, 2),
       'press-theme-bad/theme.css': ':root{}'
@@ -2756,7 +2766,7 @@ await run('blocks official theme releases outside the current Press engine range
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 3,
+        contractVersion: 4,
         engines: { press: '>=4.0.0 <5.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
@@ -3069,8 +3079,8 @@ await run('filters catalog-inferred inventory to existing files during uninstall
         value: 'cataloged',
         label: 'Cataloged',
         version: '1.0.0',
-        contractVersion: 3,
-        engines: { press: '>=3.4.0 <4.0.0' },
+        contractVersion: 4,
+        engines: { press: '>=3.4.130 <4.0.0' },
         asset: {
           name: 'press-theme-cataloged-v1.0.0.zip',
           url: 'https://example.test/press-theme-cataloged-v1.0.0.zip',

--- a/wwwroot/post/theme-contract/theme-contract_en.md
+++ b/wwwroot/post/theme-contract/theme-contract_en.md
@@ -72,9 +72,8 @@ content shapes, and archive file-type rules.
 
 - `name` and `version`: Human-facing theme identity.
 - `contractVersion`: Press runtime contract version. Contract v4 is the current
-  route href helper contract. During the v4 transition Press accepts v3 and v4
-  themes, while new v4 themes must use runtime route helpers instead of public
-  route literals.
+  and only supported route href helper contract. Themes must use runtime route
+  helpers instead of public route literals.
 - `engines.press`: Press system SemVer range the theme supports. Theme Manager
   rejects official and manually imported themes outside the current Press
   version.


### PR DESCRIPTION
## Summary
- make Press v3.4.131 the theme contract v4 cleanup release
- reduce supported theme contracts and schema enum to v4-only
- raise the system update theme guard to requiresInstalledThemeContractVersion: 4
- update Product State, Theme Manager/package tests, docs, and the Press-owned contract package to v3.4.131

## Verification
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-product-state-ledger.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-system-updates.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-theme-manager.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-contracts.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-contract-package.mjs`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-press-version-runtime.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-intent.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-runtime.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-ui-components.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-press-system-surface.mjs`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-main-guard.sh`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-package.sh`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-workflow.sh`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/sync-runtime-cache-keys.mjs --check`
- `git diff --check`

## Review
- cleanup-diff subagent review reported no P1/P2 findings

## Release notes
- This is the Press cleanup step after v3.4.130; Catalog v4-only cleanup follows after this release is live.
