### PR TITLE
Track theme demo release convergence

### DIFF
--- a/scripts/product-state-dashboard.js
+++ b/scripts/product-state-dashboard.js
@@ -148,6 +148,29 @@ function themeRows(state) {
   }));
 }
 
+function themeDemoRows(state) {
+  return Object.entries(state && state.themeDemos && typeof state.themeDemos === 'object' ? state.themeDemos : {}).map(([key, entry]) => {
+    const installed = entry.installedTheme && typeof entry.installedTheme === 'object' ? entry.installedTheme : {};
+    const pressExpected = semverLabel(entry.expectedVersion);
+    const pressObserved = semverLabel(entry.observedVersion);
+    const themeExpected = semverLabel(installed.expectedVersion);
+    const themeObserved = semverLabel(installed.observedVersion);
+    return {
+      name: entry.label || key,
+      status: entry.status,
+      expected: [
+        pressExpected ? `Press ${pressExpected}` : '',
+        themeExpected ? `Theme ${themeExpected}` : ''
+      ].filter(Boolean).join(' / '),
+      observed: [
+        pressObserved ? `Press ${pressObserved}` : '',
+        themeObserved ? `Theme ${themeObserved}` : ''
+      ].filter(Boolean).join(' / '),
+      owner: entry.repository || ''
+    };
+  });
+}
+
 function renderProductStateDashboard(state) {
   const source = state && typeof state === 'object' ? state : {};
   const pressSystem = source.pressSystem && typeof source.pressSystem === 'object' ? source.pressSystem : {};
@@ -238,8 +261,8 @@ function renderProductStateDashboard(state) {
     </section>
 
     <section>
-      <h2>Theme Demo Runtime</h2>
-      ${renderRows(dashboardRowsFromMap(source.themeDemos))}
+      <h2>Theme Demo Channels</h2>
+      ${renderRows(themeDemoRows(source))}
     </section>
 
     <section>

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -188,6 +188,11 @@ function semverToTag(value) {
   return version ? `v${version}` : '';
 }
 
+function normalizeDigest(value) {
+  const text = String(value || '').trim().replace(/^sha256:/i, '').toLowerCase();
+  return text ? `sha256:${text}` : '';
+}
+
 function compareSemver(a, b) {
   const left = normalizeSemver(a);
   const right = normalizeSemver(b);
@@ -494,6 +499,7 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
     version: '',
     contractVersion: null,
     engines: {},
+    release: {},
     artifact: {},
     problems: []
   };
@@ -506,12 +512,18 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
   out.version = String(manifest.version || '').trim();
   out.contractVersion = Number(manifest.contractVersion);
   out.engines = manifest.engines && typeof manifest.engines === 'object' ? manifest.engines : {};
+  const release = manifest.release && typeof manifest.release === 'object' ? manifest.release : {};
+  out.release = {
+    tag: String(release.tag || '').trim(),
+    htmlUrl: String(release.htmlUrl || '').trim(),
+    publishedAt: String(release.publishedAt || '').trim()
+  };
   const asset = manifest.asset && typeof manifest.asset === 'object' ? manifest.asset : {};
   out.artifact = {
     name: String(asset.name || '').trim(),
     url: String(asset.url || '').trim(),
     size: Number(asset.size || 0),
-    digest: String(asset.digest || '').trim()
+    digest: normalizeDigest(asset.digest)
   };
 
   if (manifest.schemaVersion !== 1 || manifest.type !== 'press-theme') {
@@ -526,6 +538,10 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
     out.status = 'drift';
     out.problems.push('theme release must declare version and supported contractVersion');
   }
+  if (out.release.tag !== semverToTag(out.version)) {
+    out.status = 'drift';
+    out.problems.push('theme release tag must match version');
+  }
   if (!out.engines.press || !satisfiesSemverRange(pressVersion, out.engines.press)) {
     out.status = 'drift';
     out.problems.push(`theme engines.press does not accept Press ${pressVersion}`);
@@ -539,6 +555,134 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
     out.problems.push('theme release asset must declare url, size, and digest');
   }
   if (out.status !== 'drift') out.status = 'ok';
+  return out;
+}
+
+function channelResultLabel(result) {
+  return result && result.source ? result.source : 'unknown source';
+}
+
+function themeDemoChannelSource(source, key) {
+  const channels = source && source.observedChannels && typeof source.observedChannels === 'object'
+    ? source.observedChannels
+    : {};
+  return channels[key] && channels[key].source ? channels[key].source : '';
+}
+
+function findThemePackEntry(packs, slug) {
+  if (!Array.isArray(packs)) return null;
+  return packs.find((entry) => String(entry && entry.value || '').trim() === slug) || null;
+}
+
+function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, packsResult, lockResult, pressVersion }) {
+  const slug = String(source.key || '').trim();
+  const out = {
+    status: 'unknown',
+    expectedVersion: expectedTheme && expectedTheme.version ? expectedTheme.version : '',
+    expectedTag: expectedTheme && expectedTheme.release ? expectedTheme.release.tag : '',
+    expectedDigest: expectedTheme && expectedTheme.artifact ? normalizeDigest(expectedTheme.artifact.digest) : '',
+    observedVersion: '',
+    observedTag: '',
+    observedDigest: '',
+    sources: {
+      manifest: manifestResult && manifestResult.source || '',
+      packs: packsResult && packsResult.source || '',
+      lock: lockResult && lockResult.source || ''
+    },
+    problems: []
+  };
+
+  if (!expectedTheme || expectedTheme.status !== 'ok') {
+    out.problems.push('expected theme release is unavailable or invalid');
+    return out;
+  }
+
+  if (!manifestResult || !manifestResult.ok) {
+    out.status = 'drift';
+    out.problems.push(`demo theme manifest is unreachable: ${manifestResult ? manifestResult.error : 'missing source'}`);
+    return out;
+  }
+  if (!packsResult || !packsResult.ok) {
+    out.status = 'drift';
+    out.problems.push(`demo theme packs registry is unreachable: ${packsResult ? packsResult.error : 'missing source'}`);
+    return out;
+  }
+  if (!lockResult || !lockResult.ok) {
+    out.status = 'drift';
+    out.problems.push(`demo release lock is unreachable: ${lockResult ? lockResult.error : 'missing source'}`);
+    return out;
+  }
+
+  const manifest = manifestResult.value && typeof manifestResult.value === 'object' ? manifestResult.value : {};
+  const packs = packsResult.value;
+  const lock = lockResult.value && typeof lockResult.value === 'object' ? lockResult.value : {};
+  const packEntry = findThemePackEntry(packs, slug);
+  const packRelease = packEntry && packEntry.release && typeof packEntry.release === 'object' ? packEntry.release : {};
+  const lockTheme = lock.theme && typeof lock.theme === 'object' ? lock.theme : {};
+  const lockPress = lock.pressSystem && typeof lock.pressSystem === 'object' ? lock.pressSystem : {};
+  const lockAsset = lockTheme.asset && typeof lockTheme.asset === 'object' ? lockTheme.asset : {};
+
+  out.observedVersion = String(manifest.version || '').trim();
+  out.observedTag = String(packRelease.tag || lockTheme.release && lockTheme.release.tag || '').trim();
+  out.observedDigest = normalizeDigest(packRelease.digest || lockAsset.digest);
+
+  if (String(manifest.version || '').trim() !== expectedTheme.version) {
+    out.problems.push(`demo theme manifest is ${String(manifest.version || 'unknown')}, expected ${expectedTheme.version}`);
+  }
+  if (Number(manifest.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
+    out.problems.push(`demo theme manifest contractVersion is ${Number(manifest.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
+  }
+  if (!packEntry) {
+    out.problems.push('demo packs registry is missing the installed theme entry');
+  } else {
+    if (String(packEntry.version || '').trim() !== expectedTheme.version) {
+      out.problems.push(`demo packs registry is ${String(packEntry.version || 'unknown')}, expected ${expectedTheme.version}`);
+    }
+    if (Number(packEntry.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
+      out.problems.push(`demo packs registry contractVersion is ${Number(packEntry.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
+    }
+    if (String(packRelease.tag || '').trim() !== expectedTheme.release.tag) {
+      out.problems.push(`demo packs registry release tag is ${String(packRelease.tag || 'unknown')}, expected ${expectedTheme.release.tag}`);
+    }
+    if (String(packRelease.assetName || '').trim() !== expectedTheme.artifact.name) {
+      out.problems.push('demo packs registry assetName does not match theme release');
+    }
+    if (Number(packRelease.size || 0) !== Number(expectedTheme.artifact.size || 0)) {
+      out.problems.push('demo packs registry size does not match theme release');
+    }
+    if (normalizeDigest(packRelease.digest) !== normalizeDigest(expectedTheme.artifact.digest)) {
+      out.problems.push('demo packs registry digest does not match theme release');
+    }
+  }
+  if (lock.schemaVersion !== 1 || lock.type !== 'press-theme-demo-release-lock') {
+    out.problems.push('demo release lock must be schemaVersion 1 and type press-theme-demo-release-lock');
+  }
+  if (String(lock.slug || '').trim() !== slug || String(lockTheme.value || '').trim() !== slug) {
+    out.problems.push('demo release lock slug does not match theme demo target');
+  }
+  if (String(lockPress.version || '').trim() !== pressVersion || String(lockPress.tag || '').trim() !== semverToTag(pressVersion)) {
+    out.problems.push(`demo release lock Press system is ${String(lockPress.version || 'unknown')}, expected ${pressVersion}`);
+  }
+  if (String(lockTheme.version || '').trim() !== expectedTheme.version) {
+    out.problems.push(`demo release lock theme is ${String(lockTheme.version || 'unknown')}, expected ${expectedTheme.version}`);
+  }
+  if (Number(lockTheme.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
+    out.problems.push(`demo release lock contractVersion is ${Number(lockTheme.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
+  }
+  if (String(lockTheme.release && lockTheme.release.tag || '').trim() !== expectedTheme.release.tag) {
+    out.problems.push('demo release lock theme tag does not match theme release');
+  }
+  if (String(lockAsset.name || '').trim() !== expectedTheme.artifact.name) {
+    out.problems.push('demo release lock asset name does not match theme release');
+  }
+  if (Number(lockAsset.size || 0) !== Number(expectedTheme.artifact.size || 0)) {
+    out.problems.push('demo release lock asset size does not match theme release');
+  }
+  if (normalizeDigest(lockAsset.digest) !== normalizeDigest(expectedTheme.artifact.digest)) {
+    out.problems.push('demo release lock asset digest does not match theme release');
+  }
+
+  out.status = out.problems.length ? 'drift' : 'ok';
   return out;
 }
 
@@ -564,6 +708,7 @@ function downstreamTarget(source, pressVersion, fallbackReconcilerKind) {
     source: String(source.source || '').trim(),
     expectedVersion: target.version,
     expectedTag: target.tag,
+    observedChannels: clone(source.observedChannels || {}),
     reconciler: {
       eventType: String(sourceReconciler.eventType || source.eventType || 'press-system-release').trim(),
       kind: String(sourceReconciler.kind || fallbackReconcilerKind || legacyKind || 'press-runtime-sync').trim(),
@@ -940,6 +1085,50 @@ async function buildProductState(options = {}) {
           owner: theme.repository
         });
       }
+    }
+  }
+
+  const themesBySlug = new Map(state.themes.entries.map((entry) => [entry.slug, entry]));
+  for (const source of effectiveSources.themeDemos || []) {
+    const entry = state.themeDemos[source.key];
+    if (!entry) continue;
+    entry.pressSystem = {
+      status: entry.status,
+      source: entry.source,
+      expectedVersion: entry.expectedVersion,
+      observedVersion: entry.observedVersion,
+      expectedTag: semverToTag(entry.expectedVersion),
+      observedTag: entry.observedTag
+    };
+    const manifestSource = themeDemoChannelSource(source, 'themeManifest');
+    const packsSource = themeDemoChannelSource(source, 'themePacks');
+    const lockSource = themeDemoChannelSource(source, 'demoLock');
+    const manifestResult = manifestSource
+      ? await loadJson(manifestSource)
+      : { ok: false, source: '', error: 'theme demo target is missing themeManifest observed channel' };
+    const packsResult = packsSource
+      ? await loadJson(packsSource)
+      : { ok: false, source: '', error: 'theme demo target is missing themePacks observed channel' };
+    const lockResult = lockSource
+      ? await loadJson(lockSource)
+      : { ok: false, source: '', error: 'theme demo target is missing demoLock observed channel' };
+    const installedTheme = themeDemoInstalledThemeEntry({
+      source,
+      expectedTheme: themesBySlug.get(source.key),
+      manifestResult,
+      packsResult,
+      lockResult,
+      pressVersion
+    });
+    entry.installedTheme = installedTheme;
+    entry.status = aggregateStatus([entry.pressSystem.status, installedTheme.status]);
+    if (installedTheme.status !== 'ok') {
+      addProblem(state, {
+        component: `themeDemos.${source.key}.theme`,
+        code: installedTheme.status === 'unknown' ? 'theme_demo_theme_unknown' : 'theme_demo_theme_drift',
+        message: installedTheme.problems.join('; ') || `theme demo installed theme could not be verified from ${channelResultLabel(manifestResult)}`,
+        owner: source.repository
+      });
     }
   }
 

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -514,9 +514,9 @@ function themeReleaseEntry(catalogEntry, result, pressVersion) {
   out.engines = manifest.engines && typeof manifest.engines === 'object' ? manifest.engines : {};
   const release = manifest.release && typeof manifest.release === 'object' ? manifest.release : {};
   out.release = {
-    tag: String(release.tag || '').trim(),
-    htmlUrl: String(release.htmlUrl || '').trim(),
-    publishedAt: String(release.publishedAt || '').trim()
+    tag: String(release.tag || manifest.tag || '').trim(),
+    htmlUrl: String(release.htmlUrl || manifest.htmlUrl || manifest.html_url || manifest.releaseUrl || '').trim(),
+    publishedAt: String(release.publishedAt || manifest.publishedAt || manifest.published_at || '').trim()
   };
   const asset = manifest.asset && typeof manifest.asset === 'object' ? manifest.asset : {};
   out.artifact = {
@@ -729,6 +729,9 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
   }
   if (String(lockAsset.name || '').trim() !== expectedTheme.artifact.name) {
     out.problems.push('demo release lock asset name does not match theme release');
+  }
+  if (String(lockAsset.url || '').trim() !== expectedTheme.artifact.url) {
+    out.problems.push('demo release lock asset url does not match theme release');
   }
   if (Number(lockAsset.size || 0) !== Number(expectedTheme.artifact.size || 0)) {
     out.problems.push('demo release lock asset size does not match theme release');

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -574,7 +574,7 @@ function findThemePackEntry(packs, slug) {
   return packs.find((entry) => String(entry && entry.value || '').trim() === slug) || null;
 }
 
-function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, packsResult, lockResult, pressVersion }) {
+function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, packsResult, lockResult, pressVersion, systemRelease, releaseIntentSource }) {
   const slug = String(source.key || '').trim();
   const out = {
     status: 'unknown',
@@ -614,13 +614,21 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
   }
 
   const manifest = manifestResult.value && typeof manifestResult.value === 'object' ? manifestResult.value : {};
+  const manifestEngines = manifest.engines && typeof manifest.engines === 'object' ? manifest.engines : {};
   const packs = packsResult.value;
   const lock = lockResult.value && typeof lockResult.value === 'object' ? lockResult.value : {};
   const packEntry = findThemePackEntry(packs, slug);
+  const packSource = packEntry && packEntry.source && typeof packEntry.source === 'object' ? packEntry.source : {};
   const packRelease = packEntry && packEntry.release && typeof packEntry.release === 'object' ? packEntry.release : {};
   const lockTheme = lock.theme && typeof lock.theme === 'object' ? lock.theme : {};
+  const lockThemeEngines = lockTheme.engines && typeof lockTheme.engines === 'object' ? lockTheme.engines : {};
   const lockPress = lock.pressSystem && typeof lock.pressSystem === 'object' ? lock.pressSystem : {};
   const lockAsset = lockTheme.asset && typeof lockTheme.asset === 'object' ? lockTheme.asset : {};
+  const lockPressAsset = lockPress.asset && typeof lockPress.asset === 'object' ? lockPress.asset : {};
+  const lockReleaseIntent = lockPress.releaseIntent && typeof lockPress.releaseIntent === 'object' ? lockPress.releaseIntent : {};
+  const expectedPressAsset = systemRelease && systemRelease.asset && typeof systemRelease.asset === 'object'
+    ? systemRelease.asset
+    : {};
 
   out.observedVersion = String(manifest.version || '').trim();
   out.observedTag = String(packRelease.tag || lockTheme.release && lockTheme.release.tag || '').trim();
@@ -632,6 +640,11 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
   if (Number(manifest.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
     out.problems.push(`demo theme manifest contractVersion is ${Number(manifest.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
   }
+  if (String(manifestEngines.press || '').trim() !== String(expectedTheme.engines && expectedTheme.engines.press || '').trim()) {
+    out.problems.push('demo theme manifest engines.press does not match theme release');
+  } else if (!satisfiesSemverRange(pressVersion, manifestEngines.press)) {
+    out.problems.push(`demo theme manifest engines.press does not accept Press ${pressVersion}`);
+  }
   if (!packEntry) {
     out.problems.push('demo packs registry is missing the installed theme entry');
   } else {
@@ -641,8 +654,26 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
     if (Number(packEntry.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
       out.problems.push(`demo packs registry contractVersion is ${Number(packEntry.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
     }
+    if (String(packEntry.engines && packEntry.engines.press || '').trim() !== String(expectedTheme.engines && expectedTheme.engines.press || '').trim()) {
+      out.problems.push('demo packs registry engines.press does not match theme release');
+    }
+    if (String(packSource.type || '').trim() !== 'official') {
+      out.problems.push('demo packs registry source type must be official');
+    }
+    if (String(packSource.repo || '').trim() !== expectedTheme.repository) {
+      out.problems.push('demo packs registry source repo does not match theme release');
+    }
+    if (String(packSource.manifestUrl || '').trim() !== expectedTheme.manifestUrl) {
+      out.problems.push('demo packs registry source manifestUrl does not match theme release');
+    }
     if (String(packRelease.tag || '').trim() !== expectedTheme.release.tag) {
       out.problems.push(`demo packs registry release tag is ${String(packRelease.tag || 'unknown')}, expected ${expectedTheme.release.tag}`);
+    }
+    if (String(packRelease.htmlUrl || '').trim() !== expectedTheme.release.htmlUrl) {
+      out.problems.push('demo packs registry release htmlUrl does not match theme release');
+    }
+    if (String(packRelease.publishedAt || '').trim() !== expectedTheme.release.publishedAt) {
+      out.problems.push('demo packs registry release publishedAt does not match theme release');
     }
     if (String(packRelease.assetName || '').trim() !== expectedTheme.artifact.name) {
       out.problems.push('demo packs registry assetName does not match theme release');
@@ -663,14 +694,38 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
   if (String(lockPress.version || '').trim() !== pressVersion || String(lockPress.tag || '').trim() !== semverToTag(pressVersion)) {
     out.problems.push(`demo release lock Press system is ${String(lockPress.version || 'unknown')}, expected ${pressVersion}`);
   }
+  if (String(lockPressAsset.name || '').trim() !== String(expectedPressAsset.name || '').trim()) {
+    out.problems.push('demo release lock Press asset name does not match system release');
+  }
+  if (String(lockPressAsset.url || '').trim() !== String(expectedPressAsset.url || '').trim()) {
+    out.problems.push('demo release lock Press asset url does not match system release');
+  }
+  if (Number(lockPressAsset.size || 0) !== Number(expectedPressAsset.size || 0)) {
+    out.problems.push('demo release lock Press asset size does not match system release');
+  }
+  if (normalizeDigest(lockPressAsset.digest) !== normalizeDigest(expectedPressAsset.digest)) {
+    out.problems.push('demo release lock Press asset digest does not match system release');
+  }
+  if (releaseIntentSource && String(lockReleaseIntent.source || '').trim() !== releaseIntentSource) {
+    out.problems.push('demo release lock Press releaseIntent source does not match release intent');
+  }
   if (String(lockTheme.version || '').trim() !== expectedTheme.version) {
     out.problems.push(`demo release lock theme is ${String(lockTheme.version || 'unknown')}, expected ${expectedTheme.version}`);
   }
   if (Number(lockTheme.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
     out.problems.push(`demo release lock contractVersion is ${Number(lockTheme.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
   }
+  if (String(lockThemeEngines.press || '').trim() !== String(expectedTheme.engines && expectedTheme.engines.press || '').trim()) {
+    out.problems.push('demo release lock theme engines.press does not match theme release');
+  }
   if (String(lockTheme.release && lockTheme.release.tag || '').trim() !== expectedTheme.release.tag) {
     out.problems.push('demo release lock theme tag does not match theme release');
+  }
+  if (String(lockTheme.release && lockTheme.release.htmlUrl || '').trim() !== expectedTheme.release.htmlUrl) {
+    out.problems.push('demo release lock theme release htmlUrl does not match theme release');
+  }
+  if (String(lockTheme.release && lockTheme.release.publishedAt || '').trim() !== expectedTheme.release.publishedAt) {
+    out.problems.push('demo release lock theme release publishedAt does not match theme release');
   }
   if (String(lockAsset.name || '').trim() !== expectedTheme.artifact.name) {
     out.problems.push('demo release lock asset name does not match theme release');
@@ -1118,7 +1173,9 @@ async function buildProductState(options = {}) {
       manifestResult,
       packsResult,
       lockResult,
-      pressVersion
+      pressVersion,
+      systemRelease,
+      releaseIntentSource: canonicalReleaseIntentSource
     });
     entry.installedTheme = installedTheme;
     entry.status = aggregateStatus([entry.pressSystem.status, installedTheme.status]);

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -569,12 +569,19 @@ function themeDemoChannelSource(source, key) {
   return channels[key] && channels[key].source ? channels[key].source : '';
 }
 
+function themeDemoChannelRequired(source, key) {
+  const channels = source && source.observedChannels && typeof source.observedChannels === 'object'
+    ? source.observedChannels
+    : {};
+  return !(channels[key] && channels[key].required === false);
+}
+
 function findThemePackEntry(packs, slug) {
   if (!Array.isArray(packs)) return null;
   return packs.find((entry) => String(entry && entry.value || '').trim() === slug) || null;
 }
 
-function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, packsResult, lockResult, pressVersion, systemRelease, releaseIntentSource }) {
+function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, packsResult, lockResult, lockRequired = true, pressVersion, systemRelease, releaseIntentSource }) {
   const slug = String(source.key || '').trim();
   const out = {
     status: 'unknown',
@@ -607,7 +614,7 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
     out.problems.push(`demo theme packs registry is unreachable: ${packsResult ? packsResult.error : 'missing source'}`);
     return out;
   }
-  if (!lockResult || !lockResult.ok) {
+  if ((!lockResult || !lockResult.ok) && lockRequired) {
     out.status = 'drift';
     out.problems.push(`demo release lock is unreachable: ${lockResult ? lockResult.error : 'missing source'}`);
     return out;
@@ -616,7 +623,8 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
   const manifest = manifestResult.value && typeof manifestResult.value === 'object' ? manifestResult.value : {};
   const manifestEngines = manifest.engines && typeof manifest.engines === 'object' ? manifest.engines : {};
   const packs = packsResult.value;
-  const lock = lockResult.value && typeof lockResult.value === 'object' ? lockResult.value : {};
+  const hasLock = !!(lockResult && lockResult.ok);
+  const lock = hasLock && lockResult.value && typeof lockResult.value === 'object' ? lockResult.value : {};
   const packEntry = findThemePackEntry(packs, slug);
   const packSource = packEntry && packEntry.source && typeof packEntry.source === 'object' ? packEntry.source : {};
   const packRelease = packEntry && packEntry.release && typeof packEntry.release === 'object' ? packEntry.release : {};
@@ -685,59 +693,61 @@ function themeDemoInstalledThemeEntry({ source, expectedTheme, manifestResult, p
       out.problems.push('demo packs registry digest does not match theme release');
     }
   }
-  if (lock.schemaVersion !== 1 || lock.type !== 'press-theme-demo-release-lock') {
-    out.problems.push('demo release lock must be schemaVersion 1 and type press-theme-demo-release-lock');
-  }
-  if (String(lock.slug || '').trim() !== slug || String(lockTheme.value || '').trim() !== slug) {
-    out.problems.push('demo release lock slug does not match theme demo target');
-  }
-  if (String(lockPress.version || '').trim() !== pressVersion || String(lockPress.tag || '').trim() !== semverToTag(pressVersion)) {
-    out.problems.push(`demo release lock Press system is ${String(lockPress.version || 'unknown')}, expected ${pressVersion}`);
-  }
-  if (String(lockPressAsset.name || '').trim() !== String(expectedPressAsset.name || '').trim()) {
-    out.problems.push('demo release lock Press asset name does not match system release');
-  }
-  if (String(lockPressAsset.url || '').trim() !== String(expectedPressAsset.url || '').trim()) {
-    out.problems.push('demo release lock Press asset url does not match system release');
-  }
-  if (Number(lockPressAsset.size || 0) !== Number(expectedPressAsset.size || 0)) {
-    out.problems.push('demo release lock Press asset size does not match system release');
-  }
-  if (normalizeDigest(lockPressAsset.digest) !== normalizeDigest(expectedPressAsset.digest)) {
-    out.problems.push('demo release lock Press asset digest does not match system release');
-  }
-  if (releaseIntentSource && String(lockReleaseIntent.source || '').trim() !== releaseIntentSource) {
-    out.problems.push('demo release lock Press releaseIntent source does not match release intent');
-  }
-  if (String(lockTheme.version || '').trim() !== expectedTheme.version) {
-    out.problems.push(`demo release lock theme is ${String(lockTheme.version || 'unknown')}, expected ${expectedTheme.version}`);
-  }
-  if (Number(lockTheme.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
-    out.problems.push(`demo release lock contractVersion is ${Number(lockTheme.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
-  }
-  if (String(lockThemeEngines.press || '').trim() !== String(expectedTheme.engines && expectedTheme.engines.press || '').trim()) {
-    out.problems.push('demo release lock theme engines.press does not match theme release');
-  }
-  if (String(lockTheme.release && lockTheme.release.tag || '').trim() !== expectedTheme.release.tag) {
-    out.problems.push('demo release lock theme tag does not match theme release');
-  }
-  if (String(lockTheme.release && lockTheme.release.htmlUrl || '').trim() !== expectedTheme.release.htmlUrl) {
-    out.problems.push('demo release lock theme release htmlUrl does not match theme release');
-  }
-  if (String(lockTheme.release && lockTheme.release.publishedAt || '').trim() !== expectedTheme.release.publishedAt) {
-    out.problems.push('demo release lock theme release publishedAt does not match theme release');
-  }
-  if (String(lockAsset.name || '').trim() !== expectedTheme.artifact.name) {
-    out.problems.push('demo release lock asset name does not match theme release');
-  }
-  if (String(lockAsset.url || '').trim() !== expectedTheme.artifact.url) {
-    out.problems.push('demo release lock asset url does not match theme release');
-  }
-  if (Number(lockAsset.size || 0) !== Number(expectedTheme.artifact.size || 0)) {
-    out.problems.push('demo release lock asset size does not match theme release');
-  }
-  if (normalizeDigest(lockAsset.digest) !== normalizeDigest(expectedTheme.artifact.digest)) {
-    out.problems.push('demo release lock asset digest does not match theme release');
+  if (hasLock) {
+    if (lock.schemaVersion !== 1 || lock.type !== 'press-theme-demo-release-lock') {
+      out.problems.push('demo release lock must be schemaVersion 1 and type press-theme-demo-release-lock');
+    }
+    if (String(lock.slug || '').trim() !== slug || String(lockTheme.value || '').trim() !== slug) {
+      out.problems.push('demo release lock slug does not match theme demo target');
+    }
+    if (String(lockPress.version || '').trim() !== pressVersion || String(lockPress.tag || '').trim() !== semverToTag(pressVersion)) {
+      out.problems.push(`demo release lock Press system is ${String(lockPress.version || 'unknown')}, expected ${pressVersion}`);
+    }
+    if (String(lockPressAsset.name || '').trim() !== String(expectedPressAsset.name || '').trim()) {
+      out.problems.push('demo release lock Press asset name does not match system release');
+    }
+    if (String(lockPressAsset.url || '').trim() !== String(expectedPressAsset.url || '').trim()) {
+      out.problems.push('demo release lock Press asset url does not match system release');
+    }
+    if (Number(lockPressAsset.size || 0) !== Number(expectedPressAsset.size || 0)) {
+      out.problems.push('demo release lock Press asset size does not match system release');
+    }
+    if (normalizeDigest(lockPressAsset.digest) !== normalizeDigest(expectedPressAsset.digest)) {
+      out.problems.push('demo release lock Press asset digest does not match system release');
+    }
+    if (releaseIntentSource && String(lockReleaseIntent.source || '').trim() !== releaseIntentSource) {
+      out.problems.push('demo release lock Press releaseIntent source does not match release intent');
+    }
+    if (String(lockTheme.version || '').trim() !== expectedTheme.version) {
+      out.problems.push(`demo release lock theme is ${String(lockTheme.version || 'unknown')}, expected ${expectedTheme.version}`);
+    }
+    if (Number(lockTheme.contractVersion || 0) !== Number(expectedTheme.contractVersion || 0)) {
+      out.problems.push(`demo release lock contractVersion is ${Number(lockTheme.contractVersion || 0)}, expected ${Number(expectedTheme.contractVersion || 0)}`);
+    }
+    if (String(lockThemeEngines.press || '').trim() !== String(expectedTheme.engines && expectedTheme.engines.press || '').trim()) {
+      out.problems.push('demo release lock theme engines.press does not match theme release');
+    }
+    if (String(lockTheme.release && lockTheme.release.tag || '').trim() !== expectedTheme.release.tag) {
+      out.problems.push('demo release lock theme tag does not match theme release');
+    }
+    if (String(lockTheme.release && lockTheme.release.htmlUrl || '').trim() !== expectedTheme.release.htmlUrl) {
+      out.problems.push('demo release lock theme release htmlUrl does not match theme release');
+    }
+    if (String(lockTheme.release && lockTheme.release.publishedAt || '').trim() !== expectedTheme.release.publishedAt) {
+      out.problems.push('demo release lock theme release publishedAt does not match theme release');
+    }
+    if (String(lockAsset.name || '').trim() !== expectedTheme.artifact.name) {
+      out.problems.push('demo release lock asset name does not match theme release');
+    }
+    if (String(lockAsset.url || '').trim() !== expectedTheme.artifact.url) {
+      out.problems.push('demo release lock asset url does not match theme release');
+    }
+    if (Number(lockAsset.size || 0) !== Number(expectedTheme.artifact.size || 0)) {
+      out.problems.push('demo release lock asset size does not match theme release');
+    }
+    if (normalizeDigest(lockAsset.digest) !== normalizeDigest(expectedTheme.artifact.digest)) {
+      out.problems.push('demo release lock asset digest does not match theme release');
+    }
   }
 
   out.status = out.problems.length ? 'drift' : 'ok';
@@ -1161,6 +1171,7 @@ async function buildProductState(options = {}) {
     const manifestSource = themeDemoChannelSource(source, 'themeManifest');
     const packsSource = themeDemoChannelSource(source, 'themePacks');
     const lockSource = themeDemoChannelSource(source, 'demoLock');
+    const lockRequired = themeDemoChannelRequired(source, 'demoLock');
     const manifestResult = manifestSource
       ? await loadJson(manifestSource)
       : { ok: false, source: '', error: 'theme demo target is missing themeManifest observed channel' };
@@ -1176,6 +1187,7 @@ async function buildProductState(options = {}) {
       manifestResult,
       packsResult,
       lockResult,
+      lockRequired,
       pressVersion,
       systemRelease,
       releaseIntentSource: canonicalReleaseIntentSource

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -58,6 +58,10 @@ function readJsonFile(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
 function sha256File(file) {
   return `sha256:${crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')}`;
 }
@@ -69,6 +73,19 @@ function sourceMapFromReleaseTargets(rawRoot = DEFAULT_RAW_ROOT) {
     map.set(source.key, source);
   });
   return map;
+}
+
+function normalizeObservedChannels(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return Object.fromEntries(Object.entries(source).map(([key, channel]) => {
+    const value = channel && typeof channel === 'object' ? channel : {};
+    return [key, {
+      ref: String(value.ref || '').trim(),
+      path: String(value.path || '').trim(),
+      type: String(value.type || '').trim(),
+      source: String(value.source || '').trim()
+    }];
+  }));
 }
 
 function normalizeSystemRelease(input = {}) {
@@ -141,6 +158,7 @@ function buildReleaseIntent(options = {}) {
         type: target.observed.type,
         source: source.source || ''
       },
+      observedChannels: normalizeObservedChannels(source.observedChannels),
       reconciler: {
         kind: target.reconciler.kind,
         idempotent: target.reconciler.idempotent !== false
@@ -229,6 +247,9 @@ function normalizeReleaseIntent(input = {}) {
       const expected = target && target.expected && typeof target.expected === 'object' ? target.expected : {};
       const observed = target && target.observed && typeof target.observed === 'object' ? target.observed : {};
       const reconciler = target && target.reconciler && typeof target.reconciler === 'object' ? target.reconciler : {};
+      const observedChannels = target && target.observedChannels && typeof target.observedChannels === 'object'
+        ? target.observedChannels
+        : {};
       return {
         key: String(target && target.key || '').trim(),
         category: String(target && target.category || '').trim(),
@@ -245,6 +266,7 @@ function normalizeReleaseIntent(input = {}) {
           type: String(observed.type || '').trim(),
           source: String(observed.source || '').trim()
         },
+        observedChannels: normalizeObservedChannels(observedChannels),
         reconciler: {
           kind: String(reconciler.kind || '').trim(),
           idempotent: reconciler.idempotent !== false
@@ -295,6 +317,18 @@ function validateReleaseIntent(intentInput, options = {}) {
     if (!target.observed.ref || !target.observed.path || !target.observed.type || !target.observed.source) {
       failures.push(`${prefix}.observed must declare ref, path, type, and source`);
     }
+    Object.entries(target.observedChannels || {}).forEach(([channelKey, channel]) => {
+      const channelPrefix = `${prefix}.observedChannels.${channelKey}`;
+      if (!['themeManifest', 'themePacks', 'demoLock'].includes(channelKey)) {
+        failures.push(`${channelPrefix} is not a supported observed channel`);
+      }
+      if (!channel.ref || !channel.path || !channel.type || !channel.source) {
+        failures.push(`${channelPrefix} must declare ref, path, type, and source`);
+      }
+      if (!['press-theme-manifest', 'press-theme-packs', 'theme-demo-release-lock'].includes(channel.type)) {
+        failures.push(`${channelPrefix}.type is invalid`);
+      }
+    });
     if (!target.reconciler.kind || target.reconciler.idempotent !== true) {
       failures.push(`${prefix}.reconciler must be idempotent and declare kind`);
     }
@@ -328,17 +362,23 @@ function validateReleaseIntent(intentInput, options = {}) {
 
 function releaseIntentToProductStateSources(intentInput) {
   const intent = normalizeReleaseIntent(intentInput);
+  const defaultSources = getReleaseProductStateSources(DEFAULT_RAW_ROOT);
+  const defaultSourceMap = new Map([...defaultSources.downstream, ...defaultSources.themeDemos].map((source) => [source.key, source]));
   const sources = {
     downstream: [],
     themeDemos: []
   };
   intent.targets.forEach((target) => {
+    const fallback = defaultSourceMap.get(target.key) || {};
     const source = {
       key: target.key,
       label: target.label,
       repository: target.repository,
       source: target.observed.source,
       type: target.observed.type,
+      observedChannels: Object.keys(target.observedChannels || {}).length
+        ? target.observedChannels
+        : clone(fallback.observedChannels || {}),
       eventType: target.eventType,
       reconciler: {
         eventType: target.eventType,

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -97,6 +97,36 @@ function hasCompleteThemeDemoObservedChannels(channels) {
   });
 }
 
+function deriveObservedChannelSource(target, channel, fallbackSource = '') {
+  const observedSource = String(target && target.observed && target.observed.source || '').trim();
+  const repository = String(target && target.repository || '').trim();
+  const observed = target && target.observed && typeof target.observed === 'object' ? target.observed : {};
+  if (!observedSource || !repository || !observed.ref || !observed.path || !channel.ref || !channel.path) {
+    return fallbackSource;
+  }
+  const observedSuffix = `/${repository}/${observed.ref}/${observed.path}`;
+  const channelSuffix = `/${repository}/${channel.ref}/${channel.path}`;
+  if (observedSource.endsWith(observedSuffix)) {
+    return `${observedSource.slice(0, -observedSuffix.length)}${channelSuffix}`;
+  }
+  return fallbackSource;
+}
+
+function deriveThemeDemoObservedChannels(target, fallbackChannels = {}) {
+  const channels = fallbackChannels && typeof fallbackChannels === 'object' ? fallbackChannels : {};
+  return Object.fromEntries(THEME_DEMO_OBSERVED_CHANNELS.map((key) => {
+    const channel = channels[key] && typeof channels[key] === 'object' ? channels[key] : {};
+    const normalized = {
+      ref: String(channel.ref || 'demo').trim(),
+      path: String(channel.path || '').trim(),
+      type: String(channel.type || '').trim(),
+      source: String(channel.source || '').trim()
+    };
+    normalized.source = deriveObservedChannelSource(target, normalized, normalized.source);
+    return [key, normalized];
+  }));
+}
+
 function normalizeSystemRelease(input = {}) {
   const source = input && typeof input === 'object' ? input : {};
   const version = normalizeSemver(source.version);
@@ -387,7 +417,7 @@ function releaseIntentToProductStateSources(intentInput) {
     const observedChannels = target.category === 'themeDemo'
       ? hasCompleteThemeDemoObservedChannels(target.observedChannels)
         ? target.observedChannels
-        : clone(fallback.observedChannels || {})
+        : deriveThemeDemoObservedChannels(target, fallback.observedChannels)
       : clone(target.observedChannels || {});
     const source = {
       key: target.key,

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -84,7 +84,8 @@ function normalizeObservedChannels(input = {}) {
       ref: String(value.ref || '').trim(),
       path: String(value.path || '').trim(),
       type: String(value.type || '').trim(),
-      source: String(value.source || '').trim()
+      source: String(value.source || '').trim(),
+      required: value.required === false ? false : true
     }];
   }));
 }
@@ -120,7 +121,8 @@ function deriveThemeDemoObservedChannels(target, fallbackChannels = {}) {
       ref: String(channel.ref || 'demo').trim(),
       path: String(channel.path || '').trim(),
       type: String(channel.type || '').trim(),
-      source: String(channel.source || '').trim()
+      source: String(channel.source || '').trim(),
+      required: key === 'demoLock' ? false : true
     };
     normalized.source = deriveObservedChannelSource(target, normalized, normalized.source);
     return [key, normalized];

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -10,6 +10,7 @@ const {
 
 const DEFAULT_PRESS_REPOSITORY = 'EkilyHQ/Press';
 const RELEASE_INTENT_TYPE = 'press-release-intent';
+const THEME_DEMO_OBSERVED_CHANNELS = ['themeManifest', 'themePacks', 'demoLock'];
 
 function normalizeSemver(value) {
   const raw = String(value || '').trim();
@@ -86,6 +87,14 @@ function normalizeObservedChannels(input = {}) {
       source: String(value.source || '').trim()
     }];
   }));
+}
+
+function hasCompleteThemeDemoObservedChannels(channels) {
+  const source = channels && typeof channels === 'object' ? channels : {};
+  return THEME_DEMO_OBSERVED_CHANNELS.every((key) => {
+    const channel = source[key] && typeof source[key] === 'object' ? source[key] : {};
+    return !!(channel.ref && channel.path && channel.type && channel.source);
+  });
 }
 
 function normalizeSystemRelease(input = {}) {
@@ -329,6 +338,11 @@ function validateReleaseIntent(intentInput, options = {}) {
         failures.push(`${channelPrefix}.type is invalid`);
       }
     });
+    if (target.category === 'themeDemo'
+      && Object.keys(target.observedChannels || {}).length
+      && !hasCompleteThemeDemoObservedChannels(target.observedChannels)) {
+      failures.push(`${prefix}.observedChannels must include complete themeManifest, themePacks, and demoLock channels`);
+    }
     if (!target.reconciler.kind || target.reconciler.idempotent !== true) {
       failures.push(`${prefix}.reconciler must be idempotent and declare kind`);
     }
@@ -370,15 +384,18 @@ function releaseIntentToProductStateSources(intentInput) {
   };
   intent.targets.forEach((target) => {
     const fallback = defaultSourceMap.get(target.key) || {};
+    const observedChannels = target.category === 'themeDemo'
+      ? hasCompleteThemeDemoObservedChannels(target.observedChannels)
+        ? target.observedChannels
+        : clone(fallback.observedChannels || {})
+      : clone(target.observedChannels || {});
     const source = {
       key: target.key,
       label: target.label,
       repository: target.repository,
       source: target.observed.source,
       type: target.observed.type,
-      observedChannels: Object.keys(target.observedChannels || {}).length
-        ? target.observedChannels
-        : clone(fallback.observedChannels || {}),
+      observedChannels,
       eventType: target.eventType,
       reconciler: {
         eventType: target.eventType,

--- a/scripts/release-targets.js
+++ b/scripts/release-targets.js
@@ -1,6 +1,26 @@
 const DEFAULT_RAW_ROOT = 'https://raw.githubusercontent.com';
 const RELEASE_EVENT_TYPE = 'press-system-release';
 
+function themeDemoObservedChannels(slug) {
+  return {
+    themeManifest: {
+      ref: 'demo',
+      path: `assets/themes/${slug}/theme.json`,
+      type: 'press-theme-manifest'
+    },
+    themePacks: {
+      ref: 'demo',
+      path: 'assets/themes/packs.json',
+      type: 'press-theme-packs'
+    },
+    demoLock: {
+      ref: 'demo',
+      path: 'demo-release-lock.json',
+      type: 'theme-demo-release-lock'
+    }
+  };
+}
+
 const RELEASE_TARGETS = Object.freeze([
   {
     key: 'yap',
@@ -45,6 +65,7 @@ const RELEASE_TARGETS = Object.freeze([
       path: 'assets/press-system.json',
       type: 'press-system-manifest'
     },
+    observedChannels: themeDemoObservedChannels('arcus'),
     reconciler: {
       kind: 'theme-demo-runtime-sync',
       idempotent: true
@@ -61,6 +82,7 @@ const RELEASE_TARGETS = Object.freeze([
       path: 'assets/press-system.json',
       type: 'press-system-manifest'
     },
+    observedChannels: themeDemoObservedChannels('cartograph'),
     reconciler: {
       kind: 'theme-demo-runtime-sync',
       idempotent: true
@@ -77,6 +99,7 @@ const RELEASE_TARGETS = Object.freeze([
       path: 'assets/press-system.json',
       type: 'press-system-manifest'
     },
+    observedChannels: themeDemoObservedChannels('glasswing'),
     reconciler: {
       kind: 'theme-demo-runtime-sync',
       idempotent: true
@@ -93,6 +116,7 @@ const RELEASE_TARGETS = Object.freeze([
       path: 'assets/press-system.json',
       type: 'press-system-manifest'
     },
+    observedChannels: themeDemoObservedChannels('solstice'),
     reconciler: {
       kind: 'theme-demo-runtime-sync',
       idempotent: true
@@ -110,6 +134,25 @@ function rawRoot(value = DEFAULT_RAW_ROOT) {
 
 function observedSource(target, root = DEFAULT_RAW_ROOT) {
   return `${rawRoot(root)}/${target.repository}/${target.observed.ref}/${target.observed.path}`;
+}
+
+function observedChannelSource(target, channel, root = DEFAULT_RAW_ROOT) {
+  return `${rawRoot(root)}/${target.repository}/${channel.ref}/${channel.path}`;
+}
+
+function observedChannelsWithSources(target, root = DEFAULT_RAW_ROOT) {
+  const channels = target.observedChannels && typeof target.observedChannels === 'object'
+    ? target.observedChannels
+    : {};
+  return Object.fromEntries(Object.entries(channels).map(([key, channel]) => [
+    key,
+    {
+      ref: channel.ref,
+      path: channel.path,
+      type: channel.type,
+      source: observedChannelSource(target, channel, root)
+    }
+  ]));
 }
 
 function getReleaseTargets() {
@@ -131,6 +174,7 @@ function productStateSourceFromTarget(target, root = DEFAULT_RAW_ROOT) {
     repository: target.repository,
     source: observedSource(target, root),
     type: target.observed.type,
+    observedChannels: observedChannelsWithSources(target, root),
     eventType: target.eventType,
     reconciler: {
       eventType: target.eventType,
@@ -179,6 +223,20 @@ function validateReleaseTargets(targets = RELEASE_TARGETS) {
     if (!['press-system-manifest', 'press-release-marker'].includes(String(observed.type || '').trim())) {
       failures.push(`${prefix}.observed.type is invalid`);
     }
+    const observedChannels = target && target.observedChannels && typeof target.observedChannels === 'object'
+      ? target.observedChannels
+      : {};
+    Object.entries(observedChannels).forEach(([channelKey, channel]) => {
+      const channelPrefix = `${prefix}.observedChannels.${channelKey}`;
+      if (!['themeManifest', 'themePacks', 'demoLock'].includes(channelKey)) {
+        failures.push(`${channelPrefix} is not a supported observed channel`);
+      }
+      if (!['main', 'demo'].includes(String(channel.ref || '').trim())) failures.push(`${channelPrefix}.ref must be main or demo`);
+      if (!String(channel.path || '').trim()) failures.push(`${channelPrefix}.path is required`);
+      if (!['press-theme-manifest', 'press-theme-packs', 'theme-demo-release-lock'].includes(String(channel.type || '').trim())) {
+        failures.push(`${channelPrefix}.type is invalid`);
+      }
+    });
     if (!String(reconciler.kind || '').trim()) failures.push(`${prefix}.reconciler.kind is required`);
     if (reconciler.idempotent !== true) failures.push(`${prefix}.reconciler.idempotent must be true`);
   });

--- a/scripts/test-product-state-dashboard.js
+++ b/scripts/test-product-state-dashboard.js
@@ -32,7 +32,33 @@ function sampleState(overrides = {}) {
           }
         }
       },
-      themeDemos: {},
+      themeDemos: {
+        arcus: {
+          label: 'Arcus demo runtime',
+          repository: 'EkilyHQ/Press-Theme-Arcus',
+          expectedVersion: '3.4.52',
+          expectedTag: 'v3.4.52',
+          observedChannels: {
+            themeManifest: {
+              path: 'assets/themes/arcus/theme.json',
+              type: 'press-theme-manifest'
+            },
+            themePacks: {
+              path: 'assets/themes/packs.json',
+              type: 'press-theme-packs'
+            },
+            demoLock: {
+              path: 'demo-release-lock.json',
+              type: 'theme-demo-release-lock'
+            }
+          },
+          reconciler: {
+            eventType: 'press-system-release',
+            kind: 'theme-demo-runtime-sync',
+            idempotent: true
+          }
+        }
+      },
       themes: {
         entries: [
           {
@@ -67,7 +93,20 @@ function sampleState(overrides = {}) {
         repository: 'EkilyHQ/YAP'
       }
     },
-    themeDemos: {},
+    themeDemos: {
+      arcus: {
+        label: 'Arcus demo runtime',
+        status: 'ok',
+        expectedVersion: '3.4.52',
+        observedVersion: '3.4.52',
+        repository: 'EkilyHQ/Press-Theme-Arcus',
+        installedTheme: {
+          status: 'ok',
+          expectedVersion: '3.4.2',
+          observedVersion: '3.4.2'
+        }
+      }
+    },
     themes: {
       catalog: { status: 'ok', count: 1 },
       entries: [
@@ -129,6 +168,9 @@ test('renderProductStateDashboard renders human-readable product status sections
   assert.match(html, /press-runtime-sync/);
   assert.match(html, /theme-release-compatibility/);
   assert.match(html, /YAP starter runtime/);
+  assert.match(html, /Theme Demo Channels/);
+  assert.match(html, /Arcus demo runtime/);
+  assert.match(html, /Press v3\.4\.52 \/ Theme v3\.4\.2/);
   assert.match(html, /Official Themes/);
   assert.match(html, /Arcus/);
   assert.match(html, /ekily-connect/);

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -657,6 +657,25 @@ test('buildProductState preserves release upgrade metadata for release intent va
   assert.deepEqual(state.observed.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
 });
 
+test('buildProductState honors top-level theme release metadata fallbacks', async () => {
+  const release = themeRelease('arcus');
+  release.tag = release.release.tag;
+  release.htmlUrl = release.release.htmlUrl;
+  release.publishedAt = release.release.publishedAt;
+  delete release.release;
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:theme-arcus': release
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'ok');
+  assert.equal(state.themes.entries.find((entry) => entry.slug === 'arcus').release.tag, 'v3.4.6');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'ok');
+});
+
 test('buildProductState blocks convergence when a demo installed theme is stale', async () => {
   const staleManifest = themeManifest('arcus', '3.4.5');
   const state = await buildProductState({
@@ -761,6 +780,24 @@ test('buildProductState blocks convergence when demo lock Press artifact drifts'
   assert.equal(state.status, 'drift');
   assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
   assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /release lock Press asset digest does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo lock theme asset URL drifts', async () => {
+  const release = themeRelease('arcus');
+  const lock = themeDemoLock('arcus', release);
+  lock.theme.asset.url = 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/release-artifacts/v3.4.5/press-theme-arcus-v3.4.6.zip';
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-demo-lock': lock
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /release lock asset url does not match/u);
   assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
 });
 

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -12,6 +12,8 @@ const {
   buildReleaseIntent
 } = require('./release-intent.js');
 
+const THEME_FIXTURES = ['arcus', 'cartograph', 'glasswing', 'solstice'];
+
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -27,7 +29,8 @@ function makeSources() {
     .filter((source) => source.key === 'arcus')
     .map((source) => ({
       ...source,
-      source: 'fixture:arcus-demo'
+      source: 'fixture:arcus-demo',
+      observedChannels: demoChannels('arcus')
     }));
   sources.catalog = {
     repository: 'EkilyHQ/Press-Theme-Catalog',
@@ -96,6 +99,12 @@ function themeRelease(slug, version = '3.4.6', pressRange = '>=3.4.130 <4.0.0', 
     engines: {
       press: pressRange
     },
+    release: {
+      tag: `v${version}`,
+      htmlUrl: `https://github.com/EkilyHQ/Press-Theme-${slug}/releases/tag/v${version}`,
+      publishedAt: '2026-05-25T00:00:00Z',
+      notes: ''
+    },
     asset: {
       name: `press-theme-${slug}-v${version}.zip`,
       url: `https://raw.githubusercontent.com/EkilyHQ/Press-Theme-${slug}/release-artifacts/v${version}/press-theme-${slug}-v${version}.zip`,
@@ -103,6 +112,126 @@ function themeRelease(slug, version = '3.4.6', pressRange = '>=3.4.130 <4.0.0', 
       digest: 'sha256:def456'
     },
     files: ['theme.json', 'theme.css']
+  };
+}
+
+function themeManifest(slug, version = '3.4.6', contractVersion = 4) {
+  return {
+    name: slug.charAt(0).toUpperCase() + slug.slice(1),
+    version,
+    contractVersion,
+    engines: {
+      press: '>=3.4.130 <4.0.0'
+    }
+  };
+}
+
+function themePacks(slug, release = themeRelease(slug)) {
+  return [
+    {
+      value: 'native',
+      version: '3.4.131',
+      builtIn: true
+    },
+    {
+      value: slug,
+      label: release.label,
+      version: release.version,
+      contractVersion: release.contractVersion,
+      source: {
+        type: 'official',
+        repo: `EkilyHQ/Press-Theme-${release.label}`,
+        manifestUrl: `fixture:theme-${slug}`
+      },
+      release: {
+        tag: release.release.tag,
+        htmlUrl: release.release.htmlUrl,
+        publishedAt: release.release.publishedAt,
+        assetName: release.asset.name,
+        size: release.asset.size,
+        digest: release.asset.digest
+      }
+    }
+  ];
+}
+
+function themeDemoLock(slug, release = themeRelease(slug), pressVersion = '3.4.131') {
+  return {
+    schemaVersion: 1,
+    type: 'press-theme-demo-release-lock',
+    repository: `EkilyHQ/Press-Theme-${release.label}`,
+    slug,
+    target: {
+      category: 'themeDemo',
+      ref: 'demo',
+      path: 'demo-release-lock.json',
+      type: 'theme-demo-release-lock',
+      reconciler: 'theme-demo-release-sync',
+      observed: {
+        pressSystem: {
+          path: 'assets/press-system.json',
+          type: 'press-system-manifest'
+        },
+        themeManifest: {
+          path: `assets/themes/${slug}/theme.json`,
+          type: 'press-theme-manifest'
+        },
+        themePacks: {
+          path: 'assets/themes/packs.json',
+          type: 'press-theme-packs'
+        }
+      }
+    },
+    pressSystem: {
+      version: pressVersion,
+      tag: `v${pressVersion}`,
+      sourceKind: 'release-intent',
+      asset: {
+        name: `press-system-v${pressVersion}.zip`,
+        url: `https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v${pressVersion}/press-system-v${pressVersion}.zip`,
+        size: 100,
+        digest: 'sha256:abc123'
+      },
+      releaseIntent: {
+        type: 'press-release-intent',
+        source: 'fixture:intent'
+      }
+    },
+    theme: {
+      value: slug,
+      label: release.label,
+      version: release.version,
+      contractVersion: release.contractVersion,
+      engines: release.engines,
+      release: release.release,
+      asset: release.asset,
+      releaseManifest: {
+        source: `fixture:theme-${slug}`
+      }
+    }
+  };
+}
+
+function demoChannels(slug) {
+  return {
+    themeManifest: {
+      ref: 'demo',
+      path: `assets/themes/${slug}/theme.json`,
+      type: 'press-theme-manifest',
+      source: `fixture:${slug}-theme-manifest`
+    },
+    themePacks: {
+      ref: 'demo',
+      path: 'assets/themes/packs.json',
+      type: 'press-theme-packs',
+      source: `fixture:${slug}-packs`
+    },
+    demoLock: {
+      ref: 'demo',
+      path: 'demo-release-lock.json',
+      type: 'theme-demo-release-lock',
+      source: `fixture:${slug}-demo-lock`
+    }
   };
 }
 
@@ -117,7 +246,10 @@ function releaseIntentFixture(release) {
   intent.targets.forEach((target) => {
     if (target.key === 'yap') target.observed.source = 'fixture:yap';
     else if (target.key === 'themeStarter') target.observed.source = 'fixture:starter';
-    else target.observed.source = `fixture:${target.key}-demo`;
+    else {
+      target.observed.source = `fixture:${target.key}-demo`;
+      target.observedChannels = demoChannels(target.key);
+    }
   });
   return intent;
 }
@@ -135,16 +267,22 @@ function makeFixtures(overrides = {}) {
     'fixture:solstice-demo': pressManifest(),
     'fixture:catalog': {
       schemaVersion: 1,
-      themes: [
-        {
-          value: 'arcus',
-          label: 'Arcus',
-          repo: 'EkilyHQ/Press-Theme-Arcus',
-          manifestUrl: 'fixture:theme-arcus'
-        }
-      ]
+      themes: THEME_FIXTURES.map((slug) => ({
+        value: slug,
+        label: slug.charAt(0).toUpperCase() + slug.slice(1),
+        repo: `EkilyHQ/Press-Theme-${slug.charAt(0).toUpperCase() + slug.slice(1)}`,
+        manifestUrl: `fixture:theme-${slug}`
+      }))
     },
-    'fixture:theme-arcus': themeRelease('arcus'),
+    ...Object.fromEntries(THEME_FIXTURES.flatMap((slug) => {
+      const release = themeRelease(slug);
+      return [
+        [`fixture:theme-${slug}`, release],
+        [`fixture:${slug}-theme-manifest`, themeManifest(slug, release.version, release.contractVersion)],
+        [`fixture:${slug}-packs`, themePacks(slug, release)],
+        [`fixture:${slug}-demo-lock`, themeDemoLock(slug, release)]
+      ];
+    })),
     'fixture:connect': {
       ok: true,
       service: 'ekily-connect',
@@ -463,11 +601,15 @@ test('buildProductState reports ok when all declared and observed facts agree', 
   assert.equal(state.desired.downstream.yap.reconciler.idempotent, true);
   assert.equal(state.desired.downstream.themeStarter.reconciler.kind, 'theme-starter-marker-sync');
   assert.equal(state.desired.themeDemos.arcus.reconciler.kind, 'theme-demo-runtime-sync');
-  assert.equal(state.desired.themes.catalog.expectedCount, 1);
+  assert.equal(state.desired.themes.catalog.expectedCount, 4);
   assert.equal(state.desired.themes.entries[0].expectedPressVersion, '3.4.131');
   assert.equal(state.desired.themes.entries[0].expectedContractVersion, 4);
   assert.equal(state.downstream.yap.status, 'ok');
   assert.equal(state.themeDemos.arcus.status, 'ok');
+  assert.equal(state.themeDemos.arcus.pressSystem.status, 'ok');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'ok');
+  assert.equal(state.themeDemos.arcus.installedTheme.observedVersion, '3.4.6');
+  assert.equal(state.themeDemos.arcus.installedTheme.observedDigest, 'sha256:def456');
   assert.equal(state.themes.catalog.status, 'ok');
   assert.equal(state.themes.entries[0].status, 'ok');
   assert.equal(state.connect.status, 'ok');
@@ -512,6 +654,71 @@ test('buildProductState preserves release upgrade metadata for release intent va
   assert.deepEqual(state.observed.pressSystem.themeContractUpgrade, release.themeContractUpgrade);
   assert.deepEqual(state.desired.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
   assert.deepEqual(state.observed.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
+});
+
+test('buildProductState blocks convergence when a demo installed theme is stale', async () => {
+  const staleManifest = themeManifest('arcus', '3.4.5');
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-theme-manifest': staleManifest
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /demo theme manifest is 3\.4\.5, expected 3\.4\.6/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo packs metadata has stale artifact digest', async () => {
+  const release = themeRelease('arcus');
+  const packs = themePacks('arcus', release);
+  packs[1].release.digest = `sha256:${'b'.repeat(64)}`;
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-packs': packs
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /packs registry digest does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo release lock is missing', async () => {
+  const fixtures = makeFixtures();
+  delete fixtures['fixture:arcus-demo-lock'];
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(fixtures),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /demo release lock is unreachable/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo theme manifest is unreachable', async () => {
+  const fixtures = makeFixtures();
+  delete fixtures['fixture:arcus-theme-manifest'];
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(fixtures),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /demo theme manifest is unreachable/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
 });
 
 test('buildProductState preserves legacy theme-starter reconciler fallback', async () => {

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -816,6 +816,29 @@ test('buildProductState blocks convergence when demo release lock is missing', a
   assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
 });
 
+test('buildProductState allows missing demo locks while legacy fallback channels are optional', async () => {
+  const release = systemRelease();
+  const intent = releaseIntentFixture(release);
+  intent.targets.forEach((target) => {
+    if (target.category === 'themeDemo') {
+      target.observedChannels.demoLock.required = false;
+    }
+  });
+  const fixtures = makeFixtures({
+    'fixture:intent': intent
+  });
+  delete fixtures['fixture:arcus-demo-lock'];
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(fixtures),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'ok');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'ok');
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), false);
+});
+
 test('buildProductState blocks convergence when demo theme manifest is unreachable', async () => {
   const fixtures = makeFixtures();
   delete fixtures['fixture:arcus-theme-manifest'];

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -138,6 +138,7 @@ function themePacks(slug, release = themeRelease(slug)) {
       label: release.label,
       version: release.version,
       contractVersion: release.contractVersion,
+      engines: release.engines,
       source: {
         type: 'official',
         repo: `EkilyHQ/Press-Theme-${release.label}`,
@@ -688,6 +689,78 @@ test('buildProductState blocks convergence when demo packs metadata has stale ar
   assert.equal(state.status, 'drift');
   assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
   assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /packs registry digest does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo theme engines drift', async () => {
+  const release = themeRelease('arcus');
+  const manifest = themeManifest('arcus', release.version, release.contractVersion);
+  manifest.engines.press = '>=3.4.0 <3.4.100';
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-theme-manifest': manifest
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /manifest engines\.press does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo packs source metadata drifts', async () => {
+  const release = themeRelease('arcus');
+  const packs = themePacks('arcus', release);
+  packs[1].source.repo = 'EkilyHQ/Press-Theme-Stale';
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-packs': packs
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /packs registry source repo does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo packs release provenance drifts', async () => {
+  const release = themeRelease('arcus');
+  const packs = themePacks('arcus', release);
+  packs[1].release.htmlUrl = 'https://github.com/EkilyHQ/Press-Theme-Arcus/releases/tag/v3.4.5';
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-packs': packs
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /packs registry release htmlUrl does not match/u);
+  assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
+});
+
+test('buildProductState blocks convergence when demo lock Press artifact drifts', async () => {
+  const release = themeRelease('arcus');
+  const lock = themeDemoLock('arcus', release);
+  lock.pressSystem.asset.digest = `sha256:${'c'.repeat(64)}`;
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:arcus-demo-lock': lock
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.status, 'drift');
+  assert.equal(state.themeDemos.arcus.installedTheme.status, 'drift');
+  assert.match(state.themeDemos.arcus.installedTheme.problems.join('\n'), /release lock Press asset digest does not match/u);
   assert.equal(shouldFailCheck(state, { requireConverged: true }), true);
 });
 

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -159,6 +159,19 @@ test('releaseIntentToProductStateSources restores standard theme demo channels f
   assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
 });
 
+test('validateReleaseIntent rejects partial theme demo observed channels', () => {
+  const release = systemRelease();
+  const intent = buildReleaseIntent({ systemRelease: release });
+  const arcus = intent.targets.find((target) => target.key === 'arcus');
+  arcus.observedChannels = {
+    themeManifest: arcus.observedChannels.themeManifest
+  };
+
+  const failures = validateReleaseIntent(intent, { systemRelease: release }).join('\n');
+
+  assert.match(failures, /observedChannels must include complete themeManifest, themePacks, and demoLock channels/u);
+});
+
 test('validateReleaseIntent rejects release/system mismatches', () => {
   const release = systemRelease();
   const intent = buildReleaseIntent({ systemRelease: release });

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -78,6 +78,10 @@ test('buildReleaseIntent freezes Press release targets and artifact metadata', (
   assert.deepEqual(intent.targets.map((target) => target.key), getReleaseTargets().map((target) => target.key));
   assert.equal(intent.targets[0].expected.version, '3.4.62');
   assert.equal(intent.targets[0].observed.source, 'https://raw.githubusercontent.com/EkilyHQ/YAP/main/assets/press-system.json');
+  const arcusTarget = intent.targets.find((target) => target.key === 'arcus');
+  assert.equal(arcusTarget.observedChannels.themeManifest.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/arcus/theme.json');
+  assert.equal(arcusTarget.observedChannels.themePacks.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/packs.json');
+  assert.equal(arcusTarget.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
   assert.equal(intent.targets[0].reconciler.idempotent, true);
   assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);
 });
@@ -135,6 +139,24 @@ test('releaseIntentToProductStateSources derives downstream observation sources 
   ]);
   assert.equal(sources.downstream[0].reconciler.kind, 'press-runtime-sync');
   assert.equal(sources.themeDemos[0].reconciler.kind, 'theme-demo-runtime-sync');
+  assert.equal(sources.themeDemos[0].observedChannels.themeManifest.path, 'assets/themes/arcus/theme.json');
+  assert.equal(sources.themeDemos[0].observedChannels.demoLock.type, 'theme-demo-release-lock');
+});
+
+test('releaseIntentToProductStateSources restores standard theme demo channels for older intents', () => {
+  const intent = buildReleaseIntent({
+    systemRelease: systemRelease(),
+    source: 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.4.62/release-intent.json'
+  });
+  intent.targets.forEach((target) => {
+    delete target.observedChannels;
+  });
+  const sources = releaseIntentToProductStateSources(intent);
+  const arcus = sources.themeDemos.find((source) => source.key === 'arcus');
+
+  assert.equal(arcus.observedChannels.themeManifest.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/arcus/theme.json');
+  assert.equal(arcus.observedChannels.themePacks.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/packs.json');
+  assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
 });
 
 test('validateReleaseIntent rejects release/system mismatches', () => {

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -157,6 +157,7 @@ test('releaseIntentToProductStateSources restores standard theme demo channels f
   assert.equal(arcus.observedChannels.themeManifest.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/arcus/theme.json');
   assert.equal(arcus.observedChannels.themePacks.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/packs.json');
   assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
+  assert.equal(arcus.observedChannels.demoLock.required, false);
 });
 
 test('releaseIntentToProductStateSources restores legacy theme demo channels from the observed source root', () => {
@@ -175,6 +176,7 @@ test('releaseIntentToProductStateSources restores legacy theme demo channels fro
   assert.equal(arcus.observedChannels.themeManifest.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/arcus/theme.json');
   assert.equal(arcus.observedChannels.themePacks.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/packs.json');
   assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
+  assert.equal(arcus.observedChannels.demoLock.required, false);
 });
 
 test('validateReleaseIntent rejects partial theme demo observed channels', () => {

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -159,6 +159,24 @@ test('releaseIntentToProductStateSources restores standard theme demo channels f
   assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
 });
 
+test('releaseIntentToProductStateSources restores legacy theme demo channels from the observed source root', () => {
+  const intent = buildReleaseIntent({
+    systemRelease: systemRelease(),
+    rawRoot: 'https://raw.example.test/staging',
+    source: 'https://raw.example.test/staging/EkilyHQ/Press/release-artifacts/v3.4.62/release-intent.json'
+  });
+  intent.targets.forEach((target) => {
+    if (target.category === 'themeDemo') delete target.observedChannels;
+  });
+  const sources = releaseIntentToProductStateSources(intent);
+  const arcus = sources.themeDemos.find((source) => source.key === 'arcus');
+
+  assert.equal(arcus.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/assets/press-system.json');
+  assert.equal(arcus.observedChannels.themeManifest.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/arcus/theme.json');
+  assert.equal(arcus.observedChannels.themePacks.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/assets/themes/packs.json');
+  assert.equal(arcus.observedChannels.demoLock.source, 'https://raw.example.test/staging/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
+});
+
 test('validateReleaseIntent rejects partial theme demo observed channels', () => {
   const release = systemRelease();
   const intent = buildReleaseIntent({ systemRelease: release });

--- a/scripts/test-release-targets.js
+++ b/scripts/test-release-targets.js
@@ -65,6 +65,9 @@ test('product-state defaults are derived from release targets', () => {
   assert.equal(DEFAULT_SOURCES.downstream[1].reconciler.kind, 'theme-starter-marker-sync');
   DEFAULT_SOURCES.themeDemos.forEach((source) => {
     assert.equal(source.reconciler.kind, 'theme-demo-runtime-sync');
+    assert.equal(source.observedChannels.themeManifest.source, `https://raw.githubusercontent.com/${source.repository}/demo/assets/themes/${source.key}/theme.json`);
+    assert.equal(source.observedChannels.themePacks.source, `https://raw.githubusercontent.com/${source.repository}/demo/assets/themes/packs.json`);
+    assert.equal(source.observedChannels.demoLock.source, `https://raw.githubusercontent.com/${source.repository}/demo/demo-release-lock.json`);
   });
 });
 


### PR DESCRIPTION
## Summary
- add theme demo observed channels to release targets and release intent metadata
- make Product State compare demo-installed theme manifests, packs metadata, and `demo-release-lock.json` against official root `theme-release.json`
- update the Product State dashboard so theme demo rows show both Press runtime and installed theme state

## Verification
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-targets.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-intent.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-product-state-ledger.js`
- `~/.local/bin/mise x node@22.18.0 -- node scripts/test-product-state-dashboard.js`
- `~/.local/bin/mise x node@22.18.0 -- bash scripts/test-product-state-workflow.sh`
- `git diff --check`

## Release order
- Merge the official theme demo observability PRs first and dispatch their demo sync workflows so each demo branch has `demo-release-lock.json`.
- Merge this Press PR only after those demo branches converge; otherwise the new Product State check will correctly report drift for missing demo locks.
- This PR does not change the Press runtime/editor system surface and does not require a Press system version bump by itself.

## Live validation
- Current local Product State code reports live demo drift because all four demo branches still lack `demo-release-lock.json`; that proves the new gate catches the previously invisible state.
- Arcus containment sync run `28950421947` succeeded and Pages now serves Arcus theme `3.4.7` with Theme Settings fields.

Internal review: local diff/test review completed; subagent review was skipped because the current tool policy only permits spawning subagents after explicit user authorization.
