### PR TITLE
Add theme settings contract

### DIFF
--- a/assets/js/composer-site-model.js
+++ b/assets/js/composer-site-model.js
@@ -3,6 +3,10 @@ import {
   normalizeSiteFeatureSettings,
   siteFeatureSettingsForOutput
 } from './site-features.js';
+import {
+  normalizeThemeSettingsMap,
+  themeSettingsForOutput
+} from './theme-settings.js';
 
 function deepClone(value) {
   try {
@@ -85,6 +89,7 @@ export function prepareSiteState(raw) {
   site.themeMode = safeString(src.themeMode || '');
   site.themePack = safeString(src.themePack || '');
   site.themeOverride = normalizeBoolean(src.themeOverride);
+  site.themeSettings = normalizeThemeSettingsMap(src.themeSettings);
   site.features = normalizeSiteFeatureSettings(src.features);
   const enableAllPosts = normalizeBoolean(src.enableAllPosts);
   const disableAllPosts = normalizeBoolean(src.disableAllPosts);
@@ -117,7 +122,7 @@ export function prepareSiteState(raw) {
   const recognized = new Set([
     'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'resourceURL', 'contentRoot',
     'profileLinks', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'postsPerPage',
-    'defaultLanguage', 'themeMode', 'themePack', 'themeOverride', 'repo', 'annotate', 'assetWarnings', 'landingTab', 'showAllPosts',
+    'defaultLanguage', 'themeMode', 'themePack', 'themeOverride', 'themeSettings', 'repo', 'annotate', 'assetWarnings', 'landingTab', 'showAllPosts',
     'enableAllPosts', 'disableAllPosts', 'features', 'connect'
   ]);
   const deprecated = new Set(['links']);
@@ -152,6 +157,7 @@ export function cloneSiteState(state) {
     themeMode: safeString(state.themeMode || ''),
     themePack: safeString(state.themePack || ''),
     themeOverride: normalizeBoolean(state.themeOverride),
+    themeSettings: normalizeThemeSettingsMap(state.themeSettings),
     features: normalizeSiteFeatureSettings(state.features),
     showAllPosts: normalizeBoolean(state.showAllPosts),
     landingTab: safeString(state.landingTab || ''),
@@ -267,6 +273,8 @@ function buildSiteSnapshot(state) {
   if (site.themeMode) snapshot.themeMode = site.themeMode;
   if (site.themePack) snapshot.themePack = site.themePack;
   if (site.themeOverride != null) snapshot.themeOverride = !!site.themeOverride;
+  const themeSettings = themeSettingsForOutput(site.themeSettings);
+  if (themeSettings) snapshot.themeSettings = themeSettings;
   const features = siteFeatureSettingsForOutput(site.features);
   if (features) snapshot.features = features;
   if (site.showAllPosts != null) snapshot.showAllPosts = !!site.showAllPosts;
@@ -368,6 +376,11 @@ export function computeSiteDiff(current, baseline) {
   });
   if (Object.keys(featureFields).length) {
     diff.fields.features = { type: 'object', fields: featureFields };
+    diff.hasChanges = true;
+  }
+
+  if (stableSerialize(cur.themeSettings || {}) !== stableSerialize(base.themeSettings || {})) {
+    diff.fields.themeSettings = { type: 'object' };
     diff.hasChanges = true;
   }
 
@@ -532,7 +545,7 @@ export function toSiteYaml(data) {
   const keysInOrder = [
     'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'profileLinks', 'resourceURL',
     'contentRoot', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'defaultLanguage',
-    'themeMode', 'themePack', 'themeOverride', 'features', 'showAllPosts', 'landingTab', 'repo', 'annotate', 'connect', 'assetWarnings'
+    'themeMode', 'themePack', 'themeOverride', 'themeSettings', 'features', 'showAllPosts', 'landingTab', 'repo', 'annotate', 'connect', 'assetWarnings'
   ];
   const ordered = {};
   keysInOrder.forEach((key) => {

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -488,6 +488,19 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
               commitValue(checkbox.checked);
               syncSwitchState(checkbox, toggle, checkbox.checked, false);
             });
+            if (field.defaultValue === undefined) {
+              const unsetButton = documentRef.createElement('button');
+              unsetButton.type = 'button';
+              unsetButton.className = 'btn-secondary btn-compact';
+              unsetButton.dataset.field = 'themeSettings';
+              unsetButton.dataset.subfield = field.key;
+              unsetButton.textContent = 'Not set';
+              unsetButton.addEventListener('click', () => {
+                commitValue(undefined);
+                syncSwitchState(checkbox, toggle, false, false);
+              });
+              controlCell.appendChild(unsetButton);
+            }
             return;
           }
 
@@ -561,7 +574,7 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
             commitValue(nextValue);
           });
           controlCell.appendChild(input);
-          if (field.control === 'color' && field.defaultValue === undefined) {
+          if ((field.control === 'color' || field.control === 'range') && field.defaultValue === undefined) {
             const unsetButton = documentRef.createElement('button');
             unsetButton.type = 'button';
             unsetButton.className = 'btn-secondary btn-compact';

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -1,4 +1,9 @@
 import { SITE_FEATURE_KEYS, isSiteFeatureEnabled } from './site-features.js';
+import {
+  resolveThemeSettings,
+  sanitizeThemeSlug,
+  setThemeSettingOverride
+} from './theme-settings.js';
 
 export function createComposerSiteSettingsConfigGrids(options = {}) {
   const noop = () => {};
@@ -287,6 +292,7 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
   const renderThemeGrid = (section) => {
     const { addRow } = createSingleGridFieldset(section);
     const rows = [];
+    let themeSettingsRenderToken = 0;
     const addThemeRow = (item) => {
       const row = addRow(item, rows.length);
       rows.push(row);
@@ -388,6 +394,181 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
       options: []
     });
 
+    const themeSettingsBlock = documentRef.createElement('div');
+    themeSettingsBlock.className = 'cs-theme-settings';
+    themeSettingsBlock.hidden = true;
+
+    const clearThemeSettingsBlock = () => {
+      themeSettingsBlock.innerHTML = '';
+      themeSettingsBlock.hidden = true;
+    };
+
+    const appendThemeSettingsMessage = (message) => {
+      themeSettingsBlock.innerHTML = '';
+      const note = documentRef.createElement('p');
+      note.className = 'cs-field-help cs-theme-settings-warning';
+      note.textContent = message;
+      themeSettingsBlock.appendChild(note);
+      themeSettingsBlock.hidden = false;
+    };
+
+    const colorInputValue = (value) => {
+      const color = safeString(value).trim();
+      const short = color.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+      if (short) return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`.toLowerCase();
+      return /^#[0-9a-f]{6}$/i.test(color) ? color.toLowerCase() : '#000000';
+    };
+
+    const appendThemeSettingsHeader = (pack, manifest, warningCount) => {
+      const head = documentRef.createElement('div');
+      head.className = 'cs-config-subsection-head';
+      const title = documentRef.createElement('div');
+      title.className = 'cs-config-subsection-title';
+      title.textContent = 'Current theme settings';
+      head.appendChild(title);
+      const desc = documentRef.createElement('p');
+      desc.className = 'cs-config-subsection-description';
+      const label = safeString(manifest && manifest.name ? manifest.name : pack) || pack;
+      desc.textContent = warningCount
+        ? `${label}: ${warningCount} setting warning${warningCount === 1 ? '' : 's'}`
+        : label;
+      head.appendChild(desc);
+      themeSettingsBlock.appendChild(head);
+    };
+
+    const renderThemeSettingsFields = (pack, manifest, resolution) => {
+      themeSettingsBlock.innerHTML = '';
+      const fields = Array.isArray(resolution.fields) ? resolution.fields : [];
+      const warnings = Array.isArray(resolution.warnings) ? resolution.warnings : [];
+      if (!fields.length && !warnings.length) {
+        clearThemeSettingsBlock();
+        return;
+      }
+      appendThemeSettingsHeader(pack, manifest, warnings.length);
+      if (warnings.length) {
+        const warningList = documentRef.createElement('ul');
+        warningList.className = 'cs-extra-list';
+        warnings.slice(0, 5).forEach((entry) => {
+          const item = documentRef.createElement('li');
+          item.textContent = entry && entry.message ? entry.message : String(entry || '');
+          warningList.appendChild(item);
+        });
+        themeSettingsBlock.appendChild(warningList);
+      }
+      if (fields.length) {
+        const { addRow: addSettingRow } = createSingleGridFieldset(themeSettingsBlock);
+        fields.forEach((field, index) => {
+          const rowConfig = {
+            dataKey: `themeSettings-${field.key}`,
+            label: field.label || field.key,
+            description: field.description || field.key
+          };
+          const { row, controlCell, controlId } = addSettingRow(rowConfig, index);
+          row.dataset.field = 'themeSettings';
+          row.dataset.subfield = field.key;
+          const currentValue = Object.prototype.hasOwnProperty.call(resolution.settings || {}, field.key)
+            ? resolution.settings[field.key]
+            : field.defaultValue;
+          const commitValue = (value) => {
+            const changed = setThemeSettingOverride(site, pack, field.key, value, field);
+            if (changed) markDirty();
+          };
+
+          if (field.control === 'boolean') {
+            const { toggle, checkbox } = createSwitchControl(row, field.label || field.key, {
+              target: controlCell,
+              classes: ['cs-single-grid-switch']
+            });
+            toggle.dataset.field = 'themeSettings';
+            toggle.dataset.subfield = field.key;
+            const initial = currentValue === true;
+            syncSwitchState(checkbox, toggle, initial, false);
+            checkbox.addEventListener('change', () => {
+              commitValue(checkbox.checked);
+              syncSwitchState(checkbox, toggle, checkbox.checked, false);
+            });
+            return;
+          }
+
+          if (field.control === 'select') {
+            const select = documentRef.createElement('select');
+            select.id = controlId;
+            select.className = 'cs-select';
+            select.dataset.field = 'themeSettings';
+            select.dataset.subfield = field.key;
+            (field.options || []).forEach((optionData) => {
+              const option = documentRef.createElement('option');
+              option.value = safeString(optionData.value);
+              option.textContent = safeString(optionData.label || optionData.value);
+              select.appendChild(option);
+            });
+            select.value = safeString(currentValue);
+            select.addEventListener('change', () => {
+              const selected = (field.options || []).find(option => safeString(option.value) === select.value);
+              commitValue(selected ? selected.value : select.value);
+            });
+            controlCell.appendChild(select);
+            return;
+          }
+
+          const input = documentRef.createElement('input');
+          input.id = controlId;
+          input.className = 'cs-input';
+          input.dataset.field = 'themeSettings';
+          input.dataset.subfield = field.key;
+          if (field.control === 'color') {
+            input.type = 'color';
+            input.value = colorInputValue(currentValue);
+          } else if (field.control === 'range') {
+            input.type = 'range';
+            if (field.minimum != null && !Number.isNaN(field.minimum)) input.min = String(field.minimum);
+            if (field.maximum != null && !Number.isNaN(field.maximum)) input.max = String(field.maximum);
+            if (field.step != null && !Number.isNaN(field.step)) input.step = String(field.step);
+            input.value = currentValue == null ? '' : String(currentValue);
+          } else if (field.control === 'number') {
+            input.type = 'number';
+            if (field.minimum != null && !Number.isNaN(field.minimum)) input.min = String(field.minimum);
+            if (field.maximum != null && !Number.isNaN(field.maximum)) input.max = String(field.maximum);
+            if (field.step != null && !Number.isNaN(field.step)) input.step = String(field.step);
+            input.value = currentValue == null ? '' : String(currentValue);
+          } else {
+            input.type = 'text';
+            input.value = currentValue == null ? '' : String(currentValue);
+          }
+          input.addEventListener('input', () => {
+            const nextValue = input.type === 'number' || input.type === 'range'
+              ? Number(input.value)
+              : input.value;
+            commitValue(nextValue);
+          });
+          controlCell.appendChild(input);
+        });
+      }
+      themeSettingsBlock.hidden = false;
+    };
+
+    const renderThemeSettingsForCurrentPack = () => {
+      const token = ++themeSettingsRenderToken;
+      const pack = sanitizeThemeSlug(sanitizeThemePackValue(site.themePack || themePackSelect.value || 'native') || 'native');
+      clearThemeSettingsBlock();
+      if (!fetchContent) return;
+      fetchContent(`assets/themes/${encodeURIComponent(pack)}/theme.json`, { cache: 'no-store' })
+        .then((response) => {
+          if (!response || !response.ok) throw new Error(`HTTP ${response && response.status ? response.status : 0}`);
+          return response.json();
+        })
+        .then((manifest) => {
+          if (token !== themeSettingsRenderToken) return;
+          const resolution = resolveThemeSettings({ pack, manifest, siteConfig: site });
+          renderThemeSettingsFields(pack, manifest, resolution);
+        })
+        .catch((err) => {
+          if (token !== themeSettingsRenderToken) return;
+          const message = err && err.message ? err.message : 'Theme manifest is unavailable.';
+          appendThemeSettingsMessage(`Theme settings are unavailable for ${pack}: ${message}`);
+        });
+    };
+
     const fallbackThemePacks = [
       { value: 'native', label: 'Native' },
       { value: 'github', label: 'GitHub' },
@@ -419,6 +600,7 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
       }
       const nextValue = current && seen.has(current) ? current : firstOption || '';
       themePackSelect.value = nextValue;
+      renderThemeSettingsForCurrentPack();
     };
 
     applyThemePackOptions(fallbackThemePacks);
@@ -434,6 +616,10 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
       .catch(() => {
         applyThemePackOptions(fallbackThemePacks);
       });
+
+    themePackSelect.addEventListener('change', () => {
+      renderThemeSettingsForCurrentPack();
+    });
 
     const manageThemesRow = addThemeRow({
       dataKey: 'manageThemes',
@@ -464,6 +650,8 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
       markDirty();
     });
     syncSwitchState(checkbox, toggle, site.themeOverride, true);
+    section.appendChild(themeSettingsBlock);
+    renderThemeSettingsForCurrentPack();
   };
 
   const renderAnnotateGrid = (section) => {

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -500,6 +500,13 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
             const options = field.options || [];
             const currentSignature = themeSettingValueSignature(currentValue);
             let selectedOptionIndex = -1;
+            if (field.defaultValue === undefined) {
+              const unsetOption = documentRef.createElement('option');
+              unsetOption.value = '';
+              unsetOption.dataset.valueSignature = '';
+              unsetOption.textContent = 'Not set';
+              select.appendChild(unsetOption);
+            }
             options.forEach((optionData, index) => {
               const option = documentRef.createElement('option');
               option.value = String(index);
@@ -509,7 +516,12 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
               select.appendChild(option);
             });
             if (selectedOptionIndex >= 0) select.value = String(selectedOptionIndex);
+            else if (field.defaultValue === undefined) select.value = '';
             select.addEventListener('change', () => {
+              if (select.value === '') {
+                commitValue(undefined);
+                return;
+              }
               const selectedIndex = Number(select.value);
               const selected = Number.isInteger(selectedIndex) ? options[selectedIndex] : null;
               commitValue(selected ? selected.value : select.value);

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -561,6 +561,16 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
             commitValue(nextValue);
           });
           controlCell.appendChild(input);
+          if (field.control === 'color' && field.defaultValue === undefined) {
+            const unsetButton = documentRef.createElement('button');
+            unsetButton.type = 'button';
+            unsetButton.className = 'btn-secondary btn-compact';
+            unsetButton.dataset.field = 'themeSettings';
+            unsetButton.dataset.subfield = field.key;
+            unsetButton.textContent = 'Not set';
+            unsetButton.addEventListener('click', () => commitValue(undefined));
+            controlCell.appendChild(unsetButton);
+          }
         });
       }
       themeSettingsBlock.hidden = false;

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -557,7 +557,7 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
           input.addEventListener('input', () => {
             const nextValue = (input.type === 'number' || input.type === 'range')
               ? (input.value === '' ? undefined : Number(input.value))
-              : input.value;
+              : (field.control === 'text' && field.defaultValue === undefined && input.value === '' ? undefined : input.value);
             commitValue(nextValue);
           });
           controlCell.appendChild(input);

--- a/assets/js/composer-site-settings-config-grids.js
+++ b/assets/js/composer-site-settings-config-grids.js
@@ -2,7 +2,8 @@ import { SITE_FEATURE_KEYS, isSiteFeatureEnabled } from './site-features.js';
 import {
   resolveThemeSettings,
   sanitizeThemeSlug,
-  setThemeSettingOverride
+  setThemeSettingOverride,
+  themeSettingValueSignature
 } from './theme-settings.js';
 
 export function createComposerSiteSettingsConfigGrids(options = {}) {
@@ -496,15 +497,21 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
             select.className = 'cs-select';
             select.dataset.field = 'themeSettings';
             select.dataset.subfield = field.key;
-            (field.options || []).forEach((optionData) => {
+            const options = field.options || [];
+            const currentSignature = themeSettingValueSignature(currentValue);
+            let selectedOptionIndex = -1;
+            options.forEach((optionData, index) => {
               const option = documentRef.createElement('option');
-              option.value = safeString(optionData.value);
+              option.value = String(index);
+              option.dataset.valueSignature = themeSettingValueSignature(optionData.value);
               option.textContent = safeString(optionData.label || optionData.value);
+              if (option.dataset.valueSignature === currentSignature) selectedOptionIndex = index;
               select.appendChild(option);
             });
-            select.value = safeString(currentValue);
+            if (selectedOptionIndex >= 0) select.value = String(selectedOptionIndex);
             select.addEventListener('change', () => {
-              const selected = (field.options || []).find(option => safeString(option.value) === select.value);
+              const selectedIndex = Number(select.value);
+              const selected = Number.isInteger(selectedIndex) ? options[selectedIndex] : null;
               commitValue(selected ? selected.value : select.value);
             });
             controlCell.appendChild(select);
@@ -536,8 +543,8 @@ export function createComposerSiteSettingsConfigGrids(options = {}) {
             input.value = currentValue == null ? '' : String(currentValue);
           }
           input.addEventListener('input', () => {
-            const nextValue = input.type === 'number' || input.type === 'range'
-              ? Number(input.value)
+            const nextValue = (input.type === 'number' || input.type === 'range')
+              ? (input.value === '' ? undefined : Number(input.value))
               : input.value;
             commitValue(nextValue);
           });

--- a/assets/js/composer-yaml-site-feature.js
+++ b/assets/js/composer-yaml-site-feature.js
@@ -31,6 +31,7 @@ const SITE_FIELD_LABEL_MAP = {
   themeMode: { i18nKey: 'editor.composer.site.fields.themeMode' },
   themePack: { i18nKey: 'editor.composer.site.fields.themePack' },
   themeOverride: { i18nKey: 'editor.composer.site.fields.themeOverride' },
+  themeSettings: { i18nKey: 'editor.composer.site.sections.theme.title', fallback: 'Theme settings' },
   features: { i18nKey: 'editor.composer.site.sections.publicChrome.title', fallback: 'Public chrome' },
   showAllPosts: { i18nKey: 'editor.composer.site.fields.showAllPosts' },
   landingTab: { i18nKey: 'editor.composer.site.fields.landingTab' },

--- a/assets/js/editor-preview-runtime.js
+++ b/assets/js/editor-preview-runtime.js
@@ -388,7 +388,8 @@ async function renderPreview(payload = {}) {
       persist: false,
       reset,
       features,
-      router: previewRouter
+      router: previewRouter,
+      siteConfig: payload.siteConfig || {}
     });
     if (!isCurrentPreviewRender(requestId)) return;
     const activePack = previewRuntime.setActiveThemePack((layout && layout.pack) || previewRuntime.getThemeLayoutPackFallback() || requestedPack);

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -138,6 +138,7 @@ function reflectThemeRuntimeConfig(context, options = {}, themeSettings = null) 
 
 function refreshThemeLayoutRuntimeContext(context, options = {}, regionController = null) {
   if (!context || typeof context !== 'object') return context;
+  const shouldReflectThemeConfig = !options || options.reflectThemeConfig !== false;
   if (options && Object.prototype.hasOwnProperty.call(options, 'features')) {
     context.features = options.features || null;
   }
@@ -156,7 +157,7 @@ function refreshThemeLayoutRuntimeContext(context, options = {}, regionControlle
     context.themeSettings = resolvedSettings;
     const documentRef = context.document || (typeof document !== 'undefined' ? document : null);
     applyThemeSettingsCssVariables(documentRef, resolvedSettings);
-    reflectThemeRuntimeConfig(context, options, resolvedSettings);
+    if (shouldReflectThemeConfig) reflectThemeRuntimeConfig(context, options, resolvedSettings);
   }
   if (regionController && typeof regionController.setThemeLayoutContext === 'function') {
     regionController.setThemeLayoutContext(context);
@@ -616,7 +617,6 @@ async function mountPack(pack, allowFallback = true, options = {}) {
 
   if (!isCurrentMountGeneration(mountGeneration, options)) return null;
   document.body.dataset.themeLayout = pack;
-  reflectThemeRuntimeConfig(context, runtimeOptions, themeSettings);
   warnMissingRegions(pack, manifest, context);
   regionController.setThemeLayoutContext(context);
   if (persist && pack !== DEFAULT_PACK) {

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -111,7 +111,7 @@ function firstDefined(...values) {
 }
 
 function reflectThemeRuntimeConfig(context, options = {}, themeSettings = null) {
-  if (!context || !context.theme || !context.theme.effects) return false;
+  if (!context.theme || !context.theme.effects) return false;
   const effect = context.theme.effects.reflectThemeConfig;
   if (typeof effect !== 'function') return false;
   const siteConfig = options && options.siteConfig && typeof options.siteConfig === 'object'

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -27,6 +27,10 @@ import {
   getDefaultThemeStyles,
   getRequiredThemeContentShapes
 } from './theme-contract-surface.mjs';
+import {
+  applyThemeSettingsCssVariables,
+  resolveThemeSettings
+} from './theme-settings.js';
 
 function createThemeLayoutState(options = {}) {
   return {
@@ -106,6 +110,32 @@ function firstDefined(...values) {
   return undefined;
 }
 
+function reflectThemeRuntimeConfig(context, options = {}, themeSettings = null) {
+  if (!context || !context.theme || !context.theme.effects) return false;
+  const effect = context.theme.effects.reflectThemeConfig;
+  if (typeof effect !== 'function') return false;
+  const siteConfig = options && options.siteConfig && typeof options.siteConfig === 'object'
+    ? options.siteConfig
+    : {};
+  const documentRef = context.document || (typeof document !== 'undefined' ? document : null);
+  const windowRef = (documentRef && documentRef.defaultView) || (typeof window !== 'undefined' ? window : null);
+  try {
+    effect({
+      config: siteConfig,
+      siteConfig,
+      ctx: context,
+      themeSettings: themeSettings || context.themeSettings || null,
+      features: context.features || null,
+      document: documentRef,
+      window: windowRef
+    });
+    return true;
+  } catch (err) {
+    themeDevWarn(`Theme "${context.pack || ''}" reflectThemeConfig failed`, err);
+  }
+  return false;
+}
+
 function refreshThemeLayoutRuntimeContext(context, options = {}, regionController = null) {
   if (!context || typeof context !== 'object') return context;
   if (options && Object.prototype.hasOwnProperty.call(options, 'features')) {
@@ -113,6 +143,20 @@ function refreshThemeLayoutRuntimeContext(context, options = {}, regionControlle
   }
   if (options && Object.prototype.hasOwnProperty.call(options, 'router')) {
     context.router = options.router || null;
+  }
+  if (context.manifest && context.theme && typeof context.theme === 'object') {
+    const resolvedSettings = resolveThemeSettings({
+      pack: context.pack,
+      manifest: context.manifest,
+      siteConfig: options.siteConfig || {}
+    });
+    context.theme.settings = resolvedSettings.settings;
+    context.theme.settingFields = resolvedSettings.fields;
+    context.theme.settingWarnings = resolvedSettings.warnings;
+    context.themeSettings = resolvedSettings;
+    const documentRef = context.document || (typeof document !== 'undefined' ? document : null);
+    applyThemeSettingsCssVariables(documentRef, resolvedSettings);
+    reflectThemeRuntimeConfig(context, options, resolvedSettings);
   }
   if (regionController && typeof regionController.setThemeLayoutContext === 'function') {
     regionController.setThemeLayoutContext(context);
@@ -295,6 +339,9 @@ function createThemeApi(pack, manifest) {
     version: String((manifest && manifest.version) || ''),
     contractVersion: firstDefined(manifest && manifest.contractVersion, CONTRACT_VERSION),
     manifest,
+    settings: {},
+    settingFields: [],
+    settingWarnings: [],
     mount: null,
     unmount: null,
     regions: asObject(manifest && manifest.regions) || {},
@@ -517,6 +564,16 @@ async function mountPack(pack, allowFallback = true, options = {}) {
   }
 
   const runtimeOptions = themeLayoutState.latestLayoutOptions || options;
+  const themeSettings = resolveThemeSettings({
+    pack,
+    manifest,
+    siteConfig: runtimeOptions.siteConfig || {}
+  });
+  const themeApi = createThemeApi(pack, manifest);
+  themeApi.settings = themeSettings.settings;
+  themeApi.settingFields = themeSettings.fields;
+  themeApi.settingWarnings = themeSettings.warnings;
+
   const context = {
     document: document,
     i18n: createThemeI18nContext(),
@@ -525,7 +582,8 @@ async function mountPack(pack, allowFallback = true, options = {}) {
     router: runtimeOptions.router || null,
     pack,
     manifest,
-    theme: createThemeApi(pack, manifest),
+    theme: themeApi,
+    themeSettings,
     utilities: {
       getRegion: (names) => regionController.getThemeRegion(names),
       warn: themeDevWarn
@@ -535,6 +593,7 @@ async function mountPack(pack, allowFallback = true, options = {}) {
   if (!isCurrentMountGeneration(mountGeneration, options)) return null;
   regionController.setThemeLayoutContext(context);
   applyManifestStyles(pack, manifest);
+  applyThemeSettingsCssVariables(document, themeSettings);
 
   for (const { entry, mod } of loadedModules) {
     try {
@@ -557,6 +616,7 @@ async function mountPack(pack, allowFallback = true, options = {}) {
 
   if (!isCurrentMountGeneration(mountGeneration, options)) return null;
   document.body.dataset.themeLayout = pack;
+  reflectThemeRuntimeConfig(context, runtimeOptions, themeSettings);
   warnMissingRegions(pack, manifest, context);
   regionController.setThemeLayoutContext(context);
   if (persist && pack !== DEFAULT_PACK) {

--- a/assets/js/theme-package-core.js
+++ b/assets/js/theme-package-core.js
@@ -11,12 +11,15 @@ import {
   getThemeTextExtensions,
   isPressThemeContractVersionSupported
 } from './theme-contract-surface.mjs';
+import { validateThemeConfigSchema } from './theme-settings.js';
 import {
   canParseV4RouteGuardSource,
   collectV4RouteGuardFacts,
   containsForbiddenV4RouteConstructionAst
 } from './theme-route-guard.js';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
+
+export { validateThemeConfigSchema } from './theme-settings.js';
 
 export const REQUIRED_THEME_CONTRACT_VERSION = PRESS_THEME_CONTRACT.contractVersion;
 
@@ -4162,6 +4165,7 @@ function validateThemeManifestContract(themeManifest, availablePaths) {
     throw new Error('Theme manifest scrollContainer is required.');
   }
   requireThemeObject(themeManifest.configSchema, 'configSchema');
+  validateThemeConfigSchema(themeManifest.configSchema);
   const content = requireThemeObject(themeManifest.content, 'content');
   const shapes = new Set(requireThemeStringList(content, 'shapes', 'content.shapes'));
   REQUIRED_THEME_CONTENT_SHAPES.forEach((shape) => {

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -92,13 +92,17 @@ export function getThemeSettingsForSlug(siteConfig = {}, slug = '') {
 }
 
 function hasPressUiMetadata(value) {
-  if (typeof value === 'string') return value.trim() !== '';
+  if (typeof value === 'string') return SUPPORTED_THEME_SETTING_CONTROLS.includes(value.trim().toLowerCase());
   if (!isPlainObject(value)) return false;
   return PRESS_UI_METADATA_KEYS.some(key => Object.prototype.hasOwnProperty.call(value, key));
 }
 
 function normalizeUiMetadata(value, allowGenericUi = false) {
-  if (typeof value === 'string') return { control: value };
+  if (typeof value === 'string') {
+    const control = value.trim().toLowerCase();
+    if (allowGenericUi || SUPPORTED_THEME_SETTING_CONTROLS.includes(control)) return { control: value };
+    return null;
+  }
   if (isPlainObject(value) && (allowGenericUi || hasPressUiMetadata(value))) return value;
   return null;
 }
@@ -231,7 +235,8 @@ function normalizeNumber(value, field) {
   if (field.minimum != null && num < field.minimum) return { ok: false, value: null };
   if (field.maximum != null && num > field.maximum) return { ok: false, value: null };
   if (field.step != null && Number.isFinite(field.step) && field.step > 0) {
-    const scaled = num / field.step;
+    const base = Number.isFinite(field.stepBase) ? field.stepBase : 0;
+    const scaled = (num - base) / field.step;
     if (Math.abs(scaled - Math.round(scaled)) > 1e-8) return { ok: false, value: null };
   }
   return { ok: true, value: field.integer ? Math.trunc(num) : num };
@@ -261,7 +266,8 @@ export function normalizeThemeSettingValue(field, value) {
     return byString ? { ok: true, value: byString.value } : { ok: false, value: null };
   }
   if (field.control === 'text') {
-    const text = String(value == null ? '' : value);
+    if (typeof value !== 'string') return { ok: false, value: null };
+    const text = value;
     if (field.minLength != null && text.length < field.minLength) return { ok: false, value: null };
     if (field.maxLength != null && text.length > field.maxLength) return { ok: false, value: null };
     if (field.pattern) {
@@ -347,6 +353,7 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       if (!SAFE_CSS_VARIABLE_PATTERN.test(name)) addIssue(`Theme setting "${key}" has an unsafe CSS variable "${name}".`, `${path}.${THEME_SETTINGS_META_KEY}.cssVariable`);
     });
     const rawStep = schema.multipleOf != null ? Number(schema.multipleOf) : (schema.step != null ? Number(schema.step) : null);
+    const rawStepBase = schema.multipleOf != null ? 0 : (schema.minimum != null ? Number(schema.minimum) : 0);
     if (rawStep != null && (!Number.isFinite(rawStep) || rawStep <= 0)) {
       addIssue(`Theme setting "${key}" step must be a positive finite number.`, `${path}.${schema.multipleOf != null ? 'multipleOf' : 'step'}`);
     }
@@ -364,11 +371,18 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       minimum: schema.minimum != null ? Number(schema.minimum) : null,
       maximum: schema.maximum != null ? Number(schema.maximum) : null,
       step: rawStep != null && Number.isFinite(rawStep) && rawStep > 0 ? rawStep : null,
+      stepBase: Number.isFinite(rawStepBase) ? rawStepBase : 0,
       integer: type === 'integer',
       minLength: schema.minLength != null ? Number(schema.minLength) : null,
       maxLength: schema.maxLength != null ? Number(schema.maxLength) : null,
       pattern: schema.pattern || ''
     };
+    if (strict && schema.default !== undefined) {
+      const normalizedDefault = normalizeThemeSettingValue(field, schema.default);
+      if (!normalizedDefault.ok) {
+        addIssue(`Default value for theme setting "${key}" is invalid.`, `${path}.default`);
+      }
+    }
     fields.push(field);
   });
 
@@ -456,14 +470,18 @@ export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
   const safeSlug = sanitizeThemeSlug(slug || siteConfig.themePack || 'native');
   const safeKey = normalizeSettingKey(key);
   if (!safeSlug || !safeKey) return false;
-  if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])) siteConfig[THEME_SETTINGS_ROOT_KEY] = {};
-  if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
-  const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+  const cleanup = (target) => {
+    if (target && !Object.keys(target).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+    if (isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY]) && !Object.keys(siteConfig[THEME_SETTINGS_ROOT_KEY]).length) {
+      delete siteConfig[THEME_SETTINGS_ROOT_KEY];
+    }
+  };
   if (value === undefined && (!field || field.defaultValue === undefined)) {
+    if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY]) || !isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) return false;
+    const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
     const hadValue = Object.prototype.hasOwnProperty.call(target, safeKey);
     delete target[safeKey];
-    if (!Object.keys(target).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
-    if (!Object.keys(siteConfig[THEME_SETTINGS_ROOT_KEY]).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY];
+    cleanup(target);
     return hadValue;
   }
   const normalizedValue = normalizeThemeSettingValue(field, value);
@@ -471,13 +489,21 @@ export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
   const defaultValue = field && field.defaultValue !== undefined
     ? normalizeThemeSettingValue(field, field.defaultValue)
     : { ok: false };
+  const root = isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY]) ? siteConfig[THEME_SETTINGS_ROOT_KEY] : null;
+  const existingTarget = root && isPlainObject(root[safeSlug]) ? root[safeSlug] : null;
   if (defaultValue.ok && stableSerialize(defaultValue.value) === stableSerialize(normalizedValue.value)) {
+    if (!existingTarget || !Object.prototype.hasOwnProperty.call(existingTarget, safeKey)) return false;
+    const target = existingTarget;
     delete target[safeKey];
+    cleanup(target);
+    return true;
   } else {
+    if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])) siteConfig[THEME_SETTINGS_ROOT_KEY] = {};
+    if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
+    const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+    if (Object.prototype.hasOwnProperty.call(target, safeKey) && stableSerialize(target[safeKey]) === stableSerialize(normalizedValue.value)) return false;
     target[safeKey] = normalizedValue.value;
   }
-  if (!Object.keys(target).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
-  if (!Object.keys(siteConfig[THEME_SETTINGS_ROOT_KEY]).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY];
   return true;
 }
 

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -94,7 +94,11 @@ export function getThemeSettingsForSlug(siteConfig = {}, slug = '') {
 function hasPressUiMetadata(value) {
   if (typeof value === 'string') return SUPPORTED_THEME_SETTING_CONTROLS.includes(value.trim().toLowerCase());
   if (!isPlainObject(value)) return false;
-  return PRESS_UI_METADATA_KEYS.some(key => Object.prototype.hasOwnProperty.call(value, key));
+  if (Object.prototype.hasOwnProperty.call(value, 'control')) {
+    const control = String(value.control || '').trim().toLowerCase();
+    if (SUPPORTED_THEME_SETTING_CONTROLS.includes(control)) return true;
+  }
+  return PRESS_UI_METADATA_KEYS.some(key => key !== 'control' && Object.prototype.hasOwnProperty.call(value, key));
 }
 
 function normalizeUiMetadata(value, allowGenericUi = false) {
@@ -155,11 +159,18 @@ function normalizeOptionList(schema = {}, meta = {}) {
   return options;
 }
 
+function normalizeSchemaType(type) {
+  if (!Array.isArray(type)) return type;
+  const scalar = type.find(entry => ['boolean', 'number', 'integer', 'string'].includes(entry));
+  if (scalar) return scalar;
+  return type.find(entry => entry && entry !== 'null') || type[0];
+}
+
 function inferControl(schema = {}, meta = {}) {
   const requested = String(meta.control || meta.ui || '').trim().toLowerCase();
   if (SUPPORTED_THEME_SETTING_CONTROLS.includes(requested)) return requested;
   const options = normalizeOptionList(schema, meta);
-  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  const type = normalizeSchemaType(schema.type);
   if (options.length) return 'select';
   if (type === 'boolean') return 'boolean';
   if (type === 'number' || type === 'integer') return requested === 'range' ? 'range' : 'number';
@@ -169,7 +180,7 @@ function inferControl(schema = {}, meta = {}) {
 }
 
 function typeMatchesControl(type, control) {
-  const normalizedType = Array.isArray(type) ? type[0] : type;
+  const normalizedType = normalizeSchemaType(type);
   if (!normalizedType) return true;
   if (control === 'boolean') return normalizedType === 'boolean';
   if (control === 'number' || control === 'range') return normalizedType === 'number' || normalizedType === 'integer';
@@ -307,7 +318,7 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       return;
     }
     let meta = getMeta(schema);
-    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+    const type = normalizeSchemaType(schema.type);
     let options = normalizeOptionList(schema, meta);
     const hasMetadata = hasPressSettingMetadata(schema);
     const looksNested = isPlainObject(schema.properties) || schema.items != null;

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -1,0 +1,443 @@
+const APPLIED_THEME_SETTINGS_KEY = Symbol('pressAppliedThemeSettingsCssVariables');
+
+export const THEME_SETTINGS_ROOT_KEY = 'themeSettings';
+export const THEME_SETTINGS_META_KEY = 'x-press';
+export const SUPPORTED_THEME_SETTING_CONTROLS = Object.freeze([
+  'boolean',
+  'color',
+  'number',
+  'range',
+  'select',
+  'text'
+]);
+
+const SAFE_SETTING_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const SAFE_CSS_VARIABLE_PATTERN = /^--[A-Za-z][A-Za-z0-9_-]{0,95}$/;
+const SAFE_CSS_VALUE_PATTERN = /^[#A-Za-z0-9_\-.,%()\s]+$/;
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepClone(value) {
+  try {
+    if (typeof structuredClone === 'function') return structuredClone(value);
+  } catch (_) {}
+  try { return JSON.parse(JSON.stringify(value)); }
+  catch (_) { return value; }
+}
+
+function stableSerialize(value) {
+  if (value == null) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(item => stableSerialize(item)).join(',')}]`;
+  if (typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableSerialize(value[key])}`).join(',')}}`;
+  }
+  return '';
+}
+
+function warning(message, path = '') {
+  return { message, path };
+}
+
+function normalizeSettingKey(value) {
+  const key = String(value || '').trim();
+  return SAFE_SETTING_KEY_PATTERN.test(key) ? key : '';
+}
+
+export function sanitizeThemeSlug(value) {
+  const s = String(value || '').toLowerCase().trim();
+  return s.replace(/[^a-z0-9_-]/g, '') || 'native';
+}
+
+export function normalizeThemeSettingsMap(value) {
+  const source = isPlainObject(value) ? value : {};
+  const out = {};
+  Object.keys(source).forEach((rawSlug) => {
+    const slug = sanitizeThemeSlug(rawSlug);
+    const settings = source[rawSlug];
+    if (!slug || !isPlainObject(settings)) return;
+    out[slug] = deepClone(settings);
+  });
+  return out;
+}
+
+export function themeSettingsForOutput(value) {
+  const source = normalizeThemeSettingsMap(value);
+  const out = {};
+  Object.keys(source).sort().forEach((slug) => {
+    const settings = source[slug];
+    if (settings && Object.keys(settings).length) out[slug] = deepClone(settings);
+  });
+  return Object.keys(out).length ? out : null;
+}
+
+export function getThemeSettingsForSlug(siteConfig = {}, slug = '') {
+  const cfg = isPlainObject(siteConfig) ? siteConfig : {};
+  const map = normalizeThemeSettingsMap(cfg[THEME_SETTINGS_ROOT_KEY]);
+  const safeSlug = sanitizeThemeSlug(slug || cfg.themePack || 'native');
+  return map[safeSlug] && isPlainObject(map[safeSlug]) ? deepClone(map[safeSlug]) : {};
+}
+
+function getMeta(schema = {}) {
+  const fromDash = isPlainObject(schema[THEME_SETTINGS_META_KEY]) ? schema[THEME_SETTINGS_META_KEY] : null;
+  const fromCamel = isPlainObject(schema.xPress) ? schema.xPress : null;
+  const fromUi = isPlainObject(schema.ui) ? schema.ui : null;
+  return fromDash || fromCamel || fromUi || {};
+}
+
+function scalarOptionValue(value) {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  return undefined;
+}
+
+function normalizeOptionList(schema = {}, meta = {}) {
+  const options = [];
+  const seen = new Set();
+  const add = (value, label = null) => {
+    const normalizedValue = scalarOptionValue(value);
+    if (normalizedValue === undefined) return;
+    const signature = stableSerialize(normalizedValue);
+    if (seen.has(signature)) return;
+    seen.add(signature);
+    options.push({
+      value: normalizedValue,
+      label: label == null || String(label).trim() === '' ? String(normalizedValue) : String(label)
+    });
+  };
+  if (Array.isArray(meta.options)) {
+    meta.options.forEach((entry) => {
+      if (isPlainObject(entry)) add(entry.value, entry.label || entry.title);
+      else add(entry);
+    });
+  }
+  if (Array.isArray(schema.enum)) schema.enum.forEach(value => add(value));
+  if (Array.isArray(schema.oneOf)) {
+    schema.oneOf.forEach((entry) => {
+      if (!isPlainObject(entry)) return;
+      add(entry.const, entry.title || entry.label);
+    });
+  }
+  return options;
+}
+
+function inferControl(schema = {}, meta = {}) {
+  const requested = String(meta.control || meta.ui || '').trim().toLowerCase();
+  if (SUPPORTED_THEME_SETTING_CONTROLS.includes(requested)) return requested;
+  const options = normalizeOptionList(schema, meta);
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+  if (options.length) return 'select';
+  if (type === 'boolean') return 'boolean';
+  if (type === 'number' || type === 'integer') return requested === 'range' ? 'range' : 'number';
+  if (schema.format === 'color' || schema.format === 'hex-color') return 'color';
+  if (type === 'string' || !type) return 'text';
+  return '';
+}
+
+function getRequestedControl(meta = {}) {
+  const raw = meta.control || (typeof meta.ui === 'string' ? meta.ui : '');
+  return String(raw || '').trim().toLowerCase();
+}
+
+function normalizeCssVariableList(meta = {}) {
+  const raw = meta.cssVariable || meta.cssVariables;
+  const list = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+  return list.map(item => String(item || '').trim()).filter(Boolean);
+}
+
+function normalizeCssValueMap(meta = {}) {
+  const source = isPlainObject(meta.cssValues) ? meta.cssValues : {};
+  const out = {};
+  Object.keys(source).forEach((key) => {
+    const value = String(source[key] == null ? '' : source[key]).trim();
+    if (value && SAFE_CSS_VALUE_PATTERN.test(value)) out[key] = value;
+  });
+  return out;
+}
+
+function validateCssVariableValue(field, value) {
+  const signature = stableSerialize(value);
+  if (field.cssValues && Object.prototype.hasOwnProperty.call(field.cssValues, String(value))) {
+    return field.cssValues[String(value)];
+  }
+  if (field.control === 'color') return typeof value === 'string' && HEX_COLOR_PATTERN.test(value) ? value.toLowerCase() : '';
+  if (field.control === 'number' || field.control === 'range') return Number.isFinite(Number(value)) ? String(Number(value)) : '';
+  if (field.control === 'boolean') return value === true ? '1' : (value === false ? '0' : '');
+  if (field.options && field.options.some(option => stableSerialize(option.value) === signature)) {
+    const raw = String(value);
+    return SAFE_CSS_VALUE_PATTERN.test(raw) ? raw : '';
+  }
+  if (field.control === 'text') {
+    const raw = String(value == null ? '' : value).trim();
+    return raw && SAFE_CSS_VALUE_PATTERN.test(raw) ? raw : '';
+  }
+  return '';
+}
+
+function normalizeNumber(value, field) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return { ok: false, value: null };
+  if (field.integer && !Number.isInteger(num)) return { ok: false, value: null };
+  if (field.minimum != null && num < field.minimum) return { ok: false, value: null };
+  if (field.maximum != null && num > field.maximum) return { ok: false, value: null };
+  if (field.step != null && Number.isFinite(field.step) && field.step > 0) {
+    const scaled = num / field.step;
+    if (Math.abs(scaled - Math.round(scaled)) > 1e-8) return { ok: false, value: null };
+  }
+  return { ok: true, value: field.integer ? Math.trunc(num) : num };
+}
+
+export function normalizeThemeSettingValue(field, value) {
+  if (!field || !field.key) return { ok: false, value: null };
+  if (field.control === 'boolean') {
+    if (value === true || value === false) return { ok: true, value };
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) return { ok: true, value: true };
+      if (['false', '0', 'no', 'off', 'disabled'].includes(normalized)) return { ok: true, value: false };
+    }
+    return { ok: false, value: null };
+  }
+  if (field.control === 'number' || field.control === 'range') return normalizeNumber(value, field);
+  if (field.control === 'color') {
+    const color = String(value == null ? '' : value).trim();
+    return HEX_COLOR_PATTERN.test(color) ? { ok: true, value: color.toLowerCase() } : { ok: false, value: null };
+  }
+  if (field.control === 'select') {
+    const signature = stableSerialize(value);
+    const found = (field.options || []).find(option => stableSerialize(option.value) === signature);
+    if (found) return { ok: true, value: found.value };
+    const byString = (field.options || []).find(option => String(option.value) === String(value));
+    return byString ? { ok: true, value: byString.value } : { ok: false, value: null };
+  }
+  if (field.control === 'text') {
+    const text = String(value == null ? '' : value);
+    if (field.minLength != null && text.length < field.minLength) return { ok: false, value: null };
+    if (field.maxLength != null && text.length > field.maxLength) return { ok: false, value: null };
+    if (field.pattern) {
+      try {
+        if (!(new RegExp(field.pattern)).test(text)) return { ok: false, value: null };
+      } catch (_) {
+        return { ok: false, value: null };
+      }
+    }
+    return { ok: true, value: text };
+  }
+  return { ok: false, value: null };
+}
+
+export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
+  const strict = options.strict === true;
+  const warnings = [];
+  const errors = [];
+  const addIssue = (message, path) => {
+    const issue = warning(message, path);
+    if (strict) errors.push(issue);
+    else warnings.push(issue);
+  };
+
+  if (!isPlainObject(configSchema)) {
+    addIssue('Theme configSchema must be an object.', 'configSchema');
+    return { fields: [], warnings, errors };
+  }
+
+  const properties = isPlainObject(configSchema.properties) ? configSchema.properties : {};
+  const fields = [];
+  Object.keys(properties).forEach((rawKey) => {
+    const path = `configSchema.properties.${rawKey}`;
+    const key = normalizeSettingKey(rawKey);
+    const schema = properties[rawKey];
+    if (!key) {
+      addIssue(`Unsupported theme setting key "${rawKey}".`, path);
+      return;
+    }
+    if (!isPlainObject(schema)) {
+      addIssue(`Theme setting "${rawKey}" must be an object schema.`, path);
+      return;
+    }
+    const meta = getMeta(schema);
+    const requestedControl = getRequestedControl(meta);
+    if (requestedControl && !SUPPORTED_THEME_SETTING_CONTROLS.includes(requestedControl)) {
+      addIssue(`Theme setting "${key}" uses unsupported control "${requestedControl}".`, `${path}.${THEME_SETTINGS_META_KEY}.control`);
+      return;
+    }
+    const control = inferControl(schema, meta);
+    if (!control) {
+      addIssue(`Theme setting "${key}" uses an unsupported type or control.`, path);
+      return;
+    }
+    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+    if (type === 'object' || type === 'array') {
+      addIssue(`Theme setting "${key}" must be a scalar setting.`, path);
+      return;
+    }
+    const options = normalizeOptionList(schema, meta);
+    if (control === 'select' && !options.length) {
+      addIssue(`Theme setting "${key}" select controls require enum/options.`, path);
+      return;
+    }
+    const cssVariables = normalizeCssVariableList(meta);
+    cssVariables.forEach((name) => {
+      if (!SAFE_CSS_VARIABLE_PATTERN.test(name)) addIssue(`Theme setting "${key}" has an unsafe CSS variable "${name}".`, `${path}.${THEME_SETTINGS_META_KEY}.cssVariable`);
+    });
+    const rawStep = schema.multipleOf != null ? Number(schema.multipleOf) : (schema.step != null ? Number(schema.step) : null);
+    if (rawStep != null && (!Number.isFinite(rawStep) || rawStep <= 0)) {
+      addIssue(`Theme setting "${key}" step must be a positive finite number.`, `${path}.${schema.multipleOf != null ? 'multipleOf' : 'step'}`);
+    }
+    const field = {
+      key,
+      label: String(meta.label || schema.title || key),
+      description: String(meta.description || schema.description || ''),
+      group: String(meta.group || ''),
+      control,
+      type: type || (control === 'boolean' ? 'boolean' : (control === 'number' || control === 'range' ? 'number' : 'string')),
+      defaultValue: schema.default,
+      options,
+      cssVariables: cssVariables.filter(name => SAFE_CSS_VARIABLE_PATTERN.test(name)),
+      cssValues: normalizeCssValueMap(meta),
+      minimum: schema.minimum != null ? Number(schema.minimum) : null,
+      maximum: schema.maximum != null ? Number(schema.maximum) : null,
+      step: rawStep != null && Number.isFinite(rawStep) && rawStep > 0 ? rawStep : null,
+      integer: type === 'integer',
+      minLength: schema.minLength != null ? Number(schema.minLength) : null,
+      maxLength: schema.maxLength != null ? Number(schema.maxLength) : null,
+      pattern: schema.pattern || ''
+    };
+    fields.push(field);
+  });
+
+  fields.sort((a, b) => {
+    const ag = a.group || '';
+    const bg = b.group || '';
+    if (ag !== bg) return ag.localeCompare(bg);
+    return a.key.localeCompare(b.key);
+  });
+  return { fields, warnings, errors };
+}
+
+function buildCssVariables(fields, settings) {
+  const variables = [];
+  fields.forEach((field) => {
+    if (!field.cssVariables || !field.cssVariables.length) return;
+    if (!Object.prototype.hasOwnProperty.call(settings, field.key)) return;
+    const value = validateCssVariableValue(field, settings[field.key]);
+    if (!value) return;
+    field.cssVariables.forEach((name) => variables.push({ key: field.key, name, value }));
+  });
+  return variables;
+}
+
+export function resolveThemeSettings({ pack = 'native', manifest = {}, siteConfig = {} } = {}) {
+  const slug = sanitizeThemeSlug(pack || (siteConfig && siteConfig.themePack) || 'native');
+  const schema = isPlainObject(manifest && manifest.configSchema) ? manifest.configSchema : {};
+  const normalized = normalizeThemeConfigSchema(schema);
+  const warnings = [...normalized.warnings];
+  const fields = normalized.fields;
+  const rawOverrides = getThemeSettingsForSlug(siteConfig, slug);
+  const defaults = {};
+  const overrides = {};
+  const settings = {};
+
+  fields.forEach((field) => {
+    if (field.defaultValue !== undefined) {
+      const normalizedDefault = normalizeThemeSettingValue(field, field.defaultValue);
+      if (normalizedDefault.ok) {
+        defaults[field.key] = normalizedDefault.value;
+        settings[field.key] = normalizedDefault.value;
+      } else {
+        warnings.push(warning(`Default value for theme setting "${field.key}" is invalid.`, `configSchema.properties.${field.key}.default`));
+      }
+    }
+  });
+
+  Object.keys(rawOverrides).forEach((key) => {
+    const field = fields.find(candidate => candidate.key === key);
+    if (!field) {
+      warnings.push(warning(`Unknown theme setting "${key}" was ignored.`, `${THEME_SETTINGS_ROOT_KEY}.${slug}.${key}`));
+      return;
+    }
+    const normalizedValue = normalizeThemeSettingValue(field, rawOverrides[key]);
+    if (!normalizedValue.ok) {
+      warnings.push(warning(`Invalid value for theme setting "${key}" was ignored.`, `${THEME_SETTINGS_ROOT_KEY}.${slug}.${key}`));
+      return;
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(defaults, key)
+      && stableSerialize(defaults[key]) === stableSerialize(normalizedValue.value)
+    ) {
+      settings[key] = normalizedValue.value;
+      return;
+    }
+    overrides[key] = normalizedValue.value;
+    settings[key] = normalizedValue.value;
+  });
+
+  return {
+    pack: slug,
+    schema,
+    fields,
+    defaults,
+    overrides,
+    settings,
+    cssVariables: buildCssVariables(fields, overrides),
+    warnings,
+    errors: normalized.errors
+  };
+}
+
+export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
+  if (!isPlainObject(siteConfig)) return false;
+  const safeSlug = sanitizeThemeSlug(slug || siteConfig.themePack || 'native');
+  const safeKey = normalizeSettingKey(key);
+  if (!safeSlug || !safeKey) return false;
+  if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])) siteConfig[THEME_SETTINGS_ROOT_KEY] = {};
+  if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
+  const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+  const normalizedValue = normalizeThemeSettingValue(field, value);
+  if (!normalizedValue.ok) return false;
+  const defaultValue = field && field.defaultValue !== undefined
+    ? normalizeThemeSettingValue(field, field.defaultValue)
+    : { ok: false };
+  if (defaultValue.ok && stableSerialize(defaultValue.value) === stableSerialize(normalizedValue.value)) {
+    delete target[safeKey];
+  } else {
+    target[safeKey] = normalizedValue.value;
+  }
+  if (!Object.keys(target).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+  if (!Object.keys(siteConfig[THEME_SETTINGS_ROOT_KEY]).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY];
+  return true;
+}
+
+export function applyThemeSettingsCssVariables(documentRef, resolution = {}) {
+  const root = documentRef && documentRef.documentElement;
+  if (!root || !root.style || typeof root.style.setProperty !== 'function') return false;
+  const previous = root[APPLIED_THEME_SETTINGS_KEY] instanceof Set ? root[APPLIED_THEME_SETTINGS_KEY] : new Set();
+  const next = new Map();
+  (Array.isArray(resolution.cssVariables) ? resolution.cssVariables : []).forEach((entry) => {
+    if (!entry || !SAFE_CSS_VARIABLE_PATTERN.test(String(entry.name || ''))) return;
+    const value = String(entry.value == null ? '' : entry.value).trim();
+    if (!value) return;
+    next.set(String(entry.name), value);
+  });
+  previous.forEach((name) => {
+    if (!next.has(name) && typeof root.style.removeProperty === 'function') {
+      root.style.removeProperty(name);
+    }
+  });
+  next.forEach((value, name) => {
+    root.style.setProperty(name, value);
+  });
+  root[APPLIED_THEME_SETTINGS_KEY] = new Set(next.keys());
+  return true;
+}
+
+export function validateThemeConfigSchema(configSchema = {}) {
+  const normalized = normalizeThemeConfigSchema(configSchema, { strict: true });
+  if (normalized.errors.length) {
+    const first = normalized.errors[0];
+    throw new Error(first && first.message ? first.message : 'Theme configSchema contains unsupported settings metadata.');
+  }
+  return true;
+}

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -14,6 +14,7 @@ export const SUPPORTED_THEME_SETTING_CONTROLS = Object.freeze([
 const SAFE_SETTING_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const SAFE_CSS_VARIABLE_PATTERN = /^--[A-Za-z][A-Za-z0-9_-]{0,95}$/;
 const SAFE_CSS_VALUE_PATTERN = /^[#A-Za-z0-9_\-.,%()\s]+$/;
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
 const PRESS_UI_METADATA_KEYS = Object.freeze([
   'control',
   'cssVariable',
@@ -24,6 +25,14 @@ const PRESS_UI_METADATA_KEYS = Object.freeze([
 
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(source, key) {
+  return Object.prototype.hasOwnProperty.call(source, key);
+}
+
+function isUnsafeObjectKey(value) {
+  return UNSAFE_OBJECT_KEYS.has(String(value || ''));
 }
 
 function deepClone(value) {
@@ -62,11 +71,16 @@ export function sanitizeThemeSlug(value) {
   return s.replace(/[^a-z0-9_-]/g, '') || 'native';
 }
 
+function normalizeThemeSettingsSlug(value) {
+  const slug = sanitizeThemeSlug(value);
+  return isUnsafeObjectKey(slug) ? '' : slug;
+}
+
 export function normalizeThemeSettingsMap(value) {
   const source = isPlainObject(value) ? value : {};
   const out = {};
   Object.keys(source).forEach((rawSlug) => {
-    const slug = sanitizeThemeSlug(rawSlug);
+    const slug = normalizeThemeSettingsSlug(rawSlug);
     const settings = source[rawSlug];
     if (!slug || !isPlainObject(settings)) return;
     out[slug] = deepClone(settings);
@@ -87,8 +101,8 @@ export function themeSettingsForOutput(value) {
 export function getThemeSettingsForSlug(siteConfig = {}, slug = '') {
   const cfg = isPlainObject(siteConfig) ? siteConfig : {};
   const map = normalizeThemeSettingsMap(cfg[THEME_SETTINGS_ROOT_KEY]);
-  const safeSlug = sanitizeThemeSlug(slug || cfg.themePack || 'native');
-  return map[safeSlug] && isPlainObject(map[safeSlug]) ? deepClone(map[safeSlug]) : {};
+  const safeSlug = normalizeThemeSettingsSlug(slug || cfg.themePack || 'native');
+  return safeSlug && hasOwn(map, safeSlug) && isPlainObject(map[safeSlug]) ? deepClone(map[safeSlug]) : {};
 }
 
 function hasPressUiMetadata(value) {
@@ -164,6 +178,10 @@ function normalizeSchemaType(type) {
   const scalar = type.find(entry => ['boolean', 'number', 'integer', 'string'].includes(entry));
   if (scalar) return scalar;
   return type.find(entry => entry && entry !== 'null') || type[0];
+}
+
+function isNullableSchemaType(type) {
+  return Array.isArray(type) && type.includes('null');
 }
 
 function inferControl(schema = {}, meta = {}) {
@@ -368,6 +386,9 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
     if (rawStep != null && (!Number.isFinite(rawStep) || rawStep <= 0)) {
       addIssue(`Theme setting "${key}" step must be a positive finite number.`, `${path}.${schema.multipleOf != null ? 'multipleOf' : 'step'}`);
     }
+    const defaultValue = schema.default === null && isNullableSchemaType(schema.type)
+      ? undefined
+      : schema.default;
     const field = {
       key,
       label: String(meta.label || schema.title || key),
@@ -375,7 +396,7 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       group: String(meta.group || ''),
       control,
       type: type || (control === 'boolean' ? 'boolean' : (control === 'number' || control === 'range' ? 'number' : 'string')),
-      defaultValue: schema.default,
+      defaultValue,
       options,
       cssVariables: cssVariables.filter(name => SAFE_CSS_VARIABLE_PATTERN.test(name)),
       cssValues: normalizeCssValueMap(meta),
@@ -388,8 +409,8 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       maxLength: schema.maxLength != null ? Number(schema.maxLength) : null,
       pattern: schema.pattern || ''
     };
-    if (strict && schema.default !== undefined) {
-      const normalizedDefault = normalizeThemeSettingValue(field, schema.default);
+    if (strict && defaultValue !== undefined) {
+      const normalizedDefault = normalizeThemeSettingValue(field, defaultValue);
       if (!normalizedDefault.ok) {
         addIssue(`Default value for theme setting "${key}" is invalid.`, `${path}.default`);
       }
@@ -410,7 +431,7 @@ function buildCssVariables(fields, settings) {
   const variables = [];
   fields.forEach((field) => {
     if (!field.cssVariables || !field.cssVariables.length) return;
-    if (!Object.prototype.hasOwnProperty.call(settings, field.key)) return;
+    if (!hasOwn(settings, field.key)) return;
     const value = validateCssVariableValue(field, settings[field.key]);
     if (!value) return;
     field.cssVariables.forEach((name) => variables.push({ key: field.key, name, value }));
@@ -419,7 +440,7 @@ function buildCssVariables(fields, settings) {
 }
 
 export function resolveThemeSettings({ pack = 'native', manifest = {}, siteConfig = {} } = {}) {
-  const slug = sanitizeThemeSlug(pack || (siteConfig && siteConfig.themePack) || 'native');
+  const slug = normalizeThemeSettingsSlug(pack || (siteConfig && siteConfig.themePack) || 'native') || 'native';
   const schema = isPlainObject(manifest && manifest.configSchema) ? manifest.configSchema : {};
   const normalized = normalizeThemeConfigSchema(schema);
   const warnings = [...normalized.warnings];
@@ -478,7 +499,7 @@ export function resolveThemeSettings({ pack = 'native', manifest = {}, siteConfi
 
 export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
   if (!isPlainObject(siteConfig)) return false;
-  const safeSlug = sanitizeThemeSlug(slug || siteConfig.themePack || 'native');
+  const safeSlug = normalizeThemeSettingsSlug(slug || siteConfig.themePack || 'native');
   const safeKey = normalizeSettingKey(key);
   if (!safeSlug || !safeKey) return false;
   const cleanup = (target) => {
@@ -488,9 +509,13 @@ export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
     }
   };
   if (value === undefined && (!field || field.defaultValue === undefined)) {
-    if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY]) || !isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) return false;
+    if (
+      !isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])
+      || !hasOwn(siteConfig[THEME_SETTINGS_ROOT_KEY], safeSlug)
+      || !isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])
+    ) return false;
     const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
-    const hadValue = Object.prototype.hasOwnProperty.call(target, safeKey);
+    const hadValue = hasOwn(target, safeKey);
     delete target[safeKey];
     cleanup(target);
     return hadValue;
@@ -501,18 +526,20 @@ export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
     ? normalizeThemeSettingValue(field, field.defaultValue)
     : { ok: false };
   const root = isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY]) ? siteConfig[THEME_SETTINGS_ROOT_KEY] : null;
-  const existingTarget = root && isPlainObject(root[safeSlug]) ? root[safeSlug] : null;
+  const existingTarget = root && hasOwn(root, safeSlug) && isPlainObject(root[safeSlug]) ? root[safeSlug] : null;
   if (defaultValue.ok && stableSerialize(defaultValue.value) === stableSerialize(normalizedValue.value)) {
-    if (!existingTarget || !Object.prototype.hasOwnProperty.call(existingTarget, safeKey)) return false;
+    if (!existingTarget || !hasOwn(existingTarget, safeKey)) return false;
     const target = existingTarget;
     delete target[safeKey];
     cleanup(target);
     return true;
   } else {
     if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])) siteConfig[THEME_SETTINGS_ROOT_KEY] = {};
-    if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
+    if (!hasOwn(siteConfig[THEME_SETTINGS_ROOT_KEY], safeSlug) || !isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) {
+      siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
+    }
     const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
-    if (Object.prototype.hasOwnProperty.call(target, safeKey) && stableSerialize(target[safeKey]) === stableSerialize(normalizedValue.value)) return false;
+    if (hasOwn(target, safeKey) && stableSerialize(target[safeKey]) === stableSerialize(normalizedValue.value)) return false;
     target[safeKey] = normalizedValue.value;
   }
   return true;

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -14,7 +14,6 @@ export const SUPPORTED_THEME_SETTING_CONTROLS = Object.freeze([
 const SAFE_SETTING_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const SAFE_CSS_VARIABLE_PATTERN = /^--[A-Za-z][A-Za-z0-9_-]{0,95}$/;
 const SAFE_CSS_VALUE_PATTERN = /^[#A-Za-z0-9_\-.,%()\s]+$/;
-const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
 
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -36,6 +35,10 @@ function stableSerialize(value) {
     return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableSerialize(value[key])}`).join(',')}}`;
   }
   return '';
+}
+
+export function themeSettingValueSignature(value) {
+  return stableSerialize(value);
 }
 
 function warning(message, path = '') {
@@ -88,6 +91,13 @@ function getMeta(schema = {}) {
   return fromDash || fromCamel || fromUi || {};
 }
 
+function hasPressSettingMetadata(schema = {}) {
+  return isPlainObject(schema[THEME_SETTINGS_META_KEY])
+    || isPlainObject(schema.xPress)
+    || isPlainObject(schema.ui)
+    || typeof schema.ui === 'string';
+}
+
 function scalarOptionValue(value) {
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
   return undefined;
@@ -136,6 +146,16 @@ function inferControl(schema = {}, meta = {}) {
   return '';
 }
 
+function typeMatchesControl(type, control) {
+  const normalizedType = Array.isArray(type) ? type[0] : type;
+  if (!normalizedType) return true;
+  if (control === 'boolean') return normalizedType === 'boolean';
+  if (control === 'number' || control === 'range') return normalizedType === 'number' || normalizedType === 'integer';
+  if (control === 'color' || control === 'text') return normalizedType === 'string';
+  if (control === 'select') return normalizedType !== 'object' && normalizedType !== 'array';
+  return false;
+}
+
 function getRequestedControl(meta = {}) {
   const raw = meta.control || (typeof meta.ui === 'string' ? meta.ui : '');
   return String(raw || '').trim().toLowerCase();
@@ -157,12 +177,19 @@ function normalizeCssValueMap(meta = {}) {
   return out;
 }
 
+function normalizeHexColor(value) {
+  const color = String(value == null ? '' : value).trim().toLowerCase();
+  const short = color.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  if (short) return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`.toLowerCase();
+  return /^#[0-9a-f]{6}$/i.test(color) ? color : '';
+}
+
 function validateCssVariableValue(field, value) {
   const signature = stableSerialize(value);
   if (field.cssValues && Object.prototype.hasOwnProperty.call(field.cssValues, String(value))) {
     return field.cssValues[String(value)];
   }
-  if (field.control === 'color') return typeof value === 'string' && HEX_COLOR_PATTERN.test(value) ? value.toLowerCase() : '';
+  if (field.control === 'color') return normalizeHexColor(value);
   if (field.control === 'number' || field.control === 'range') return Number.isFinite(Number(value)) ? String(Number(value)) : '';
   if (field.control === 'boolean') return value === true ? '1' : (value === false ? '0' : '');
   if (field.options && field.options.some(option => stableSerialize(option.value) === signature)) {
@@ -202,8 +229,8 @@ export function normalizeThemeSettingValue(field, value) {
   }
   if (field.control === 'number' || field.control === 'range') return normalizeNumber(value, field);
   if (field.control === 'color') {
-    const color = String(value == null ? '' : value).trim();
-    return HEX_COLOR_PATTERN.test(color) ? { ok: true, value: color.toLowerCase() } : { ok: false, value: null };
+    const color = normalizeHexColor(value);
+    return color ? { ok: true, value: color } : { ok: false, value: null };
   }
   if (field.control === 'select') {
     const signature = stableSerialize(value);
@@ -247,17 +274,27 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
   const fields = [];
   Object.keys(properties).forEach((rawKey) => {
     const path = `configSchema.properties.${rawKey}`;
-    const key = normalizeSettingKey(rawKey);
     const schema = properties[rawKey];
-    if (!key) {
-      addIssue(`Unsupported theme setting key "${rawKey}".`, path);
-      return;
-    }
     if (!isPlainObject(schema)) {
       addIssue(`Theme setting "${rawKey}" must be an object schema.`, path);
       return;
     }
     const meta = getMeta(schema);
+    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+    const options = normalizeOptionList(schema, meta);
+    const hasMetadata = hasPressSettingMetadata(schema);
+    const looksNested = isPlainObject(schema.properties) || schema.items != null;
+    const scalarCandidate = (!type && !looksNested)
+      || ['boolean', 'number', 'integer', 'string'].includes(type)
+      || schema.format === 'color'
+      || schema.format === 'hex-color'
+      || options.length > 0;
+    if (!hasMetadata && !scalarCandidate) return;
+    const key = normalizeSettingKey(rawKey);
+    if (!key) {
+      addIssue(`Unsupported theme setting key "${rawKey}".`, path);
+      return;
+    }
     const requestedControl = getRequestedControl(meta);
     if (requestedControl && !SUPPORTED_THEME_SETTING_CONTROLS.includes(requestedControl)) {
       addIssue(`Theme setting "${key}" uses unsupported control "${requestedControl}".`, `${path}.${THEME_SETTINGS_META_KEY}.control`);
@@ -268,12 +305,14 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       addIssue(`Theme setting "${key}" uses an unsupported type or control.`, path);
       return;
     }
-    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
     if (type === 'object' || type === 'array') {
       addIssue(`Theme setting "${key}" must be a scalar setting.`, path);
       return;
     }
-    const options = normalizeOptionList(schema, meta);
+    if (!typeMatchesControl(type, control)) {
+      addIssue(`Theme setting "${key}" uses control "${control}" with incompatible type "${type}".`, `${path}.${THEME_SETTINGS_META_KEY}.control`);
+      return;
+    }
     if (control === 'select' && !options.length) {
       addIssue(`Theme setting "${key}" select controls require enum/options.`, path);
       return;
@@ -395,6 +434,13 @@ export function setThemeSettingOverride(siteConfig, slug, key, value, field) {
   if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY])) siteConfig[THEME_SETTINGS_ROOT_KEY] = {};
   if (!isPlainObject(siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug])) siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug] = {};
   const target = siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+  if (value === undefined && (!field || field.defaultValue === undefined)) {
+    const hadValue = Object.prototype.hasOwnProperty.call(target, safeKey);
+    delete target[safeKey];
+    if (!Object.keys(target).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY][safeSlug];
+    if (!Object.keys(siteConfig[THEME_SETTINGS_ROOT_KEY]).length) delete siteConfig[THEME_SETTINGS_ROOT_KEY];
+    return hadValue;
+  }
   const normalizedValue = normalizeThemeSettingValue(field, value);
   if (!normalizedValue.ok) return false;
   const defaultValue = field && field.defaultValue !== undefined

--- a/assets/js/theme-settings.js
+++ b/assets/js/theme-settings.js
@@ -14,6 +14,13 @@ export const SUPPORTED_THEME_SETTING_CONTROLS = Object.freeze([
 const SAFE_SETTING_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const SAFE_CSS_VARIABLE_PATTERN = /^--[A-Za-z][A-Za-z0-9_-]{0,95}$/;
 const SAFE_CSS_VALUE_PATTERN = /^[#A-Za-z0-9_\-.,%()\s]+$/;
+const PRESS_UI_METADATA_KEYS = Object.freeze([
+  'control',
+  'cssVariable',
+  'cssVariables',
+  'cssValues',
+  'options'
+]);
 
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -84,18 +91,29 @@ export function getThemeSettingsForSlug(siteConfig = {}, slug = '') {
   return map[safeSlug] && isPlainObject(map[safeSlug]) ? deepClone(map[safeSlug]) : {};
 }
 
-function getMeta(schema = {}) {
+function hasPressUiMetadata(value) {
+  if (typeof value === 'string') return value.trim() !== '';
+  if (!isPlainObject(value)) return false;
+  return PRESS_UI_METADATA_KEYS.some(key => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function normalizeUiMetadata(value, allowGenericUi = false) {
+  if (typeof value === 'string') return { control: value };
+  if (isPlainObject(value) && (allowGenericUi || hasPressUiMetadata(value))) return value;
+  return null;
+}
+
+function getMeta(schema = {}, options = {}) {
   const fromDash = isPlainObject(schema[THEME_SETTINGS_META_KEY]) ? schema[THEME_SETTINGS_META_KEY] : null;
   const fromCamel = isPlainObject(schema.xPress) ? schema.xPress : null;
-  const fromUi = isPlainObject(schema.ui) ? schema.ui : null;
+  const fromUi = normalizeUiMetadata(schema.ui, options.allowGenericUi === true);
   return fromDash || fromCamel || fromUi || {};
 }
 
 function hasPressSettingMetadata(schema = {}) {
   return isPlainObject(schema[THEME_SETTINGS_META_KEY])
     || isPlainObject(schema.xPress)
-    || isPlainObject(schema.ui)
-    || typeof schema.ui === 'string';
+    || hasPressUiMetadata(schema.ui);
 }
 
 function scalarOptionValue(value) {
@@ -204,6 +222,9 @@ function validateCssVariableValue(field, value) {
 }
 
 function normalizeNumber(value, field) {
+  if (value == null || typeof value === 'boolean') return { ok: false, value: null };
+  if (typeof value === 'string' && value.trim() === '') return { ok: false, value: null };
+  if (typeof value !== 'string' && typeof value !== 'number') return { ok: false, value: null };
   const num = Number(value);
   if (!Number.isFinite(num)) return { ok: false, value: null };
   if (field.integer && !Number.isInteger(num)) return { ok: false, value: null };
@@ -279,9 +300,9 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       addIssue(`Theme setting "${rawKey}" must be an object schema.`, path);
       return;
     }
-    const meta = getMeta(schema);
+    let meta = getMeta(schema);
     const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
-    const options = normalizeOptionList(schema, meta);
+    let options = normalizeOptionList(schema, meta);
     const hasMetadata = hasPressSettingMetadata(schema);
     const looksNested = isPlainObject(schema.properties) || schema.items != null;
     const scalarCandidate = (!type && !looksNested)
@@ -290,6 +311,10 @@ export function normalizeThemeConfigSchema(configSchema = {}, options = {}) {
       || schema.format === 'hex-color'
       || options.length > 0;
     if (!hasMetadata && !scalarCandidate) return;
+    if (!hasMetadata && scalarCandidate) {
+      meta = getMeta(schema, { allowGenericUi: true });
+      options = normalizeOptionList(schema, meta);
+    }
     const key = normalizeSettingKey(rawKey);
     if (!key) {
       addIssue(`Unsupported theme setting key "${rawKey}".`, path);

--- a/assets/main.js
+++ b/assets/main.js
@@ -2288,7 +2288,7 @@ try {
 } catch (_) {}
 
 // Build layout according to the active theme pack before binding UI logic
-await ensureThemeLayout({ features: getSiteFeatureContext(), router: createThemeRouterContext() });
+await ensureThemeLayout({ features: getSiteFeatureContext(), router: createThemeRouterContext(), siteConfig });
 setBootProgress(0.6);
 
 // Ensure theme controls are present, then apply and bind

--- a/assets/main.js
+++ b/assets/main.js
@@ -767,6 +767,19 @@ function createThemeRouterContext() {
   };
 }
 
+function reflectActiveThemeConfig(themeContext = getThemeLayoutContext()) {
+  return callThemeEffect('reflectThemeConfig', {
+    config: siteConfig,
+    siteConfig,
+    ctx: themeContext || null,
+    themeSettings: themeContext && themeContext.themeSettings ? themeContext.themeSettings : null,
+    features: getSiteFeatureContext(),
+    router: createThemeRouterContext(),
+    document,
+    window
+  });
+}
+
 function renderPostNavForSite(container, postsIndex, postname, options = {}) {
   return renderPostNav(container, postsIndex, postname, {
     router: createThemeRouterContext(),
@@ -2288,7 +2301,7 @@ try {
 } catch (_) {}
 
 // Build layout according to the active theme pack before binding UI logic
-await ensureThemeLayout({ features: getSiteFeatureContext(), router: createThemeRouterContext(), siteConfig });
+const bootThemeLayoutContext = await ensureThemeLayout({ features: getSiteFeatureContext(), router: createThemeRouterContext(), siteConfig });
 setBootProgress(0.6);
 
 // Ensure theme controls are present, then apply and bind
@@ -2326,12 +2339,7 @@ callThemeEffect('setupResponsiveTabsObserver', {
 
 // Reflect theme config in the layout (e.g., data attributes)
 try {
-  callThemeEffect('reflectThemeConfig', {
-    config: siteConfig,
-    features: getSiteFeatureContext(),
-    document,
-    window
-  });
+  reflectActiveThemeConfig(bootThemeLayoutContext);
 } catch (_) {}
 
 // Soft reset to the site's default language without full reload
@@ -2589,12 +2597,7 @@ try {
     // Apply site-controlled theme after loading config
     try {
       applyThemeConfig(siteConfig);
-      callThemeEffect('reflectThemeConfig', {
-        config: siteConfig,
-        features: getSiteFeatureContext(),
-        document,
-        window
-      });
+      reflectActiveThemeConfig();
     } catch (_) {}
 
     // Initialize global error reporter with optional report URL from site config

--- a/assets/main.js
+++ b/assets/main.js
@@ -2301,7 +2301,12 @@ try {
 } catch (_) {}
 
 // Build layout according to the active theme pack before binding UI logic
-const bootThemeLayoutContext = await ensureThemeLayout({ features: getSiteFeatureContext(), router: createThemeRouterContext(), siteConfig });
+const bootThemeLayoutContext = await ensureThemeLayout({
+  features: getSiteFeatureContext(),
+  router: createThemeRouterContext(),
+  siteConfig,
+  reflectThemeConfig: false
+});
 setBootProgress(0.6);
 
 // Ensure theme controls are present, then apply and bind

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.131",
-  "tag": "v3.4.131",
+  "version": "3.4.132",
+  "tag": "v3.4.132",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.130 <3.4.131"
+      ">=3.4.131 <3.4.132"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.130 before installing v3.4.131."
+    "message": "Update to v3.4.131 before installing v3.4.132."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 4,
-    "message": "Update installed themes to contract v4 before installing v3.4.131."
+    "message": "Update installed themes to contract v4 before installing v3.4.132."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.130 and publish the content model migration before installing v3.4.131."
+    "message": "Install v3.4.131 and publish the content model migration before installing v3.4.132."
   }
 }

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -72,6 +72,14 @@
       "type": "boolean",
       "description": "Allow theme override via UI or config."
     },
+    "themeSettings": {
+      "type": "object",
+      "description": "Theme-specific validated settings, scoped by theme slug. For example: themeSettings.arcus.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
     "cardCoverFallback": {
       "type": "boolean",
       "description": "Use card cover image as fallback when missing."

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -119,7 +119,13 @@
           }
         },
         "additionalProperties": {
-          "type": "boolean"
+          "oneOf": [
+            { "type": "boolean" },
+            {
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
         }
       }
     },

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -105,8 +105,22 @@
     },
     "configSchema": {
       "type": "object",
-      "description": "JSON-schema fragment for theme-specific config.",
-      "additionalProperties": true
+      "description": "JSON-schema fragment for theme-specific scalar settings. Press supports boolean, color, number/range, select, and text controls with optional x-press CSS variable metadata.",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "object"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/themeSettingDeclaration"
+          }
+        },
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
     },
     "content": {
       "type": "object",
@@ -172,6 +186,127 @@
         },
         "handler": {
           "type": "string"
+        }
+      }
+    },
+    "themeSettingDeclaration": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["string", "number", "integer", "boolean"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["string", "number", "integer", "boolean"]
+              }
+            }
+          ]
+        },
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": {},
+        "enum": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" }
+            ]
+          }
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "multipleOf": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "x-press": {
+          "$ref": "#/$defs/themeSettingPressMetadata"
+        },
+        "xPress": {
+          "$ref": "#/$defs/themeSettingPressMetadata"
+        },
+        "ui": {
+          "$ref": "#/$defs/themeSettingPressMetadata"
+        }
+      }
+    },
+    "themeSettingPressMetadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "control": {
+          "type": "string",
+          "enum": ["boolean", "color", "number", "range", "select", "text"]
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "cssVariable": {
+          "oneOf": [
+            { "type": "string", "pattern": "^--[A-Za-z][A-Za-z0-9_-]{0,95}$" },
+            {
+              "type": "array",
+              "items": { "type": "string", "pattern": "^--[A-Za-z][A-Za-z0-9_-]{0,95}$" },
+              "uniqueItems": true
+            }
+          ]
+        },
+        "cssVariables": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^--[A-Za-z][A-Za-z0-9_-]{0,95}$" },
+          "uniqueItems": true
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "number" },
+              { "type": "boolean" },
+              {
+                "type": "object",
+                "required": ["value"],
+                "additionalProperties": true,
+                "properties": {
+                  "value": {
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "number" },
+                      { "type": "boolean" }
+                    ]
+                  },
+                  "label": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
         }
       }
     }

--- a/assets/schema/theme.json
+++ b/assets/schema/theme.json
@@ -114,7 +114,8 @@
         "properties": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/themeSettingDeclaration"
+            "type": "object",
+            "additionalProperties": true
           }
         },
         "additionalProperties": {

--- a/packages/press-theme-contract/index.mjs
+++ b/packages/press-theme-contract/index.mjs
@@ -17,9 +17,9 @@ const themePackageCore = await importPackagedOrSourceModule(
 );
 
 const { PRESS_THEME_CONTRACT } = contractSurface;
-const { containsForbiddenV4RouteConstruction } = themePackageCore;
+const { containsForbiddenV4RouteConstruction, validateThemeConfigSchema } = themePackageCore;
 
-export { PRESS_THEME_CONTRACT, containsForbiddenV4RouteConstruction };
+export { PRESS_THEME_CONTRACT, containsForbiddenV4RouteConstruction, validateThemeConfigSchema };
 
 const ROUTE_HELPER_CONTRACT_VERSION = 4;
 const THEME_TEXT_EXTENSIONS = new Set(PRESS_THEME_CONTRACT.archive && PRESS_THEME_CONTRACT.archive.textExtensions);

--- a/packages/press-theme-contract/package.json
+++ b/packages/press-theme-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekilyhq/press-theme-contract",
-  "version": "3.4.131",
+  "version": "3.4.132",
   "description": "Press theme contract helpers and packaged theme validation rules.",
   "type": "module",
   "license": "UNLICENSED",
@@ -25,6 +25,7 @@
     "assets/js/press-version.js",
     "assets/js/theme-contract-surface.mjs",
     "assets/js/theme-package-core.js",
+    "assets/js/theme-settings.js",
     "assets/js/theme-route-guard.js",
     "assets/js/vendor/acorn.mjs",
     "assets/js/vendor/acorn-walk.mjs",

--- a/packages/press-theme-contract/scripts/sync-assets.mjs
+++ b/packages/press-theme-contract/scripts/sync-assets.mjs
@@ -10,6 +10,7 @@ const files = [
   ['assets/js/press-version.js', 'assets/js/press-version.js'],
   ['assets/js/theme-contract-surface.mjs', 'assets/js/theme-contract-surface.mjs'],
   ['assets/js/theme-package-core.js', 'assets/js/theme-package-core.js'],
+  ['assets/js/theme-settings.js', 'assets/js/theme-settings.js'],
   ['assets/js/theme-route-guard.js', 'assets/js/theme-route-guard.js'],
   ['assets/js/vendor/acorn.mjs', 'assets/js/vendor/acorn.mjs'],
   ['assets/js/vendor/acorn-walk.mjs', 'assets/js/vendor/acorn-walk.mjs'],

--- a/scripts/build-theme-contract-package.mjs
+++ b/scripts/build-theme-contract-package.mjs
@@ -31,6 +31,7 @@ const files = [
   ['assets/js/press-version.js', 'assets/js/press-version.js'],
   ['assets/js/theme-contract-surface.mjs', 'assets/js/theme-contract-surface.mjs'],
   ['assets/js/theme-package-core.js', 'assets/js/theme-package-core.js'],
+  ['assets/js/theme-settings.js', 'assets/js/theme-settings.js'],
   ['assets/js/theme-route-guard.js', 'assets/js/theme-route-guard.js'],
   ['assets/js/vendor/acorn.mjs', 'assets/js/vendor/acorn.mjs'],
   ['assets/js/vendor/acorn-walk.mjs', 'assets/js/vendor/acorn-walk.mjs'],

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1229,7 +1229,7 @@ assert.doesNotMatch(
 
 assert.match(
   composerSiteModelSource,
-  /export function prepareSiteState\(raw\)[\s\S]*site\.features = normalizeSiteFeatureSettings\(src\.features\)[\s\S]*'enableAllPosts', 'disableAllPosts', 'features', 'connect'[\s\S]*export function computeSiteDiff\(current, baseline\)[\s\S]*diff\.fields\.features[\s\S]*diff\.fields\.annotate[\s\S]*export function toSiteYaml\(data\)/,
+  /export function prepareSiteState\(raw\)[\s\S]*site\.themeSettings = normalizeThemeSettingsMap\(src\.themeSettings\)[\s\S]*site\.features = normalizeSiteFeatureSettings\(src\.features\)[\s\S]*'themeSettings'[\s\S]*'enableAllPosts', 'disableAllPosts', 'features', 'connect'[\s\S]*export function computeSiteDiff\(current, baseline\)[\s\S]*diff\.fields\.features[\s\S]*diff\.fields\.themeSettings[\s\S]*diff\.fields\.annotate[\s\S]*export function toSiteYaml\(data\)[\s\S]*'themeMode', 'themePack', 'themeOverride', 'themeSettings'/,
   'site model boundary should own site.yaml normalization, diffing, and serialization'
 );
 
@@ -7642,6 +7642,12 @@ assert.match(
   siteSettingsSource,
   /const renderThemeGrid = \(section\) => \{[\s\S]*dataKey: 'themeMode'[\s\S]*dataKey: 'themePack'[\s\S]*dataKey: 'themeOverride'/,
   'Theme compact grid should include all single-value theme fields'
+);
+
+assert.match(
+  siteSettingsSource,
+  /from '\.\/theme-settings\.js';[\s\S]*const themeSettingsBlock = documentRef\.createElement\('div'\)[\s\S]*setThemeSettingOverride\(site, pack, field\.key, value, field\)[\s\S]*resolveThemeSettings\(\{ pack, manifest, siteConfig: site \}\)/,
+  'Theme compact grid should render current theme settings from the shared theme settings contract'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -7652,7 +7652,7 @@ assert.match(
 
 assert.match(
   siteSettingsSource,
-  /themeSettingValueSignature[\s\S]*option\.value = String\(index\);[\s\S]*option\.dataset\.valueSignature = themeSettingValueSignature\(optionData\.value\);[\s\S]*const selectedIndex = Number\(select\.value\);[\s\S]*commitValue\(selected \? selected\.value : select\.value\);/,
+  /themeSettingValueSignature[\s\S]*field\.defaultValue === undefined[\s\S]*unsetOption\.value = '';[\s\S]*option\.value = String\(index\);[\s\S]*option\.dataset\.valueSignature = themeSettingValueSignature\(optionData\.value\);[\s\S]*select\.value === ''[\s\S]*commitValue\(undefined\);[\s\S]*const selectedIndex = Number\(select\.value\);[\s\S]*commitValue\(selected \? selected\.value : select\.value\);/,
   'Theme settings select controls should preserve mixed scalar option types'
 );
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -7664,6 +7664,12 @@ assert.match(
 
 assert.match(
   siteSettingsSource,
+  /field\.control === 'color' && field\.defaultValue === undefined[\s\S]*unsetButton\.textContent = 'Not set';[\s\S]*unsetButton\.addEventListener\('click', \(\) => commitValue\(undefined\)\);/,
+  'Theme settings optional color controls should expose an unset path'
+);
+
+assert.match(
+  siteSettingsSource,
   /const renderAssetWarningsGrid = \(section\) => \{[\s\S]*dataKey: 'assetWarnings'[\s\S]*fields\.assetLargeImage[\s\S]*fields\.assetLargeImageThreshold/,
   'Asset warnings compact grid should include the warning toggle and threshold rows'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -7652,6 +7652,18 @@ assert.match(
 
 assert.match(
   siteSettingsSource,
+  /themeSettingValueSignature[\s\S]*option\.value = String\(index\);[\s\S]*option\.dataset\.valueSignature = themeSettingValueSignature\(optionData\.value\);[\s\S]*const selectedIndex = Number\(select\.value\);[\s\S]*commitValue\(selected \? selected\.value : select\.value\);/,
+  'Theme settings select controls should preserve mixed scalar option types'
+);
+
+assert.match(
+  siteSettingsSource,
+  /input\.type === 'number' \|\| input\.type === 'range'[\s\S]*input\.value === '' \? undefined : Number\(input\.value\)[\s\S]*commitValue\(nextValue\);/,
+  'Theme settings numeric controls should allow optional overrides to be cleared'
+);
+
+assert.match(
+  siteSettingsSource,
   /const renderAssetWarningsGrid = \(section\) => \{[\s\S]*dataKey: 'assetWarnings'[\s\S]*fields\.assetLargeImage[\s\S]*fields\.assetLargeImageThreshold/,
   'Asset warnings compact grid should include the warning toggle and threshold rows'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -7664,6 +7664,12 @@ assert.match(
 
 assert.match(
   siteSettingsSource,
+  /field\.control === 'text' && field\.defaultValue === undefined && input\.value === '' \? undefined : input\.value[\s\S]*commitValue\(nextValue\);/,
+  'Theme settings optional text controls should allow blank values to clear persisted overrides'
+);
+
+assert.match(
+  siteSettingsSource,
   /field\.control === 'color' && field\.defaultValue === undefined[\s\S]*unsetButton\.textContent = 'Not set';[\s\S]*unsetButton\.addEventListener\('click', \(\) => commitValue\(undefined\)\);/,
   'Theme settings optional color controls should expose an unset path'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -7670,8 +7670,14 @@ assert.match(
 
 assert.match(
   siteSettingsSource,
-  /field\.control === 'color' && field\.defaultValue === undefined[\s\S]*unsetButton\.textContent = 'Not set';[\s\S]*unsetButton\.addEventListener\('click', \(\) => commitValue\(undefined\)\);/,
-  'Theme settings optional color controls should expose an unset path'
+  /field\.control === 'boolean'[\s\S]*field\.defaultValue === undefined[\s\S]*unsetButton\.textContent = 'Not set';[\s\S]*commitValue\(undefined\);[\s\S]*syncSwitchState\(checkbox, toggle, false, false\);/,
+  'Theme settings optional boolean controls should expose an unset path'
+);
+
+assert.match(
+  siteSettingsSource,
+  /\(field\.control === 'color' \|\| field\.control === 'range'\) && field\.defaultValue === undefined[\s\S]*unsetButton\.textContent = 'Not set';[\s\S]*unsetButton\.addEventListener\('click', \(\) => commitValue\(undefined\)\);/,
+  'Theme settings optional color and range controls should expose an unset path'
 );
 
 assert.match(

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -118,6 +118,11 @@ if ! grep -qx "press-system-${version}/assets/js/theme-router-helpers.js" "${ent
   exit 1
 fi
 
+if ! grep -qx "press-system-${version}/assets/js/theme-settings.js" "${entries_file}"; then
+  echo "expected package to include theme settings resolver code" >&2
+  exit 1
+fi
+
 if ! grep -qx "press-system-${version}/assets/js/theme-install-service.js" "${entries_file}"; then
   echo "expected package to include theme install service code" >&2
   exit 1

--- a/scripts/test-theme-contract-package.mjs
+++ b/scripts/test-theme-contract-package.mjs
@@ -10,7 +10,7 @@ const sourceManifest = JSON.parse(await fs.readFile(path.join(root, 'packages', 
 
 assert.equal(sourceManifest.name, '@ekilyhq/press-theme-contract');
 assert.equal(sourceManifest.version, system.version);
-assert.equal(system.version, '3.4.131');
+assert.equal(system.version, '3.4.132');
 assert.equal(system.tag, `v${system.version}`);
 assert.equal(sourceManifest.publishConfig && sourceManifest.publishConfig.registry, 'https://npm.pkg.github.com');
 
@@ -21,11 +21,13 @@ try {
     import {
       PRESS_THEME_CONTRACT,
       containsForbiddenV4RouteConstruction,
+      validateThemeConfigSchema,
       validateThemeRouteHelperContract
     } from './packages/press-theme-contract/index.mjs';
 
     assert.equal(PRESS_THEME_CONTRACT.contractVersion, 4);
     assert.equal(typeof containsForbiddenV4RouteConstruction, 'function');
+    assert.equal(typeof validateThemeConfigSchema, 'function');
     assert.equal(typeof validateThemeRouteHelperContract, 'function');
   `], {
     cwd: root,
@@ -50,6 +52,7 @@ try {
     'index.mjs',
     'scripts/sync-assets.mjs',
     'assets/js/theme-package-core.js',
+    'assets/js/theme-settings.js',
     'assets/js/theme-route-guard.js',
     'assets/js/vendor/acorn.mjs',
     'assets/js/vendor/acorn-walk.mjs'

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -11,7 +11,10 @@ import {
   getRequiredThemeRegions,
   getRequiredThemeViews
 } from '../assets/js/theme-contract-surface.mjs';
-import { containsForbiddenV4RouteConstruction as containsForbiddenV4RouteConstructionExport } from '../assets/js/theme-package-core.js';
+import {
+  containsForbiddenV4RouteConstruction as containsForbiddenV4RouteConstructionExport,
+  validateThemeConfigSchema
+} from '../assets/js/theme-package-core.js';
 import { containsForbiddenV4RouteConstructionAst } from '../assets/js/theme-route-guard.js';
 
 const root = process.cwd();
@@ -4716,6 +4719,11 @@ themeNames.forEach((themeName) => {
     fail(`${relManifest} must declare scrollContainer`);
   }
   requireObject(manifest.configSchema, 'configSchema', relManifest);
+  try {
+    validateThemeConfigSchema(manifest.configSchema);
+  } catch (err) {
+    fail(`${relManifest} configSchema contains unsupported theme setting metadata: ${err && err.message ? err.message : err}`);
+  }
   const content = requireObject(manifest.content, 'content', relManifest);
   const shapes = requireList(content, 'shapes', 'content.shapes', relManifest);
   REQUIRED_CONTENT_SHAPES.forEach((shape) => {

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -4470,6 +4470,17 @@ const schemaThemeConfigProperty = schema.properties
 if (!schemaThemeConfigProperty || schemaThemeConfigProperty.type !== 'object' || schemaThemeConfigProperty.additionalProperties !== true) {
   fail('assets/schema/theme.json configSchema properties must allow nested non-Press object schemas');
 }
+const schemaThemeConfigAdditionalProperties = schema.properties
+  && schema.properties.configSchema
+  && schema.properties.configSchema.properties
+  && schema.properties.configSchema.properties.additionalProperties;
+const schemaThemeConfigAdditionalPropertiesAllowsSchemas = schemaThemeConfigAdditionalProperties
+  && Array.isArray(schemaThemeConfigAdditionalProperties.oneOf)
+  && schemaThemeConfigAdditionalProperties.oneOf.some(entry => entry && entry.type === 'boolean')
+  && schemaThemeConfigAdditionalProperties.oneOf.some(entry => entry && entry.type === 'object' && entry.additionalProperties === true);
+if (!schemaThemeConfigAdditionalPropertiesAllowsSchemas) {
+  fail('assets/schema/theme.json configSchema.additionalProperties must allow boolean values and schema object values');
+}
 if (!themeLayoutSource.includes('theme-contract-surface.mjs') || !themePackageCoreSource.includes('theme-contract-surface.mjs')) {
   fail('theme runtime and Theme Manager package core must import the shared theme contract surface');
 }

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -4462,6 +4462,14 @@ const schemaContentShapes = schema.$defs && schema.$defs.contentShapeList && sch
 if (JSON.stringify(schemaContentShapes || []) !== JSON.stringify(REQUIRED_CONTENT_SHAPES)) {
   fail('assets/schema/theme.json content shape enum must match the shared theme contract surface');
 }
+const schemaThemeConfigProperty = schema.properties
+  && schema.properties.configSchema
+  && schema.properties.configSchema.properties
+  && schema.properties.configSchema.properties.properties
+  && schema.properties.configSchema.properties.properties.additionalProperties;
+if (!schemaThemeConfigProperty || schemaThemeConfigProperty.type !== 'object' || schemaThemeConfigProperty.additionalProperties !== true) {
+  fail('assets/schema/theme.json configSchema properties must allow nested non-Press object schemas');
+}
 if (!themeLayoutSource.includes('theme-contract-surface.mjs') || !themePackageCoreSource.includes('theme-contract-surface.mjs')) {
   fail('theme runtime and Theme Manager package core must import the shared theme contract surface');
 }

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const themeSource = readFileSync(resolve(here, '../assets/js/theme.js'), 'utf8');
+const mainSource = readFileSync(resolve(here, '../assets/main.js'), 'utf8');
 let importCounter = 0;
 
 assert.doesNotMatch(
@@ -16,6 +17,16 @@ assert.match(
   themeSource,
   /function createThemePackState\(\) \{[\s\S]*suppressedThemePacks: new Set\(\)[\s\S]*export function createThemePackController\(\) \{[\s\S]*const runtime = createThemePackRuntime\(\)[\s\S]*isSuppressed\(name\)/,
   'theme-pack suppression state should be scoped to explicit controller runtimes'
+);
+assert.match(
+  mainSource,
+  /function reflectActiveThemeConfig\(themeContext = getThemeLayoutContext\(\)\) \{[\s\S]*return callThemeEffect\('reflectThemeConfig', \{[\s\S]*ctx: themeContext \|\| null,[\s\S]*themeSettings: themeContext && themeContext\.themeSettings \? themeContext\.themeSettings : null,/,
+  'main boot reflection should preserve resolved theme settings when reflecting theme config'
+);
+assert.doesNotMatch(
+  mainSource,
+  /callThemeEffect\('reflectThemeConfig', \{\s*config: siteConfig,\s*features: getSiteFeatureContext\(\),/,
+  'main boot reflection should not call reflectThemeConfig without ctx/themeSettings'
 );
 
 class TestElement {

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const themeSource = readFileSync(resolve(here, '../assets/js/theme.js'), 'utf8');
 const mainSource = readFileSync(resolve(here, '../assets/main.js'), 'utf8');
+const themeLayoutSource = readFileSync(resolve(here, '../assets/js/theme-layout.js'), 'utf8');
 let importCounter = 0;
 
 assert.doesNotMatch(
@@ -27,6 +28,16 @@ assert.doesNotMatch(
   mainSource,
   /callThemeEffect\('reflectThemeConfig', \{\s*config: siteConfig,\s*features: getSiteFeatureContext\(\),/,
   'main boot reflection should not call reflectThemeConfig without ctx/themeSettings'
+);
+assert.match(
+  mainSource,
+  /await ensureThemeLayout\(\{[\s\S]*features: getSiteFeatureContext\(\),[\s\S]*router: createThemeRouterContext\(\),[\s\S]*siteConfig,[\s\S]*reflectThemeConfig: false[\s\S]*\}\);/,
+  'main boot should let reflectActiveThemeConfig own the public boot reflect call'
+);
+assert.match(
+  themeLayoutSource,
+  /const shouldReflectThemeConfig = !options \|\| options\.reflectThemeConfig !== false;[\s\S]*if \(shouldReflectThemeConfig\) reflectThemeRuntimeConfig\(context, options, resolvedSettings\);/,
+  'theme layout runtime refresh should support explicit reflectThemeConfig opt-out'
 );
 
 class TestElement {
@@ -487,6 +498,50 @@ await run('theme layout mount context exposes router href helpers', async () => 
   await ensureThemeLayout({ pack: 'routepack', persist: false, reset: true, router });
   assert.equal(mountedRouter, router);
   assert.equal(mountedRouter.getHomeHref(), '?tab=home');
+});
+
+await run('theme layout reflects config once and honors opt-out', async () => {
+  const reflected = [];
+  installGlobals({
+    savedPack: 'reflectpack',
+    manifests: {
+      reflectpack: makeManifest('reflectpack', ['modules/layout.js']),
+      silentpack: makeManifest('silentpack', ['modules/layout.js'])
+    }
+  });
+  window.__pressThemeModuleLoader = async () => ({
+    theme: {
+      effects: {
+        reflectThemeConfig(payload) {
+          reflected.push(payload);
+        }
+      }
+    }
+  });
+  const { ensureThemeLayout } = await freshThemeLayout();
+  await ensureThemeLayout({
+    pack: 'reflectpack',
+    persist: false,
+    reset: true,
+    siteConfig: { themePack: 'reflectpack' }
+  });
+  assert.equal(reflected.length, 1, 'fresh theme layout mount should reflect config once by default');
+
+  await ensureThemeLayout({
+    pack: 'silentpack',
+    persist: false,
+    reset: true,
+    siteConfig: { themePack: 'silentpack' },
+    reflectThemeConfig: false
+  });
+  assert.equal(reflected.length, 1, 'reflectThemeConfig false should suppress fresh-mount reflection');
+
+  await ensureThemeLayout({
+    pack: 'silentpack',
+    persist: false,
+    siteConfig: { themePack: 'silentpack' }
+  });
+  assert.equal(reflected.length, 2, 'cached layout refresh should still reflect when not opted out');
 });
 
 await run('theme controls ignore retired legacy DOM bridge hints from the active theme context', async () => {

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -171,6 +171,95 @@ assert.equal(invalidBlankNumericOverride.settings.radiusScale, 1, 'blank strings
 assert.deepEqual(invalidBlankNumericOverride.overrides, {});
 assert.ok(invalidBlankNumericOverride.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
 
+const steppedMinimumResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: {
+      type: 'object',
+      properties: {
+        oddColumns: {
+          type: 'number',
+          minimum: 1,
+          maximum: 9,
+          step: 2,
+          default: 1,
+          'x-press': {
+            control: 'number'
+          }
+        }
+      }
+    }
+  },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        oddColumns: 3
+      }
+    }
+  }
+});
+assert.equal(steppedMinimumResolution.settings.oddColumns, 3, 'schema.step should validate relative to non-zero minimum like native number inputs');
+assert.deepEqual(steppedMinimumResolution.overrides, { oddColumns: 3 });
+
+const invalidSteppedMinimumResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: {
+      type: 'object',
+      properties: {
+        oddColumns: {
+          type: 'number',
+          minimum: 1,
+          maximum: 9,
+          step: 2,
+          default: 1,
+          'x-press': {
+            control: 'number'
+          }
+        }
+      }
+    }
+  },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        oddColumns: 2
+      }
+    }
+  }
+});
+assert.equal(invalidSteppedMinimumResolution.settings.oddColumns, 1, 'schema.step should still reject values off the min-relative step grid');
+assert.deepEqual(invalidSteppedMinimumResolution.overrides, {});
+assert.ok(invalidSteppedMinimumResolution.warnings.some(entry => entry.path === 'themeSettings.arcus.oddColumns'));
+
+const malformedTextResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: {
+      type: 'object',
+      properties: {
+        tagline: {
+          type: 'string',
+          default: 'Hello',
+          'x-press': {
+            control: 'text'
+          }
+        }
+      }
+    }
+  },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        tagline: { raw: 'bad' }
+      }
+    }
+  }
+});
+assert.equal(malformedTextResolution.settings.tagline, 'Hello', 'object overrides should not be coerced into text settings');
+assert.deepEqual(malformedTextResolution.overrides, {});
+assert.ok(malformedTextResolution.warnings.some(entry => entry.path === 'themeSettings.arcus.tagline'));
+
 const normalizedMap = normalizeThemeSettingsMap({
   Arcus: { accentColor: '#abcdef' },
   'bad slug!': { accentColor: '#fedcba' },
@@ -201,6 +290,18 @@ const optionalNumberField = {
 assert.equal(setThemeSettingOverride(optionalNumberSite, 'arcus', 'maxWidth', undefined, optionalNumberField), true);
 assert.equal(optionalNumberSite.themeSettings, undefined, 'clearing an optional numeric setting should remove the persisted override');
 assert.notEqual(themeSettingValueSignature(1), themeSettingValueSignature('1'), 'select option signatures should preserve scalar types');
+
+const invalidDraftSite = { themePack: 'arcus' };
+assert.equal(setThemeSettingOverride(invalidDraftSite, 'arcus', 'accentColor', 'not-a-color', accentField), false);
+assert.equal(invalidDraftSite.themeSettings, undefined, 'invalid setting values should not create empty themeSettings maps');
+
+const optionalColorSite = { themePack: 'arcus', themeSettings: { arcus: { accentColor: '#112233' } } };
+const optionalColorField = {
+  ...accentField,
+  defaultValue: undefined
+};
+assert.equal(setThemeSettingOverride(optionalColorSite, 'arcus', 'accentColor', undefined, optionalColorField), true);
+assert.equal(optionalColorSite.themeSettings, undefined, 'clearing an optional color setting should remove the persisted override');
 
 const shortColorResolution = resolveThemeSettings({
   pack: 'arcus',
@@ -334,6 +435,23 @@ assert.throws(
     type: 'object',
     properties: {
       radiusScale: {
+        type: 'number',
+        default: 'wide',
+        'x-press': {
+          control: 'number'
+        }
+      }
+    }
+  }),
+  /Default value for theme setting "radiusScale" is invalid/,
+  'theme package validation should reject defaults that do not resolve through the declared setting'
+);
+
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      radiusScale: {
         type: 'string',
         ui: 'range'
       }
@@ -377,6 +495,13 @@ assert.equal(
         ui: {
           order: 1
         },
+        properties: {
+          density: { type: 'string' }
+        }
+      },
+      nestedWithGenericStringUi: {
+        type: 'object',
+        ui: 'fieldset',
         properties: {
           density: { type: 'string' }
         }

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   applyThemeSettingsCssVariables,
+  getThemeSettingsForSlug,
   normalizeThemeSettingsMap,
   resolveThemeSettings,
   setThemeSettingOverride,
@@ -287,6 +288,30 @@ assert.equal(nullableTextResolution.fields[0].type, 'string', 'nullable schema a
 assert.equal(nullableTextResolution.settings.eyebrow, 'Launch');
 assert.deepEqual(nullableTextResolution.overrides, { eyebrow: 'Launch' });
 
+const nullableDefaultSchema = {
+  type: 'object',
+  properties: {
+    eyebrow: {
+      type: ['null', 'string'],
+      default: null,
+      'x-press': {
+        control: 'text'
+      }
+    }
+  }
+};
+assert.equal(validateThemeConfigSchema(nullableDefaultSchema), true, 'nullable settings may declare null as their JSON Schema default');
+const nullableDefaultResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: nullableDefaultSchema
+  },
+  siteConfig: {}
+});
+assert.deepEqual(nullableDefaultResolution.defaults, {}, 'nullable null defaults should be treated as absent for scalar controls');
+assert.deepEqual(nullableDefaultResolution.settings, {}, 'nullable null defaults should not create a runtime setting');
+assert.deepEqual(nullableDefaultResolution.warnings, [], 'nullable null defaults should not warn during runtime resolution');
+
 const normalizedMap = normalizeThemeSettingsMap({
   Arcus: { accentColor: '#abcdef' },
   'bad slug!': { accentColor: '#fedcba' },
@@ -296,6 +321,17 @@ assert.deepEqual(normalizedMap, {
   arcus: { accentColor: '#abcdef' },
   badslug: { accentColor: '#fedcba' }
 });
+const prototypeSettings = JSON.parse('{"__proto__":{"accentColor":"#123456"},"constructor":{"accentColor":"#654321"},"arcus":{"accentColor":"#abcdef"}}');
+assert.deepEqual(
+  normalizeThemeSettingsMap(prototypeSettings),
+  { arcus: { accentColor: '#abcdef' } },
+  'theme settings maps should reject prototype-bearing slugs before indexing'
+);
+assert.deepEqual(
+  getThemeSettingsForSlug({ themeSettings: prototypeSettings }, '__proto__'),
+  {},
+  'prototype-bearing theme slugs should never resolve inherited settings'
+);
 assert.deepEqual(themeSettingsForOutput({ arcus: {}, solstice: { accentColor: '#123456' } }), {
   solstice: { accentColor: '#123456' }
 });
@@ -318,9 +354,37 @@ assert.equal(setThemeSettingOverride(optionalNumberSite, 'arcus', 'maxWidth', un
 assert.equal(optionalNumberSite.themeSettings, undefined, 'clearing an optional numeric setting should remove the persisted override');
 assert.notEqual(themeSettingValueSignature(1), themeSettingValueSignature('1'), 'select option signatures should preserve scalar types');
 
+const optionalBooleanSite = { themePack: 'arcus', themeSettings: { arcus: { showHero: false } } };
+const optionalBooleanField = {
+  key: 'showHero',
+  control: 'boolean',
+  type: 'boolean',
+  defaultValue: undefined
+};
+assert.equal(setThemeSettingOverride(optionalBooleanSite, 'arcus', 'showHero', undefined, optionalBooleanField), true);
+assert.equal(optionalBooleanSite.themeSettings, undefined, 'clearing an optional boolean setting should remove the persisted override');
+
+const optionalRangeSite = { themePack: 'arcus', themeSettings: { arcus: { radiusScale: 0.75 } } };
+const optionalRangeField = {
+  key: 'radiusScale',
+  control: 'range',
+  type: 'number',
+  defaultValue: undefined,
+  minimum: 0,
+  maximum: 2,
+  step: 0.25
+};
+assert.equal(setThemeSettingOverride(optionalRangeSite, 'arcus', 'radiusScale', undefined, optionalRangeField), true);
+assert.equal(optionalRangeSite.themeSettings, undefined, 'clearing an optional range setting should remove the persisted override');
+
 const invalidDraftSite = { themePack: 'arcus' };
 assert.equal(setThemeSettingOverride(invalidDraftSite, 'arcus', 'accentColor', 'not-a-color', accentField), false);
 assert.equal(invalidDraftSite.themeSettings, undefined, 'invalid setting values should not create empty themeSettings maps');
+
+const prototypeSlugSite = { themePack: '__proto__' };
+assert.equal(setThemeSettingOverride(prototypeSlugSite, '__proto__', 'accentColor', '#112233', accentField), false);
+assert.equal(prototypeSlugSite.themeSettings, undefined, 'prototype-bearing theme slugs should not create theme settings maps');
+assert.equal({}.accentColor, undefined, 'prototype-bearing theme slugs should not pollute object prototypes');
 
 const optionalColorSite = { themePack: 'arcus', themeSettings: { arcus: { accentColor: '#112233' } } };
 const optionalColorField = {

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -260,6 +260,33 @@ assert.equal(malformedTextResolution.settings.tagline, 'Hello', 'object override
 assert.deepEqual(malformedTextResolution.overrides, {});
 assert.ok(malformedTextResolution.warnings.some(entry => entry.path === 'themeSettings.arcus.tagline'));
 
+const nullableTextResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: {
+      type: 'object',
+      properties: {
+        eyebrow: {
+          type: ['null', 'string'],
+          'x-press': {
+            control: 'text'
+          }
+        }
+      }
+    }
+  },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        eyebrow: 'Launch'
+      }
+    }
+  }
+});
+assert.equal(nullableTextResolution.fields[0].type, 'string', 'nullable schema arrays should normalize to the supported scalar type');
+assert.equal(nullableTextResolution.settings.eyebrow, 'Launch');
+assert.deepEqual(nullableTextResolution.overrides, { eyebrow: 'Launch' });
+
 const normalizedMap = normalizeThemeSettingsMap({
   Arcus: { accentColor: '#abcdef' },
   'bad slug!': { accentColor: '#fedcba' },
@@ -302,6 +329,16 @@ const optionalColorField = {
 };
 assert.equal(setThemeSettingOverride(optionalColorSite, 'arcus', 'accentColor', undefined, optionalColorField), true);
 assert.equal(optionalColorSite.themeSettings, undefined, 'clearing an optional color setting should remove the persisted override');
+
+const optionalTextSite = { themePack: 'arcus', themeSettings: { arcus: { eyebrow: 'Launch' } } };
+const optionalTextField = {
+  key: 'eyebrow',
+  control: 'text',
+  type: 'string',
+  defaultValue: undefined
+};
+assert.equal(setThemeSettingOverride(optionalTextSite, 'arcus', 'eyebrow', undefined, optionalTextField), true);
+assert.equal(optionalTextSite.themeSettings, undefined, 'clearing an optional text setting should remove the persisted override');
 
 const shortColorResolution = resolveThemeSettings({
   pack: 'arcus',
@@ -502,6 +539,15 @@ assert.equal(
       nestedWithGenericStringUi: {
         type: 'object',
         ui: 'fieldset',
+        properties: {
+          density: { type: 'string' }
+        }
+      },
+      nestedWithGenericControlUi: {
+        type: 'object',
+        ui: {
+          control: 'fieldset'
+        },
         properties: {
           density: { type: 'string' }
         }

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import {
+  applyThemeSettingsCssVariables,
+  normalizeThemeSettingsMap,
+  resolveThemeSettings,
+  setThemeSettingOverride,
+  themeSettingsForOutput,
+  validateThemeConfigSchema
+} from '../assets/js/theme-settings.js';
+import {
+  computeSiteDiff,
+  prepareSiteState,
+  toSiteYaml
+} from '../assets/js/composer-site-model.js';
+
+const arcusManifest = {
+  configSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      accentColor: {
+        type: 'string',
+        format: 'color',
+        default: '#7b8bff',
+        title: 'Accent color',
+        'x-press': {
+          control: 'color',
+          group: 'Brand',
+          cssVariable: '--arcus-user-accent'
+        }
+      },
+      radiusScale: {
+        type: 'number',
+        default: 1,
+        minimum: 0,
+        maximum: 1.6,
+        multipleOf: 0.05,
+        title: 'Corner radius',
+        'x-press': {
+          control: 'range',
+          group: 'Shape',
+          cssVariable: '--arcus-radius-scale'
+        }
+      },
+      cardDensity: {
+        type: 'string',
+        default: 'comfortable',
+        enum: ['comfortable', 'compact', 'spacious'],
+        title: 'Card density',
+        'x-press': {
+          control: 'select',
+          group: 'Layout',
+          options: [
+            { value: 'comfortable', label: 'Comfortable' },
+            { value: 'compact', label: 'Compact' },
+            { value: 'spacious', label: 'Spacious' }
+          ]
+        }
+      }
+    }
+  }
+};
+
+const siteConfig = {
+  themePack: 'arcus',
+  themeSettings: {
+    arcus: {
+      accentColor: '#ff0055',
+      radiusScale: 2,
+      cardDensity: 'dense',
+      unknownSetting: true
+    }
+  }
+};
+
+const resolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: arcusManifest,
+  siteConfig
+});
+
+assert.deepEqual(resolution.defaults, {
+  accentColor: '#7b8bff',
+  radiusScale: 1,
+  cardDensity: 'comfortable'
+});
+assert.equal(resolution.settings.accentColor, '#ff0055');
+assert.equal(resolution.settings.radiusScale, 1, 'invalid number overrides should fall back to the schema default');
+assert.equal(resolution.settings.cardDensity, 'comfortable', 'invalid select overrides should fall back to the schema default');
+assert.deepEqual(resolution.overrides, { accentColor: '#ff0055' });
+assert.ok(resolution.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
+assert.ok(resolution.warnings.some(entry => entry.path === 'themeSettings.arcus.cardDensity'));
+assert.ok(resolution.warnings.some(entry => entry.path === 'themeSettings.arcus.unknownSetting'));
+assert.deepEqual(resolution.cssVariables, [
+  { key: 'accentColor', name: '--arcus-user-accent', value: '#ff0055' }
+]);
+
+const emptyResolution = resolveThemeSettings({
+  pack: 'native',
+  manifest: { configSchema: { type: 'object', additionalProperties: true } },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        accentColor: '#00ff00'
+      }
+    }
+  }
+});
+assert.deepEqual(emptyResolution.settings, {}, 'settings from another theme slug should not leak into the current theme');
+assert.deepEqual(emptyResolution.cssVariables, [], 'empty configSchema should not emit CSS variables');
+assert.equal(emptyResolution.warnings.length, 0, 'empty configSchema should not warn when another slug has settings');
+
+const radiusOverride = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: arcusManifest,
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        radiusScale: 1.25
+      }
+    }
+  }
+});
+assert.deepEqual(radiusOverride.cssVariables, [
+  { key: 'radiusScale', name: '--arcus-radius-scale', value: '1.25' }
+]);
+
+const invalidStepOverride = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: arcusManifest,
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        radiusScale: 1.23
+      }
+    }
+  }
+});
+assert.equal(invalidStepOverride.settings.radiusScale, 1, 'number overrides should respect multipleOf constraints');
+assert.deepEqual(invalidStepOverride.overrides, {});
+assert.ok(invalidStepOverride.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
+
+const normalizedMap = normalizeThemeSettingsMap({
+  Arcus: { accentColor: '#abcdef' },
+  'bad slug!': { accentColor: '#fedcba' },
+  solstice: null
+});
+assert.deepEqual(normalizedMap, {
+  arcus: { accentColor: '#abcdef' },
+  badslug: { accentColor: '#fedcba' }
+});
+assert.deepEqual(themeSettingsForOutput({ arcus: {}, solstice: { accentColor: '#123456' } }), {
+  solstice: { accentColor: '#123456' }
+});
+
+const draftSite = { themePack: 'arcus' };
+const accentField = resolution.fields.find(field => field.key === 'accentColor');
+assert.equal(setThemeSettingOverride(draftSite, 'arcus', 'accentColor', '#112233', accentField), true);
+assert.deepEqual(draftSite.themeSettings, { arcus: { accentColor: '#112233' } });
+assert.equal(setThemeSettingOverride(draftSite, 'arcus', 'accentColor', '#7b8bff', accentField), true);
+assert.equal(draftSite.themeSettings, undefined, 'setting a schema default should remove the persisted override');
+
+const cssValues = new Map();
+const fakeDocument = {
+  documentElement: {
+    style: {
+      setProperty(name, value) {
+        cssValues.set(name, value);
+      },
+      removeProperty(name) {
+        cssValues.delete(name);
+      }
+    }
+  }
+};
+assert.equal(applyThemeSettingsCssVariables(fakeDocument, resolution), true);
+assert.equal(cssValues.get('--arcus-user-accent'), '#ff0055');
+assert.equal(cssValues.has('--arcus-radius-scale'), false, 'schema defaults should not be injected as CSS overrides');
+assert.equal(applyThemeSettingsCssVariables(fakeDocument, { cssVariables: [] }), true);
+assert.equal(cssValues.has('--arcus-user-accent'), false, 'stale theme CSS variables should be removed');
+
+const prepared = prepareSiteState({
+  siteTitle: 'Theme Site',
+  themePack: 'arcus',
+  themeSettings: {
+    arcus: {
+      accentColor: '#ff0055',
+      radiusScale: 1.25,
+      cardDensity: 'compact'
+    },
+    solstice: {
+      accentColor: '#445566'
+    }
+  }
+});
+const yaml = toSiteYaml(prepared);
+assert.match(yaml, /^themeSettings:\n/m);
+assert.match(yaml, /arcus:\n\s+accentColor: "#ff0055"\n\s+radiusScale: 1\.25\n\s+cardDensity: compact/);
+assert.match(yaml, /solstice:\n\s+accentColor: "#445566"/);
+
+const diff = computeSiteDiff(
+  prepareSiteState({ themePack: 'arcus', themeSettings: { arcus: { accentColor: '#ff0055' } } }),
+  prepareSiteState({ themePack: 'arcus' })
+);
+assert.equal(diff.hasChanges, true);
+assert.deepEqual(diff.fields.themeSettings, { type: 'object' });
+
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      accentColor: {
+        type: 'string',
+        format: 'color',
+        default: '#ffffff',
+        'x-press': {
+          control: 'color',
+          cssVariable: 'arcus-accent'
+        }
+      }
+    }
+  }),
+  /unsafe CSS variable/,
+  'theme package validation should reject unsafe CSS variable mappings'
+);
+
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      labelStyle: {
+        type: 'string',
+        default: 'plain',
+        'x-press': {
+          control: 'slider'
+        }
+      }
+    }
+  }),
+  /unsupported control "slider"/,
+  'theme package validation should reject unsupported explicit controls'
+);
+
+console.log('ok - theme settings contract');

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -141,6 +141,36 @@ assert.equal(invalidStepOverride.settings.radiusScale, 1, 'number overrides shou
 assert.deepEqual(invalidStepOverride.overrides, {});
 assert.ok(invalidStepOverride.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
 
+const invalidNumericScalarOverrides = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: arcusManifest,
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        radiusScale: false
+      }
+    }
+  }
+});
+assert.equal(invalidNumericScalarOverrides.settings.radiusScale, 1, 'boolean values should not be coerced into numeric theme settings');
+assert.deepEqual(invalidNumericScalarOverrides.overrides, {});
+assert.ok(invalidNumericScalarOverrides.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
+
+const invalidBlankNumericOverride = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: arcusManifest,
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        radiusScale: ''
+      }
+    }
+  }
+});
+assert.equal(invalidBlankNumericOverride.settings.radiusScale, 1, 'blank strings should not be coerced into numeric theme settings');
+assert.deepEqual(invalidBlankNumericOverride.overrides, {});
+assert.ok(invalidBlankNumericOverride.warnings.some(entry => entry.path === 'themeSettings.arcus.radiusScale'));
+
 const normalizedMap = normalizeThemeSettingsMap({
   Arcus: { accentColor: '#abcdef' },
   'bad slug!': { accentColor: '#fedcba' },
@@ -299,6 +329,34 @@ assert.throws(
   'theme package validation should reject controls incompatible with schema types'
 );
 
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      radiusScale: {
+        type: 'string',
+        ui: 'range'
+      }
+    }
+  }),
+  /incompatible type "string"/,
+  'theme package validation should honor string ui control shorthands'
+);
+
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      radiusScale: {
+        type: 'number',
+        ui: 'slider'
+      }
+    }
+  }),
+  /unsupported control "slider"/,
+  'theme package validation should reject unsupported string ui control shorthands'
+);
+
 assert.equal(
   validateThemeConfigSchema({
     type: 'object',
@@ -310,6 +368,15 @@ assert.equal(
         }
       },
       typelessNestedConfig: {
+        properties: {
+          density: { type: 'string' }
+        }
+      },
+      nestedWithGenericUi: {
+        type: 'object',
+        ui: {
+          order: 1
+        },
         properties: {
           density: { type: 'string' }
         }

--- a/scripts/test-theme-settings.js
+++ b/scripts/test-theme-settings.js
@@ -4,6 +4,7 @@ import {
   normalizeThemeSettingsMap,
   resolveThemeSettings,
   setThemeSettingOverride,
+  themeSettingValueSignature,
   themeSettingsForOutput,
   validateThemeConfigSchema
 } from '../assets/js/theme-settings.js';
@@ -160,6 +161,47 @@ assert.deepEqual(draftSite.themeSettings, { arcus: { accentColor: '#112233' } })
 assert.equal(setThemeSettingOverride(draftSite, 'arcus', 'accentColor', '#7b8bff', accentField), true);
 assert.equal(draftSite.themeSettings, undefined, 'setting a schema default should remove the persisted override');
 
+const optionalNumberSite = { themePack: 'arcus', themeSettings: { arcus: { maxWidth: 72 } } };
+const optionalNumberField = {
+  key: 'maxWidth',
+  control: 'number',
+  type: 'number',
+  defaultValue: undefined
+};
+assert.equal(setThemeSettingOverride(optionalNumberSite, 'arcus', 'maxWidth', undefined, optionalNumberField), true);
+assert.equal(optionalNumberSite.themeSettings, undefined, 'clearing an optional numeric setting should remove the persisted override');
+assert.notEqual(themeSettingValueSignature(1), themeSettingValueSignature('1'), 'select option signatures should preserve scalar types');
+
+const shortColorResolution = resolveThemeSettings({
+  pack: 'arcus',
+  manifest: {
+    configSchema: {
+      type: 'object',
+      properties: {
+        accentColor: {
+          type: 'string',
+          format: 'color',
+          default: '#abc',
+          'x-press': {
+            control: 'color',
+            cssVariable: '--arcus-short-accent'
+          }
+        }
+      }
+    }
+  },
+  siteConfig: {
+    themeSettings: {
+      arcus: {
+        accentColor: '#aabbcc'
+      }
+    }
+  }
+});
+assert.equal(shortColorResolution.defaults.accentColor, '#aabbcc', 'short color defaults should normalize to the browser color input form');
+assert.deepEqual(shortColorResolution.overrides, {}, 'expanded short color defaults should not persist as overrides');
+assert.deepEqual(shortColorResolution.cssVariables, [], 'expanded short color defaults should not emit CSS override variables');
+
 const cssValues = new Map();
 const fakeDocument = {
   documentElement: {
@@ -239,6 +281,43 @@ assert.throws(
   }),
   /unsupported control "slider"/,
   'theme package validation should reject unsupported explicit controls'
+);
+
+assert.throws(
+  () => validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      radiusScale: {
+        type: 'string',
+        'x-press': {
+          control: 'range'
+        }
+      }
+    }
+  }),
+  /incompatible type "string"/,
+  'theme package validation should reject controls incompatible with schema types'
+);
+
+assert.equal(
+  validateThemeConfigSchema({
+    type: 'object',
+    properties: {
+      nestedLegacyConfig: {
+        type: 'object',
+        properties: {
+          tone: { type: 'string' }
+        }
+      },
+      typelessNestedConfig: {
+        properties: {
+          density: { type: 'string' }
+        }
+      }
+    }
+  }),
+  true,
+  'theme package validation should ignore non-Press nested config schemas'
 );
 
 console.log('ok - theme settings contract');


### PR DESCRIPTION
## Summary
- Add the Press Theme Settings Contract pipeline for `theme.json.configSchema`.
- Persist verified overrides in `site.yaml` under `themeSettings.<themeSlug>` and expose resolved values through `ctx.theme.settings` in public runtime and editor preview.
- Add dynamic Site Settings controls for scalar theme settings, safe CSS variable injection, schema/package validation, and package exports through `@ekilyhq/press-theme-contract@3.4.132`.

## Verification
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-settings.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-runtime.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-theme-manager.js`
- `~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-theme-contracts.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-composer-identity-grid.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-ui-components.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-site-features.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-theme-contract-package.mjs`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/sync-runtime-cache-keys.mjs --check`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-package.sh`
- `git diff --check`
- Headless Chrome smoke with `/Users/sam/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`: opened Site Settings, selected Arcus through a mocked installed-packs response, edited accent/radius/density/background/media settings, verified resolver output and CSS variables, and found no unexpected console/request failures.

## Release Notes
- This is a Press system-surface change and targets system release `v3.4.132`.
- Arcus theme settings pilot is in a separate PR and should merge/release only after this Press release exists.
