### PR TITLE
Bump Press system release manifest

### DIFF
--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,21 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.132",
-  "tag": "v3.4.132",
+  "version": "3.4.133",
+  "tag": "v3.4.133",
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.131 <3.4.132"
+      ">=3.4.132 <3.4.133"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.131 before installing v3.4.132."
+    "message": "Update to v3.4.132 before installing v3.4.133."
   },
   "themeContractUpgrade": {
     "requiresInstalledThemeContractVersion": 4,
-    "message": "Update installed themes to contract v4 before installing v3.4.132."
+    "message": "Update installed themes to contract v4 before installing v3.4.133."
   },
   "contentModelUpgrade": {
     "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.131 and publish the content model migration before installing v3.4.132."
+    "message": "Install v3.4.132 and publish the content model migration before installing v3.4.133."
   }
 }

--- a/packages/press-theme-contract/package.json
+++ b/packages/press-theme-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekilyhq/press-theme-contract",
-  "version": "3.4.132",
+  "version": "3.4.133",
   "description": "Press theme contract helpers and packaged theme validation rules.",
   "type": "module",
   "license": "UNLICENSED",

--- a/scripts/test-theme-contract-package.mjs
+++ b/scripts/test-theme-contract-package.mjs
@@ -10,7 +10,7 @@ const sourceManifest = JSON.parse(await fs.readFile(path.join(root, 'packages', 
 
 assert.equal(sourceManifest.name, '@ekilyhq/press-theme-contract');
 assert.equal(sourceManifest.version, system.version);
-assert.equal(system.version, '3.4.132');
+assert.equal(system.version, '3.4.133');
 assert.equal(system.tag, `v${system.version}`);
 assert.equal(sourceManifest.publishConfig && sourceManifest.publishConfig.registry, 'https://npm.pkg.github.com');
 


### PR DESCRIPTION
## Summary
- bump the Press system manifest to v3.4.133 after #481 changed the system surface
- update upgrade/theme/content guard messages to reference v3.4.133

## Why
The system-release workflow for #481 failed in Plan release because assets/press-system.json still declared v3.4.132, which is not greater than the latest release v3.4.132.

## Verification
- ~/.local/bin/mise x node@22.18.0 -- node scripts/sync-runtime-cache-keys.mjs --check
- ~/.local/bin/mise x node@22.18.0 -- node scripts/test-press-version-runtime.js
- ~/.local/bin/mise x node@22.18.0 -- node --experimental-default-type=module scripts/test-system-updates.js
- bash scripts/test-system-release-workflow.sh
- ~/.local/bin/mise x node@22.18.0 -- bash scripts/test-system-release-package.sh
- ~/.local/bin/mise x node@22.18.0 -- node scripts/test-press-system-surface.mjs
- ~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-intent.js
- ~/.local/bin/mise x node@22.18.0 -- node scripts/test-release-targets.js
- bash scripts/test-main-guard.sh

## Release impact
- Press system release: yes, this allows the pending system-surface release to publish as v3.4.133.
- Downstream sync: expected after the system-release workflow succeeds.