### PR TITLE
Guard Press release graph

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -17,6 +17,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify release graph
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${RUNNER_TEMP}/press-github-releases.json"
+          node scripts/test-release-graph.js
+          node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check
+          bash scripts/test-system-release-workflow.sh
+
       - name: Enforce main safety rules
         run: |
           bash scripts/check-main-safety.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -23,10 +23,26 @@ jobs:
         run: |
           git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
           gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${RUNNER_TEMP}/press-github-releases.json"
-          node scripts/test-release-graph.js
           candidate_tag="$(node -e "const manifest = require('./assets/press-system.json'); process.stdout.write(String(manifest.tag || '').trim());")"
+          node scripts/test-release-graph.js
+          node scripts/test-system-release-transaction.mjs
           candidate_archive="$(PRESS_PACKAGE_SOURCE=worktree bash scripts/package-system-release.sh "${candidate_tag}" "${RUNNER_TEMP}/release-graph-candidate")"
-          node scripts/release-graph.js --mode auto --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check
+          release_plan_paths_file="$(mktemp)"
+          node scripts/print-press-system-surface.mjs release-plan-paths > "${release_plan_paths_file}"
+          release_plan_paths=()
+          while IFS= read -r release_plan_path; do
+            release_plan_paths+=("${release_plan_path}")
+          done < "${release_plan_paths_file}"
+          if [[ "${#release_plan_paths[@]}" -eq 0 ]]; then
+            echo "Press system release-plan path list is empty" >&2
+            exit 1
+          fi
+          validation_mode="auto"
+          if [[ -n "$(git diff --name-only "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" -- "${release_plan_paths[@]}")" ]]; then
+            validation_mode="candidate"
+          fi
+          node scripts/release-graph.js --mode "${validation_mode}" --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check
+          bash scripts/test-system-release-package.sh
           bash scripts/test-system-release-workflow.sh
 
       - name: Enforce main safety rules

--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -24,7 +24,9 @@ jobs:
           git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
           gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${RUNNER_TEMP}/press-github-releases.json"
           node scripts/test-release-graph.js
-          node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check
+          candidate_tag="$(node -e "const manifest = require('./assets/press-system.json'); process.stdout.write(String(manifest.tag || '').trim());")"
+          candidate_archive="$(PRESS_PACKAGE_SOURCE=worktree bash scripts/package-system-release.sh "${candidate_tag}" "${RUNNER_TEMP}/release-graph-candidate")"
+          node scripts/release-graph.js --mode auto --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check
           bash scripts/test-system-release-workflow.sh
 
       - name: Enforce main safety rules

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -25,7 +25,13 @@ jobs:
           fetch-depth: 0
 
       - name: Verify release package boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${RUNNER_TEMP}/press-github-releases.json"
+          node scripts/test-release-graph.js
+          node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-composer-action-contract.js
           node scripts/test-composer-root-contract.js
@@ -126,6 +132,16 @@ jobs:
             echo "archive_size=${archive_size}"
             echo "archive_sha256=${archive_sha256}"
           } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify release graph candidate
+        if: steps.plan.outputs.should_release == 'true'
+        run: |
+          node scripts/release-graph.js \
+            --mode candidate \
+            --artifact-ref origin/release-artifacts \
+            --github-releases "${RUNNER_TEMP}/press-github-releases.json" \
+            --candidate-archive "${{ steps.package.outputs.archive_path }}" \
+            --check
 
       - name: Create draft release
         if: steps.plan.outputs.should_release == 'true'

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -24,14 +24,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify release package boundary
+      - name: Inspect release transaction
+        id: transaction
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          mkdir -p dist
           git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          git fetch --force --tags origin
           gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "${RUNNER_TEMP}/press-github-releases.json"
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases "${RUNNER_TEMP}/press-github-releases.json" \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --github-output "${GITHUB_OUTPUT}" \
+            > dist/release-transaction.json
+
+      - name: Verify release package boundary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRANSACTION_ACTION: ${{ steps.transaction.outputs.action }}
+          CANDIDATE_VERSION: ${{ steps.transaction.outputs.version }}
+        run: |
+          set -euo pipefail
           node scripts/test-release-graph.js
-          node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check
+          node scripts/test-system-release-transaction.mjs
+          graph_args=(
+            --mode audit
+            --artifact-ref origin/release-artifacts
+            --github-releases "${RUNNER_TEMP}/press-github-releases.json"
+            --check
+          )
+          case "${TRANSACTION_ACTION}" in
+            resume-stage|resume-publish|resume-promote)
+              graph_args+=(--transient-candidate-version "${CANDIDATE_VERSION}")
+              ;;
+          esac
+          node scripts/release-graph.js "${graph_args[@]}"
           node scripts/sync-runtime-cache-keys.mjs --check
           node scripts/test-composer-action-contract.js
           node scripts/test-composer-root-contract.js
@@ -64,63 +95,73 @@ jobs:
       - name: Plan release
         id: plan
         env:
-          GH_TOKEN: ${{ github.token }}
+          TRANSACTION_ACTION: ${{ steps.transaction.outputs.action }}
+          TRANSACTION_ROOT_TAG: ${{ steps.transaction.outputs.root_tag }}
+          TRANSACTION_TAG: ${{ steps.transaction.outputs.tag }}
         run: |
           set -euo pipefail
-
-          latest_tag="$(gh release view --json tagName -q '.tagName' 2>/dev/null || true)"
-          if [[ -z "${latest_tag}" ]]; then
-            latest_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 || true)"
-          fi
-
-          source_version="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) { throw new Error('assets/press-system.json must declare matching version and tag'); } process.stdout.write(version);")"
+          latest_tag="${TRANSACTION_ROOT_TAG}"
+          source_version="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) throw new Error('assets/press-system.json must declare matching version and tag'); process.stdout.write(version);")"
           next_tag="v${source_version}"
 
-          release_plan_paths_file="$(mktemp)"
-          if ! node scripts/print-press-system-surface.mjs release-plan-paths > "${release_plan_paths_file}"; then
-            echo "Failed to read Press system release-plan paths" >&2
-            exit 1
-          fi
-          release_plan_paths=()
-          while IFS= read -r release_plan_path; do
-            release_plan_paths+=("${release_plan_path}")
-          done < "${release_plan_paths_file}"
-          if [[ "${#release_plan_paths[@]}" -eq 0 ]]; then
-            echo "Press system release-plan path list is empty" >&2
-            exit 1
-          fi
-          if [[ -n "${latest_tag}" ]]; then
-            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- "${release_plan_paths[@]}")"
-          else
-            changed_files="$(git ls-files -- "${release_plan_paths[@]}")"
-          fi
+          case "${TRANSACTION_ACTION}" in
+            resume-stage|resume-publish)
+              changed_files="Resume interrupted ${next_tag} release transaction"
+              ;;
+            resume-promote|dispatch)
+              {
+                echo "should_release=false"
+                echo "latest_tag=${latest_tag}"
+                echo "next_tag=${next_tag}"
+                echo "asset_name=press-system-${next_tag}.zip"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+              ;;
+            new|settled)
+              release_plan_paths_file="$(mktemp)"
+              node scripts/print-press-system-surface.mjs release-plan-paths > "${release_plan_paths_file}"
+              release_plan_paths=()
+              while IFS= read -r release_plan_path; do
+                release_plan_paths+=("${release_plan_path}")
+              done < "${release_plan_paths_file}"
+              if [[ "${#release_plan_paths[@]}" -eq 0 ]]; then
+                echo "Press system release-plan path list is empty" >&2
+                exit 1
+              fi
+              changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- "${release_plan_paths[@]}")"
+              ;;
+            *)
+              echo "Unknown release transaction action: ${TRANSACTION_ACTION}" >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p dist
+          printf '%s\n' "${changed_files}" > dist/release-changed-files.txt
 
           if [[ -z "${changed_files}" ]]; then
             {
               echo "should_release=false"
               echo "latest_tag=${latest_tag}"
+              echo "next_tag=${next_tag}"
+              echo "asset_name=press-system-${next_tag}.zip"
             } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
-          if [[ -n "${latest_tag}" ]]; then
-            export LATEST_TAG="${latest_tag}"
-            export NEXT_TAG="${next_tag}"
-            node -e "function parse(tag) { const match = String(tag || '').match(/^v(\\d+)\\.(\\d+)\\.(\\d+)$/); if (!match) throw new Error(\`invalid release tag: \${tag}\`); return match.slice(1).map(Number); } const latest = parse(process.env.LATEST_TAG); const next = parse(process.env.NEXT_TAG); for (let i = 0; i < 3; i += 1) { if (next[i] > latest[i]) process.exit(0); if (next[i] < latest[i]) break; } throw new Error(\`assets/press-system.json version \${process.env.NEXT_TAG} must be greater than latest release \${process.env.LATEST_TAG}\`);"
-          fi
+          export LATEST_TAG="${latest_tag}"
+          export NEXT_TAG="${next_tag}"
+          node -e "function parse(tag) { const match = String(tag || '').match(/^v(\\d+)\\.(\\d+)\\.(\\d+)$/); if (!match) throw new Error(\`invalid release tag: \${tag}\`); return match.slice(1).map(Number); } const latest = parse(process.env.LATEST_TAG); const next = parse(process.env.NEXT_TAG); for (let i = 0; i < 3; i += 1) { if (next[i] > latest[i]) process.exit(0); if (next[i] < latest[i]) break; } throw new Error(\`assets/press-system.json version \${process.env.NEXT_TAG} must be greater than latest release \${process.env.LATEST_TAG}\`);"
 
           {
             echo "should_release=true"
             echo "latest_tag=${latest_tag}"
             echo "next_tag=${next_tag}"
             echo "asset_name=press-system-${next_tag}.zip"
-            echo "changed_files<<EOF"
-            printf '%s\n' "${changed_files}"
-            echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Build system update package
-        if: steps.plan.outputs.should_release == 'true'
+        if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage')
         id: package
         run: |
           set -euo pipefail
@@ -133,163 +174,139 @@ jobs:
             echo "archive_sha256=${archive_sha256}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Verify release graph candidate
-        if: steps.plan.outputs.should_release == 'true'
-        run: |
-          node scripts/release-graph.js \
-            --mode candidate \
-            --artifact-ref origin/release-artifacts \
-            --github-releases "${RUNNER_TEMP}/press-github-releases.json" \
-            --candidate-archive "${{ steps.package.outputs.archive_path }}" \
-            --check
-
-      - name: Create draft release
-        if: steps.plan.outputs.should_release == 'true'
-        id: create
+      - name: Load staged system update package
+        if: steps.transaction.outputs.action == 'resume-publish'
+        id: staged_package
         env:
-          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.transaction.outputs.tag }}
+          ASSET_NAME: ${{ steps.transaction.outputs.asset_name }}
         run: |
           set -euo pipefail
-          next_tag="${{ steps.plan.outputs.next_tag }}"
-          latest_tag="${{ steps.plan.outputs.latest_tag }}"
-          asset_name="${{ steps.plan.outputs.asset_name }}"
+          archive_path="dist/${ASSET_NAME}"
+          git show "origin/release-artifacts:${TAG}/${ASSET_NAME}" > "${archive_path}"
+          archive_size="$(wc -c < "${archive_path}" | tr -d ' ')"
+          archive_sha256="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
+          {
+            echo "archive_path=${archive_path}"
+            echo "archive_size=${archive_size}"
+            echo "archive_sha256=${archive_sha256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify release graph candidate
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          TRANSACTION_ACTION: ${{ steps.transaction.outputs.action }}
+          CANDIDATE_VERSION: ${{ steps.transaction.outputs.version }}
+          CANDIDATE_ARCHIVE: ${{ steps.package.outputs.archive_path || steps.staged_package.outputs.archive_path }}
+        run: |
+          set -euo pipefail
+          graph_args=(
+            --mode candidate
+            --artifact-ref origin/release-artifacts
+            --github-releases "${RUNNER_TEMP}/press-github-releases.json"
+            --candidate-archive "${CANDIDATE_ARCHIVE}"
+            --check
+          )
+          case "${TRANSACTION_ACTION}" in
+            resume-stage|resume-publish)
+              graph_args+=(--transient-candidate-version "${CANDIDATE_VERSION}")
+              ;;
+          esac
+          node scripts/release-graph.js "${graph_args[@]}"
+
+      - name: Ensure draft release and asset
+        if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage')
+        id: draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
+          LATEST_TAG: ${{ steps.plan.outputs.latest_tag }}
+          ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
+          ARCHIVE_PATH: ${{ steps.package.outputs.archive_path }}
+          ARCHIVE_SIZE: ${{ steps.package.outputs.archive_size }}
+          ARCHIVE_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+        run: |
+          set -euo pipefail
           notes_file="dist/release-notes.md"
-          export NEXT_TAG="${next_tag}"
-
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-create.json
-          python3 - <<'PY' > dist/stale-draft-release-ids.txt
-          import json
-          import os
-
-          next_tag = os.environ["NEXT_TAG"]
-          with open("dist/releases-before-create.json", "r", encoding="utf-8") as fh:
-              releases = json.load(fh)
-
-          for release in releases:
-              if release.get("draft") and release.get("tag_name") == next_tag:
-                  print(release["id"])
-          PY
-
-          while IFS= read -r draft_release_id; do
-            [[ -n "${draft_release_id}" ]] || continue
-            echo "Deleting stale draft release ${draft_release_id}"
-            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${draft_release_id}" >/dev/null
-          done < dist/stale-draft-release-ids.txt
-
-          if [[ -s dist/stale-draft-release-ids.txt ]]; then
-            if git ls-remote --exit-code --tags origin "refs/tags/${next_tag}" >/dev/null 2>&1; then
-              echo "Deleting stale remote tag ${next_tag}"
-              git push --delete origin "${next_tag}"
-            fi
-            if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
-              echo "Deleting stale local tag ${next_tag}"
-              git tag -d "${next_tag}"
-            fi
-          fi
-
-          if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
-            echo "Refusing to overwrite existing tag ${next_tag}" >&2
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${next_tag}" >/dev/null 2>&1; then
-            echo "Refusing to overwrite existing remote tag ${next_tag}" >&2
-            exit 1
-          fi
-
           {
             echo "## Migration Guide"
             echo
-            echo "Use the System Updates tool in Markdown Editor to download and apply \`${asset_name}\`."
+            echo "Use the System Updates tool in Markdown Editor to download and apply \`${ASSET_NAME}\`."
             echo
             echo "## System Package"
             echo
-            echo "- Asset: \`${asset_name}\`"
-            echo "- SHA-256: \`${{ steps.package.outputs.archive_sha256 }}\`"
+            echo "- Asset: \`${ASSET_NAME}\`"
+            echo "- SHA-256: \`${ARCHIVE_SHA256}\`"
             echo
             echo "## Changed System Files"
             echo
-            printf '%s\n' "${{ steps.plan.outputs.changed_files }}" | sed 's/^/- /'
-            if [[ -n "${latest_tag}" ]]; then
-              echo
-              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${latest_tag}...${next_tag}"
-            fi
+            while IFS= read -r changed_file; do
+              printf -- '- %s\n' "${changed_file}"
+            done < dist/release-changed-files.txt
+            echo
+            echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${LATEST_TAG}...${NEXT_TAG}"
           } > "${notes_file}"
 
-          export RELEASE_NOTES_FILE="${notes_file}"
-          python3 - <<'PY' > dist/create-release.json
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          git fetch --force --tags origin
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-draft.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases dist/releases-before-draft.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/pre-draft-transaction.json
+          current_action="$(node -e "const state = require('./dist/pre-draft-transaction.json'); process.stdout.write(state.action);")"
+          release_id="$(node -e "const state = require('./dist/pre-draft-transaction.json'); process.stdout.write(String(state.releaseId || ''));")"
+
+          if [[ "${current_action}" == "new" ]]; then
+            export RELEASE_NOTES_FILE="${notes_file}"
+            python3 - <<'PY' > dist/create-release.json
           import json
           import os
           from pathlib import Path
 
-          next_tag = os.environ["NEXT_TAG"]
-          notes_file = Path(os.environ["RELEASE_NOTES_FILE"])
           print(json.dumps({
-              "tag_name": next_tag,
+              "tag_name": os.environ["NEXT_TAG"],
               "target_commitish": os.environ["GITHUB_SHA"],
-              "name": next_tag,
-              "body": notes_file.read_text(encoding="utf-8"),
+              "name": os.environ["NEXT_TAG"],
+              "body": Path(os.environ["RELEASE_NOTES_FILE"]).read_text(encoding="utf-8"),
               "draft": True,
               "prerelease": False
           }))
           PY
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input dist/create-release.json > dist/release-created.json
+            release_id="$(node -e "const release = require('./dist/release-created.json'); if (!Number.isInteger(release.id)) throw new Error('release creation response did not include a numeric id'); process.stdout.write(String(release.id));")"
+          elif [[ "${current_action}" != "resume-stage" || -z "${release_id}" ]]; then
+            echo "Expected a new or resumable draft transaction, found ${current_action}" >&2
+            exit 1
+          fi
 
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input dist/create-release.json > dist/release-created.json
-          release_id="$(python3 - <<'PY'
-          import json
-          import sys
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-before-asset.json
+          asset_count="$(EXPECTED_ASSET="${ASSET_NAME}" node -e "const release = require('./dist/release-before-asset.json'); const matches = (release.assets || []).filter((asset) => asset.name === process.env.EXPECTED_ASSET); process.stdout.write(String(matches.length));")"
+          if [[ "${asset_count}" == "0" ]]; then
+            curl --fail-with-body --silent --show-error --request POST \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "Content-Type: application/zip" \
+              --data-binary @"${ARCHIVE_PATH}" \
+              "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?name=${ASSET_NAME}&label=Press%20system%20update%20package" \
+              > dist/release-asset.json
+          elif [[ "${asset_count}" != "1" ]]; then
+            echo "Expected at most one ${ASSET_NAME} on draft ${release_id}, found ${asset_count}" >&2
+            exit 1
+          fi
 
-          with open("dist/release-created.json", "r", encoding="utf-8") as fh:
-              release = json.load(fh)
-
-          release_id = release.get("id")
-          if not isinstance(release_id, int):
-              sys.exit("release creation response did not include a numeric id")
-          print(release_id)
-          PY
-          )"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-draft.json
+          tag_commit="$(git rev-parse -q --verify "${NEXT_TAG}^{commit}" 2>/dev/null || true)"
+          node scripts/system-release-transaction.mjs create-receipt \
+            --repository "${GITHUB_REPOSITORY}" \
+            --source-commit "${GITHUB_SHA}" \
+            --release dist/release-draft.json \
+            --archive "${ARCHIVE_PATH}" \
+            --tag-commit "${tag_commit}" \
+            --out dist/release-candidate.json
           echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
-
-          curl --fail-with-body --silent --show-error --request POST \
-            --header "Authorization: Bearer ${GH_TOKEN}" \
-            --header "Accept: application/vnd.github+json" \
-            --header "Content-Type: application/zip" \
-            --data-binary @"${{ steps.package.outputs.archive_path }}" \
-            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?name=${asset_name}&label=Press%20system%20update%20package" \
-            > dist/release-asset.json
-
-      - name: Validate release asset
-        if: steps.plan.outputs.should_release == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
-          EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
-          EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" > dist/release.json
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          with open("dist/release.json", "r", encoding="utf-8") as fh:
-              release = json.load(fh)
-
-          expected_name = os.environ["EXPECTED_ASSET"]
-          expected_size = int(os.environ["EXPECTED_SIZE"])
-          expected_sha = os.environ["EXPECTED_SHA256"].lower()
-          assets = [asset for asset in release.get("assets", []) if asset.get("name") == expected_name]
-          if len(assets) != 1:
-              sys.exit(f"expected exactly one release asset named {expected_name}, found {len(assets)}")
-
-          asset = assets[0]
-          if int(asset.get("size") or 0) != expected_size:
-              sys.exit(f"asset size mismatch: expected {expected_size}, got {asset.get('size')}")
-
-          digest = str(asset.get("digest") or "").lower()
-          if digest and digest != f"sha256:{expected_sha}":
-              sys.exit(f"asset digest mismatch: expected sha256:{expected_sha}, got {digest}")
-          PY
 
       - name: Publish theme contract package
         if: steps.plan.outputs.should_release == 'true'
@@ -310,62 +327,140 @@ jobs:
             npm pack "@ekilyhq/press-theme-contract@${package_version}" --json --pack-destination "${published_pack_dir}" --registry=https://npm.pkg.github.com > dist/theme-contract-package-published.json
             published_tarball="$(node -e 'const fs = require("fs"); const path = require("path"); const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); console.log(path.join(process.argv[2], data[0].filename));' dist/theme-contract-package-published.json "${published_pack_dir}")"
             node scripts/compare-theme-contract-package.mjs "${built_tarball}" "${published_tarball}"
-            echo "@ekilyhq/press-theme-contract@${package_version} is already published and matches this build."
           else
             npm publish "${built_tarball}" --registry=https://npm.pkg.github.com
           fi
 
-      - name: Publish release
-        if: steps.plan.outputs.should_release == 'true'
+      - name: Stage candidate artifact
+        if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage')
         env:
-          GH_TOKEN: ${{ github.token }}
-          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY' > dist/publish-release.json
-          import json
-          import os
-
-          print(json.dumps({
-              "tag_name": os.environ["NEXT_TAG"],
-              "target_commitish": os.environ["GITHUB_SHA"],
-              "name": os.environ["NEXT_TAG"],
-              "draft": False,
-              "make_latest": "true"
-          }))
-          PY
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" --input dist/publish-release.json >/dev/null
-
-      - name: Publish fetchable artifact
-        if: steps.plan.outputs.should_release == 'true'
-        id: artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
-          EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
-          EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+          TAG: ${{ steps.plan.outputs.next_tag }}
+          ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
           ARCHIVE_PATH: ${{ steps.package.outputs.archive_path }}
         run: |
           set -euo pipefail
+          artifact_branch="release-artifacts"
+          artifact_path="${TAG}/${ASSET_NAME}"
+          receipt_path="${TAG}/release-candidate.json"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "${artifact_branch}"
+          rm -rf artifacts-worktree
+          git worktree add artifacts-worktree "origin/${artifact_branch}"
+          if [[ -e "artifacts-worktree/${artifact_path}" || -e "artifacts-worktree/${receipt_path}" ]]; then
+            echo "Candidate staging paths already exist; rerun so transaction inspection can validate them" >&2
+            exit 1
+          fi
+          mkdir -p "artifacts-worktree/${TAG}"
+          cp "${ARCHIVE_PATH}" "artifacts-worktree/${artifact_path}"
+          cp dist/release-candidate.json "artifacts-worktree/${receipt_path}"
+          git -C artifacts-worktree add "${artifact_path}" "${receipt_path}"
+          git -C artifacts-worktree commit -m "Stage ${ASSET_NAME}"
+          git -C artifacts-worktree push origin "HEAD:${artifact_branch}"
+          git worktree remove artifacts-worktree --force
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+
+      - name: Publish release
+        if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
           tag="${{ steps.plan.outputs.next_tag }}"
-          asset="${{ steps.plan.outputs.asset_name }}"
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          git fetch --force --tags origin
+          git show "origin/release-artifacts:${tag}/release-candidate.json" > dist/release-candidate.json
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-publish.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases dist/releases-before-publish.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/pre-publish-transaction.json
+          publish_action="$(node -e "const state = require('./dist/pre-publish-transaction.json'); process.stdout.write(state.action);")"
+          release_id="$(node -e "const state = require('./dist/pre-publish-transaction.json'); process.stdout.write(String(state.releaseId || ''));")"
+
+          if [[ "${publish_action}" == "resume-publish" ]]; then
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-before-publish.json
+            tag_commit="$(git rev-parse -q --verify "${tag}^{commit}" 2>/dev/null || true)"
+            node scripts/system-release-transaction.mjs verify-release \
+              --release dist/release-before-publish.json \
+              --receipt dist/release-candidate.json \
+              --expected-state draft \
+              --tag-commit "${tag_commit}"
+            printf '%s\n' '{"draft":false,"make_latest":"true"}' > dist/publish-release.json
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --input dist/publish-release.json >/dev/null
+          elif [[ "${publish_action}" != "resume-promote" ]]; then
+            echo "Expected staged draft or published candidate, found ${publish_action}" >&2
+            exit 1
+          fi
+
+          git fetch --force --tags origin
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-after-publish.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases dist/releases-after-publish.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/post-publish-transaction.json
+          post_action="$(node -e "const state = require('./dist/post-publish-transaction.json'); process.stdout.write(state.action);")"
+          if [[ "${post_action}" != "resume-promote" ]]; then
+            echo "Published candidate did not converge to resume-promote; found ${post_action}" >&2
+            exit 1
+          fi
+
+      - name: Promote latest release artifacts
+        if: (steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')) || steps.transaction.outputs.action == 'resume-promote'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.transaction.outputs.tag }}"
+          asset="${{ steps.transaction.outputs.asset_name }}"
+          if [[ -z "${tag}" || -z "${asset}" ]]; then
+            tag="${{ steps.plan.outputs.next_tag }}"
+            asset="${{ steps.plan.outputs.asset_name }}"
+          fi
           artifact_branch="release-artifacts"
           artifact_path="${tag}/${asset}"
-          manifest_path="system-release.json"
+          receipt_path="${tag}/release-candidate.json"
           immutable_manifest_path="${tag}/system-release.json"
-          release_intent_path="release-intent.json"
           immutable_release_intent_path="${tag}/release-intent.json"
-          product_state_path="product-state.json"
-          product_state_dashboard_path="product-state.html"
           artifact_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${artifact_path}"
           system_release_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${immutable_manifest_path}"
           release_intent_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${immutable_release_intent_path}"
-          latest_release_intent_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${release_intent_path}"
+          latest_release_intent_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/release-intent.json"
           export FETCHABLE_ASSET_URL="${artifact_url}"
           export RELEASE_INTENT_URL="${release_intent_url}"
           export LATEST_RELEASE_INTENT_URL="${latest_release_intent_url}"
 
-          gh api "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" > dist/release-published.json
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          git fetch --force --tags origin
+          git show "origin/release-artifacts:${receipt_path}" > dist/release-candidate.json
+          git show "origin/release-artifacts:${artifact_path}" > dist/staged-system-release.zip
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-promotion.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases dist/releases-before-promotion.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/pre-promotion-transaction.json
+          promotion_action="$(node -e "const state = require('./dist/pre-promotion-transaction.json'); process.stdout.write(state.action);")"
+          release_id="$(node -e "const state = require('./dist/pre-promotion-transaction.json'); process.stdout.write(String(state.releaseId || ''));")"
+          if [[ "${promotion_action}" != "resume-promote" ]]; then
+            echo "Expected resume-promote before latest promotion, found ${promotion_action}" >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-published.json
+          tag_commit="$(git rev-parse --verify "${tag}^{commit}")"
+          node scripts/system-release-transaction.mjs verify-release \
+            --release dist/release-published.json \
+            --receipt dist/release-candidate.json \
+            --expected-state published \
+            --tag-commit "${tag_commit}"
+
+          export ARCHIVE_PATH="dist/staged-system-release.zip"
+          export EXPECTED_ASSET="${asset}"
           python3 - <<'PY'
           import json
           import os
@@ -373,48 +468,35 @@ jobs:
           import zipfile
           from pathlib import Path
 
-          with open("dist/release-published.json", "r", encoding="utf-8") as fh:
-              release = json.load(fh)
-          with open("assets/press-system.json", "r", encoding="utf-8") as fh:
-              system = json.load(fh)
-
-          expected_name = os.environ["EXPECTED_ASSET"]
-          expected_size = int(os.environ["EXPECTED_SIZE"])
-          expected_sha = os.environ["EXPECTED_SHA256"].lower()
+          release = json.loads(Path("dist/release-published.json").read_text(encoding="utf-8"))
+          receipt = json.loads(Path("dist/release-candidate.json").read_text(encoding="utf-8"))
+          system = json.loads(Path("assets/press-system.json").read_text(encoding="utf-8"))
           version = str(system.get("version") or "").strip()
           tag = str(system.get("tag") or "").strip()
-          if not version or tag != f"v{version}" or tag != str(release.get("tag_name") or ""):
-              sys.exit("assets/press-system.json version must match the published release tag")
-          assets = [asset for asset in release.get("assets", []) if asset.get("name") == expected_name]
-          if len(assets) != 1:
-              sys.exit(f"expected exactly one release asset named {expected_name}, found {len(assets)}")
-
-          asset = assets[0]
-          digest = str(asset.get("digest") or "").lower() or f"sha256:{expected_sha}"
+          published_at = str(release.get("published_at") or "").strip()
+          if not published_at:
+              sys.exit("published GitHub Release is missing published_at")
+          if tag != f"v{version}" or tag != release.get("tag_name") or tag != receipt.get("tag"):
+              sys.exit("source manifest, candidate receipt, and GitHub Release tag must match")
+          asset = receipt["asset"]
           runtime_manifest_path = "assets/press-runtime-manifest.json"
-          runtime = {}
           with zipfile.ZipFile(os.environ["ARCHIVE_PATH"]) as archive:
-              runtime_name = f"press-system-{tag}/{runtime_manifest_path}"
-              try:
-                  runtime = json.loads(archive.read(runtime_name).decode("utf-8"))
-              except KeyError:
-                  sys.exit(f"release archive is missing {runtime_manifest_path}")
+              runtime = json.loads(archive.read(f"press-system-{tag}/{runtime_manifest_path}").decode("utf-8"))
           runtime_entries = runtime.get("entries") if isinstance(runtime.get("entries"), list) else []
           runtime_graph = runtime.get("graph") if isinstance(runtime.get("graph"), dict) else {}
           runtime_edges = runtime_graph.get("edges") if isinstance(runtime_graph.get("edges"), list) else []
-          expected_cache_key = f"press-system-{tag}"
           if runtime.get("schemaVersion") != 1 or runtime.get("type") != "press-runtime-assets":
               sys.exit("runtime manifest must use the press-runtime-assets schema")
-          if runtime.get("version") != version or runtime.get("tag") != tag or runtime.get("cacheKey") != expected_cache_key:
+          if runtime.get("version") != version or runtime.get("tag") != tag or runtime.get("cacheKey") != f"press-system-{tag}":
               sys.exit("runtime manifest version, tag, and cacheKey must match the release")
           if not runtime_entries or not runtime_edges:
               sys.exit("runtime manifest must include file inventory and asset graph edges")
           manifest = {
               "schemaVersion": 1,
-              "name": release.get("name") or release.get("tag_name") or "",
-              "tag": release.get("tag_name") or "",
+              "name": release.get("name") or tag,
+              "tag": tag,
               "version": version,
-              "publishedAt": release.get("published_at") or release.get("created_at") or "",
+              "publishedAt": published_at,
               "notes": release.get("body") or "",
               "upgradeFrom": system.get("upgradeFrom") or {},
               "themeContractUpgrade": system.get("themeContractUpgrade") or {},
@@ -429,10 +511,10 @@ jobs:
               },
               "htmlUrl": release.get("html_url") or "",
               "asset": {
-                  "name": asset.get("name") or expected_name,
+                  "name": asset["name"],
                   "url": os.environ["FETCHABLE_ASSET_URL"],
-                  "size": int(asset.get("size") or expected_size),
-                  "digest": digest
+                  "size": asset["size"],
+                  "digest": asset["digest"]
               },
               "intent": {
                   "type": "press-release-intent",
@@ -442,10 +524,7 @@ jobs:
                   "latestUrl": os.environ["LATEST_RELEASE_INTENT_URL"]
               }
           }
-          Path("dist/system-release.json").write_text(
-              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
-              encoding="utf-8"
-          )
+          Path("dist/system-release.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
           PY
           node scripts/release-intent.js \
             --system-release dist/system-release.json \
@@ -468,44 +547,109 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${artifact_branch}" || true
+          git fetch origin "${artifact_branch}"
           rm -rf artifacts-worktree
-          if git show-ref --verify --quiet "refs/remotes/origin/${artifact_branch}"; then
-            git worktree add artifacts-worktree "origin/${artifact_branch}"
-          else
-            git worktree add --detach artifacts-worktree
-            git -C artifacts-worktree checkout --orphan "${artifact_branch}"
-            git -C artifacts-worktree rm -rf . >/dev/null 2>&1 || true
+          git worktree add artifacts-worktree "origin/${artifact_branch}"
+          current_root_tag="$(node -e "const manifest = require('./artifacts-worktree/system-release.json'); process.stdout.write(String(manifest.tag || ''));")"
+          expected_root_tag="${{ steps.transaction.outputs.root_tag }}"
+          if [[ "${current_root_tag}" != "${expected_root_tag}" ]]; then
+            echo "release-artifacts latest moved from ${expected_root_tag} to ${current_root_tag}; refusing promotion" >&2
+            exit 1
           fi
-
-          mkdir -p "artifacts-worktree/${tag}"
-          cp "${{ steps.package.outputs.archive_path }}" "artifacts-worktree/${artifact_path}"
-          cp dist/system-release.json "artifacts-worktree/${manifest_path}"
+          if [[ -e "artifacts-worktree/${immutable_manifest_path}" || -e "artifacts-worktree/${immutable_release_intent_path}" ]]; then
+            echo "Final immutable manifests already exist before promotion; rerun for transaction inspection" >&2
+            exit 1
+          fi
           cp dist/system-release.json "artifacts-worktree/${immutable_manifest_path}"
           cp dist/release-intent.json "artifacts-worktree/${immutable_release_intent_path}"
-          cp dist/release-intent.json "artifacts-worktree/${release_intent_path}"
-          cp dist/product-state.json "artifacts-worktree/${product_state_path}"
-          cp dist/product-state.html "artifacts-worktree/${product_state_dashboard_path}"
-          git -C artifacts-worktree add "${artifact_path}" "${manifest_path}" "${immutable_manifest_path}" "${immutable_release_intent_path}" "${release_intent_path}" "${product_state_path}" "${product_state_dashboard_path}"
-          if git -C artifacts-worktree diff --cached --quiet; then
-            echo "Artifact ${artifact_path}, ${manifest_path}, release intent, ${product_state_path}, and ${product_state_dashboard_path} are already published."
-          else
-            git -C artifacts-worktree commit -m "Publish ${asset}"
-            git -C artifacts-worktree push origin "HEAD:${artifact_branch}"
+          cp dist/system-release.json artifacts-worktree/system-release.json
+          cp dist/release-intent.json artifacts-worktree/release-intent.json
+          cp dist/product-state.json artifacts-worktree/product-state.json
+          cp dist/product-state.html artifacts-worktree/product-state.html
+          git -C artifacts-worktree add \
+            "${immutable_manifest_path}" \
+            "${immutable_release_intent_path}" \
+            system-release.json \
+            release-intent.json \
+            product-state.json \
+            product-state.html
+          git -C artifacts-worktree commit -m "Promote ${asset}"
+          promotion_commit="$(git -C artifacts-worktree rev-parse HEAD)"
+
+          git fetch --force --tags origin
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-artifact-push.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref "${promotion_commit}" \
+            --releases dist/releases-before-artifact-push.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/pre-push-transaction.json
+          pre_push_action="$(node -e "const state = require('./dist/pre-push-transaction.json'); process.stdout.write(state.action);")"
+          if [[ "${pre_push_action}" != "dispatch" ]]; then
+            echo "Local promotion candidate did not converge to dispatch; found ${pre_push_action}" >&2
+            exit 1
           fi
+          node scripts/release-graph.js \
+            --mode audit \
+            --artifact-ref "${promotion_commit}" \
+            --github-releases dist/releases-before-artifact-push.json \
+            --check
+
+          tag_ref_oid="$(git rev-parse "refs/tags/${tag}")"
+          git -C artifacts-worktree push \
+            --atomic \
+            --force-with-lease="refs/tags/${tag}:${tag_ref_oid}" \
+            origin \
+            "HEAD:${artifact_branch}" \
+            "refs/tags/${tag}:refs/tags/${tag}"
           git worktree remove artifacts-worktree --force
-          echo "url=${artifact_url}" >> "${GITHUB_OUTPUT}"
+
+          git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
+          git fetch --force --tags origin
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-after-promotion.json
+          node scripts/system-release-transaction.mjs inspect \
+            --artifact-ref origin/release-artifacts \
+            --releases dist/releases-after-promotion.json \
+            --source-commit "${GITHUB_SHA}" \
+            --repository "${GITHUB_REPOSITORY}" \
+            > dist/post-promotion-transaction.json
+          post_action="$(node -e "const state = require('./dist/post-promotion-transaction.json'); process.stdout.write(state.action);")"
+          if [[ "${post_action}" != "dispatch" ]]; then
+            echo "Promoted transaction did not converge to dispatch; found ${post_action}" >&2
+            exit 1
+          fi
+          node scripts/release-graph.js \
+            --mode audit \
+            --artifact-ref origin/release-artifacts \
+            --github-releases dist/releases-after-promotion.json \
+            --check
+
+      - name: Prepare release dispatch
+        if: (steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')) || steps.transaction.outputs.action == 'resume-promote' || steps.transaction.outputs.action == 'dispatch'
+        id: dispatch_state
+        env:
+          TAG: ${{ steps.transaction.outputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${TAG:-${{ steps.plan.outputs.next_tag }}}"
+          if [[ ! -f dist/system-release.json ]]; then
+            git show "origin/release-artifacts:${tag}/system-release.json" > dist/system-release.json
+          fi
+          if [[ ! -f dist/release-intent.json ]]; then
+            git show "origin/release-artifacts:${tag}/release-intent.json" > dist/release-intent.json
+          fi
+          SYSTEM_RELEASE_PATH=dist/system-release.json node -e "const release = require('./' + process.env.SYSTEM_RELEASE_PATH); const digest = String(release.asset && release.asset.digest || '').replace(/^sha256:/, ''); if (!release.tag || !release.asset || !release.asset.name || !release.asset.size || !/^[0-9a-f]{64}$/.test(digest)) throw new Error('final system release manifest has incomplete dispatch metadata'); console.log('tag=' + release.tag); console.log('asset_name=' + release.asset.name); console.log('asset_size=' + release.asset.size); console.log('asset_sha256=' + digest);" >> "${GITHUB_OUTPUT}"
 
       - name: Dispatch release targets
-        if: steps.plan.outputs.should_release == 'true'
+        if: (steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')) || steps.transaction.outputs.action == 'resume-promote' || steps.transaction.outputs.action == 'dispatch'
         env:
           EKILY_RELEASE_APP_ID: ${{ vars.EKILY_RELEASE_APP_ID }}
           EKILY_RELEASE_PRIVATE_KEY: ${{ secrets.EKILY_RELEASE_PRIVATE_KEY }}
           RELEASE_DISPATCH_TARGETS: ${{ vars.RELEASE_DISPATCH_TARGETS }}
-          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
-          ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
-          ASSET_SIZE: ${{ steps.package.outputs.archive_size }}
-          ASSET_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+          NEXT_TAG: ${{ steps.dispatch_state.outputs.tag }}
+          ASSET_NAME: ${{ steps.dispatch_state.outputs.asset_name }}
+          ASSET_SIZE: ${{ steps.dispatch_state.outputs.asset_size }}
+          ASSET_SHA256: ${{ steps.dispatch_state.outputs.asset_sha256 }}
           PRESS_RELEASE_INTENT_JSON: dist/release-intent.json
         run: |
           set -euo pipefail

--- a/scripts/package-system-release.sh
+++ b/scripts/package-system-release.sh
@@ -18,6 +18,7 @@ mkdir -p "${output_dir}"
 output_dir="$(cd "${output_dir}" && pwd)"
 archive_path="${output_dir}/${archive_name}"
 cd "${repo_root}"
+rm -f "${archive_path}"
 
 tmp_dir="$(mktemp -d)"
 cleanup() {
@@ -81,9 +82,18 @@ fi
 
 node scripts/sync-runtime-cache-keys.mjs --materialize-root "${payload_dir}" --tag "${version}" >&2
 
+if [[ -n "$(find "${payload_dir}" -type l -print -quit)" ]]; then
+  echo "Press system package must not contain symbolic links" >&2
+  exit 1
+fi
+while IFS= read -r -d '' payload_path; do
+  touch -t 198001010000 "${payload_path}"
+done < <(find "${payload_dir}" -print0)
+
 (
   cd "${tmp_dir}"
-  zip -qr "${archive_path}" "${prefix%/}"
+  LC_ALL=C find "${prefix%/}" -type f -print | LC_ALL=C sort > "${tmp_dir}/zip-files.txt"
+  TZ=UTC zip -q -X "${archive_path}" -@ < "${tmp_dir}/zip-files.txt"
 )
 
 printf '%s\n' "${archive_path}"

--- a/scripts/release-graph-policy.json
+++ b/scripts/release-graph-policy.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "type": "press-release-graph-policy",
+  "repository": "EkilyHQ/Press",
+  "support": {
+    "floor": "3.4.64",
+    "sourceRanges": [
+      ">=3.4.64"
+    ],
+    "updateStrategy": "latest-only"
+  },
+  "candidateGate": {
+    "mode": "recovery-required",
+    "baselineVersion": "3.4.133",
+    "reason": "The current latest-only updater cannot move every supported published source directly to v3.4.133.",
+    "removalCondition": "Publish a recovery transition whose upgradeFrom ranges directly admit every declared supported published source, then change this mode to direct."
+  },
+  "legacyExceptions": [
+    {
+      "id": "v3.4.108-missing-predecessor",
+      "from": "3.4.64",
+      "to": "3.4.108",
+      "status": "recovery-required",
+      "unpublishedRange": ">3.4.64 <3.4.108",
+      "targetRanges": [
+        ">=3.4.107 <3.4.108"
+      ],
+      "missingSources": [
+        "3.4.107"
+      ],
+      "reason": "v3.4.108 requires v3.4.107, but releases v3.4.65 through v3.4.107 were never published.",
+      "removalCondition": "After a recovery transition restores a direct path from the support floor, set status to recovered and record recoveredByVersion while retaining this immutable history."
+    }
+  ],
+  "artifactLayout": {
+    "systemRelease": "v{version}/system-release.json",
+    "releaseIntent": "v{version}/release-intent.json",
+    "asset": "v{version}/press-system-v{version}.zip",
+    "rawRoot": "https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts"
+  }
+}

--- a/scripts/release-graph.js
+++ b/scripts/release-graph.js
@@ -394,8 +394,8 @@ function validatePublishedRelease(release, policy, artifactPaths, githubReleases
   if (!githubRelease) {
     failures.push(`${label} is missing a matching GitHub Release object`);
   } else {
-    if (githubRelease.draft === true || githubRelease.prerelease === true) {
-      failures.push(`${label} GitHub Release must be published and non-prerelease`);
+    if (githubRelease.draft === true || githubRelease.prerelease === true || githubRelease.immutable !== true) {
+      failures.push(`${label} GitHub Release must be published, non-prerelease, and immutable`);
     }
     const releaseAssets = Array.isArray(githubRelease.assets) ? githubRelease.assets : [];
     const matchingAssets = releaseAssets.filter((entry) => String(entry && entry.name || '') === expected.assetName);
@@ -570,8 +570,17 @@ function analyzeReleaseGraph(input = {}) {
   const gitTags = input.gitTags instanceof Set ? input.gitTags : new Set(input.gitTags || []);
   const githubReleases = input.githubReleases instanceof Map ? input.githubReleases : new Map();
   const candidate = input.candidate;
+  const worktreeCandidateVersion = normalizeSemver(candidate && candidate.version);
+  const transientCandidateVersionInput = String(input.transientCandidateVersion || '').trim();
+  const transientCandidateVersion = normalizeSemver(transientCandidateVersionInput);
+  const effectiveGitTags = new Set(gitTags);
   const failures = validatePolicy(policy);
   if (failures.length) return { failures, publishedVersions: [], supportedSources: [], directMissing: [] };
+  if (transientCandidateVersionInput && !transientCandidateVersion) {
+    failures.push('transientCandidateVersion must be an exact semantic version');
+  } else if (transientCandidateVersion) {
+    effectiveGitTags.delete(semverToTag(transientCandidateVersion));
+  }
 
   const requestedMode = String(input.validationMode || 'audit').trim();
   if (!['audit', 'auto', 'candidate'].includes(requestedMode)) {
@@ -610,6 +619,18 @@ function analyzeReleaseGraph(input = {}) {
   });
   const latestPublishedVersion = publishedVersions[publishedVersions.length - 1];
   const latestPublishedRelease = publishedByVersion.get(latestPublishedVersion);
+  if (transientCandidateVersion) {
+    if (transientCandidateVersion !== worktreeCandidateVersion) {
+      failures.push('transientCandidateVersion must match the worktree candidate');
+    }
+    if (publishedByVersion.has(transientCandidateVersion)) {
+      failures.push(`transient candidate v${transientCandidateVersion} already has finalized immutable manifests`);
+    }
+    const transientRelease = githubReleases.get(semverToTag(transientCandidateVersion));
+    if (!transientRelease || transientRelease.prerelease === true) {
+      failures.push(`transient candidate v${transientCandidateVersion} must have one non-prerelease GitHub Release object`);
+    }
+  }
   if (!artifactPaths.has('system-release.json') || !String(input.latestSystemReleaseText || '')) {
     failures.push('release artifact registry is missing latest system-release.json');
   } else if (input.latestSystemReleaseText !== latestPublishedRelease.manifestText) {
@@ -671,7 +692,7 @@ function analyzeReleaseGraph(input = {}) {
       failures.push(`legacy exception ${exception.id} targetRanges do not match v${target} upgradeFrom`);
     }
     const unexpectedPublished = publishedVersions.filter((version) => satisfiesSemverRange(version, exception.unpublishedRange));
-    const unexpectedTags = [...gitTags].map(normalizeSemver).filter((version) => version
+    const unexpectedTags = [...effectiveGitTags].map(normalizeSemver).filter((version) => version
       && satisfiesSemverRange(version, exception.unpublishedRange));
     if (unexpectedPublished.length || unexpectedTags.length) {
       failures.push(`legacy exception ${exception.id} unpublishedRange contains a published tag or artifact`);
@@ -708,7 +729,6 @@ function analyzeReleaseGraph(input = {}) {
         failures.push(`published source v${sourceVersion} cannot reach published latest v${latestPublishedVersion}`);
       }
     });
-  const worktreeCandidateVersion = normalizeSemver(candidate && candidate.version);
   policy.legacyExceptions.forEach((exception) => {
     const from = normalizeSemver(exception.from);
     const reachesLatest = canReachPublishedLatest(from);
@@ -752,7 +772,7 @@ function analyzeReleaseGraph(input = {}) {
     if (!candidateVersion || compareSemver(candidateVersion, latestPublishedVersion) <= 0) {
       failures.push(`release candidate must be newer than published latest v${latestPublishedVersion}`);
     }
-    if (candidateVersion && gitTags.has(semverToTag(candidateVersion))) {
+    if (candidateVersion && effectiveGitTags.has(semverToTag(candidateVersion))) {
       failures.push(`release candidate tag ${semverToTag(candidateVersion)} already exists`);
     }
     failures.push(...validateCandidateArchive(candidate, input.candidateArchive));
@@ -835,8 +855,13 @@ function parseJsonBlob(text, label) {
 function loadPublishedReleaseRegistry(options = {}) {
   const policy = options.policy;
   const artifactRef = String(options.artifactRef || '').trim();
+  const transientCandidateVersionInput = String(options.transientCandidateVersion || '').trim();
+  const transientCandidateVersion = normalizeSemver(transientCandidateVersionInput);
   const cwd = options.cwd || process.cwd();
   if (!artifactRef) throw new Error('release artifact ref is required');
+  if (transientCandidateVersionInput && !transientCandidateVersion) {
+    throw new Error('transient candidate version must be an exact semantic version');
+  }
   try {
     gitOutput(['rev-parse', '--verify', artifactRef], { cwd });
   } catch (error) {
@@ -854,11 +879,23 @@ function loadPublishedReleaseRegistry(options = {}) {
     .split(/\r?\n/u)
     .map((value) => value.trim())
     .filter((value) => /^v\d+\.\d+\.\d+$/u.test(value)));
+  let transientCandidateFinalized = false;
+  if (transientCandidateVersion) {
+    const expected = expectedTargetMetadata(policy, transientCandidateVersion);
+    const hasManifest = artifactPaths.has(expected.systemReleasePath);
+    const hasIntent = artifactPaths.has(expected.releaseIntentPath);
+    if (hasManifest !== hasIntent) {
+      throw new Error(`transient candidate v${transientCandidateVersion} has a partial immutable manifest tuple`);
+    }
+    transientCandidateFinalized = hasManifest && hasIntent;
+    if (!transientCandidateFinalized) gitTags.delete(expected.tag);
+  }
   const floor = normalizeSemver(policy.support.floor);
   const versions = new Set();
   artifactPaths.forEach((artifactPath) => {
     const match = artifactPath.match(/^v(\d+\.\d+\.\d+)\//u);
     const version = normalizeSemver(match && match[1]);
+    if (version === transientCandidateVersion && !transientCandidateFinalized) return;
     if (version && compareSemver(version, floor) >= 0) versions.add(version);
   });
   gitTags.forEach((tag) => {
@@ -900,6 +937,7 @@ function loadPublishedReleaseRegistry(options = {}) {
     artifactRef,
     artifactPaths,
     gitTags,
+    transientCandidateFinalized,
     latestReleaseIntentText,
     latestSystemReleaseText,
     publishedReleases
@@ -918,6 +956,7 @@ function loadGitHubReleaseRegistry(file) {
     releases.set(tag, {
       draft: entry.draft === true,
       prerelease: entry.prerelease === true,
+      immutable: entry.immutable === true,
       assets: Array.isArray(entry.assets) ? entry.assets : []
     });
   });
@@ -966,6 +1005,7 @@ function parseArgs(argv) {
     artifactRef: 'origin/release-artifacts',
     githubReleasesPath: '',
     candidateArchivePath: '',
+    transientCandidateVersion: '',
     validationMode: 'audit',
     quiet: false,
     help: false
@@ -977,6 +1017,7 @@ function parseArgs(argv) {
     else if (arg === '--artifact-ref') options.artifactRef = argv[++index] || '';
     else if (arg === '--github-releases') options.githubReleasesPath = argv[++index] || '';
     else if (arg === '--candidate-archive') options.candidateArchivePath = argv[++index] || '';
+    else if (arg === '--transient-candidate-version') options.transientCandidateVersion = argv[++index] || '';
     else if (arg === '--mode') options.validationMode = argv[++index] || '';
     else if (arg === '--quiet') options.quiet = true;
     else if (arg === '--check') continue;
@@ -996,6 +1037,7 @@ function printHelp() {
     '  --artifact-ref <ref>  Git ref containing published release artifacts',
     '  --github-releases <path>  Paginated GitHub Releases API JSON (required)',
     '  --candidate-archive <path>  Built candidate ZIP required in candidate mode',
+    '  --transient-candidate-version <version>  Exclude one non-finalized candidate transaction',
     '  --mode <mode>          audit, auto, or candidate (default: audit)',
     '  --check               Validate and exit non-zero on failure',
     '  --quiet               Suppress the success summary'
@@ -1018,12 +1060,16 @@ function main(argv = process.argv.slice(2)) {
   const registry = loadPublishedReleaseRegistry({
     policy,
     artifactRef: options.artifactRef,
+    transientCandidateVersion: options.transientCandidateVersion,
     cwd: process.cwd()
   });
   const result = analyzeReleaseGraph({
     policy,
     candidate,
     candidateArchive,
+    transientCandidateVersion: registry.transientCandidateFinalized
+      ? ''
+      : options.transientCandidateVersion,
     validationMode: options.validationMode,
     publishedReleases: registry.publishedReleases,
     artifactPaths: registry.artifactPaths,

--- a/scripts/release-graph.js
+++ b/scripts/release-graph.js
@@ -1,0 +1,1073 @@
+#!/usr/bin/env node
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { isDeepStrictEqual } = require('node:util');
+
+const POLICY_TYPE = 'press-release-graph-policy';
+const RELEASE_INTENT_TYPE = 'press-release-intent';
+const SYSTEM_RELEASE_TYPE = 'press-system';
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+function normalizeSemver(value) {
+  const raw = String(value || '').trim();
+  const match = raw.match(/^v?(\d+)\.(\d+)\.(\d+)$/iu);
+  if (!match) return '';
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+}
+
+function semverToTag(value) {
+  const version = normalizeSemver(value);
+  return version ? `v${version}` : '';
+}
+
+function compareSemver(leftValue, rightValue) {
+  const left = normalizeSemver(leftValue);
+  const right = normalizeSemver(rightValue);
+  if (!left || !right) return null;
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] === rightParts[index]) continue;
+    return leftParts[index] > rightParts[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+function testComparator(version, token) {
+  const raw = String(token || '').trim();
+  if (raw === '*') return true;
+  const match = raw.match(/^(>=|<=|>|<|=)?\s*(v?\d+\.\d+\.\d+)$/iu);
+  if (!match) return false;
+  const comparison = compareSemver(version, match[2]);
+  if (comparison === null) return false;
+  const operator = match[1] || '=';
+  if (operator === '>') return comparison > 0;
+  if (operator === '>=') return comparison >= 0;
+  if (operator === '<') return comparison < 0;
+  if (operator === '<=') return comparison <= 0;
+  return comparison === 0;
+}
+
+function isValidSemverRange(range) {
+  const clauses = String(range || '').split('||').map((part) => part.trim()).filter(Boolean);
+  if (!clauses.length) return false;
+  return clauses.every((clause) => {
+    const tokens = clause.split(/\s+/u).filter(Boolean);
+    return tokens.length > 0 && tokens.every((token) => token === '*'
+      || /^(>=|<=|>|<|=)?\s*v?\d+\.\d+\.\d+$/iu.test(token));
+  });
+}
+
+function satisfiesSemverRange(version, range) {
+  const normalizedVersion = normalizeSemver(version);
+  if (!normalizedVersion || !isValidSemverRange(range)) return false;
+  return String(range).split('||').map((part) => part.trim()).filter(Boolean).some((clause) => {
+    const tokens = clause.split(/\s+/u).filter(Boolean);
+    return tokens.every((token) => testComparator(normalizedVersion, token));
+  });
+}
+
+function semverParts(value) {
+  const version = normalizeSemver(value);
+  return version ? version.split('.').map(Number) : null;
+}
+
+function compareParts(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] === right[index]) continue;
+    return left[index] > right[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+function nextPatch(parts) {
+  return [parts[0], parts[1], parts[2] + 1];
+}
+
+function rangeIntervals(range) {
+  if (!isValidSemverRange(range)) return [];
+  return String(range).split('||').map((clause) => {
+    let lower = [0, 0, 0];
+    let upper = null;
+    clause.trim().split(/\s+/u).filter(Boolean).forEach((token) => {
+      if (token === '*') return;
+      const match = token.match(/^(>=|<=|>|<|=)?\s*(v?\d+\.\d+\.\d+)$/iu);
+      const operator = match[1] || '=';
+      const version = semverParts(match[2]);
+      if (operator === '>=' && compareParts(version, lower) > 0) lower = version;
+      else if (operator === '>' && compareParts(nextPatch(version), lower) > 0) lower = nextPatch(version);
+      else if (operator === '<' && (!upper || compareParts(version, upper) < 0)) upper = version;
+      else if (operator === '<=' && (!upper || compareParts(nextPatch(version), upper) < 0)) upper = nextPatch(version);
+      else if (operator === '=') {
+        if (compareParts(version, lower) > 0) lower = version;
+        if (!upper || compareParts(nextPatch(version), upper) < 0) upper = nextPatch(version);
+      }
+    });
+    return { lower, upper, empty: Boolean(upper && compareParts(lower, upper) >= 0) };
+  });
+}
+
+function intervalIsCovered(candidateInterval, supportIntervals) {
+  if (candidateInterval.empty || !candidateInterval.upper) return false;
+  const intervals = supportIntervals.filter((interval) => !interval.empty)
+    .sort((left, right) => compareParts(left.lower, right.lower));
+  let cursor = candidateInterval.lower;
+  for (const interval of intervals) {
+    if (interval.upper && compareParts(interval.upper, cursor) <= 0) continue;
+    if (compareParts(interval.lower, cursor) > 0) return false;
+    if (!interval.upper || compareParts(interval.upper, candidateInterval.upper) >= 0) return true;
+    if (compareParts(interval.upper, cursor) > 0) cursor = interval.upper;
+  }
+  return false;
+}
+
+function normalizeUpgradeFrom(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    ranges: Array.isArray(source.ranges) ? source.ranges.map((range) => String(range || '').trim()) : [],
+    allowUnknownSource: source.allowUnknownSource === true,
+    message: String(source.message || '').trim()
+  };
+}
+
+function normalizeAsset(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    name: String(source.name || '').trim(),
+    url: String(source.url || '').trim(),
+    size: Number(source.size || 0),
+    digest: String(source.digest || '').trim().toLowerCase()
+  };
+}
+
+function normalizeRuntime(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    manifestPath: String(source.manifestPath || '').trim(),
+    type: String(source.type || '').trim(),
+    strategy: String(source.strategy || '').trim(),
+    cacheKey: String(source.cacheKey || '').trim(),
+    entryCount: Number(source.entryCount || 0),
+    edgeCount: Number(source.edgeCount || 0)
+  };
+}
+
+function sha256(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+function jsonMatches(left, right) {
+  return isDeepStrictEqual(left || {}, right || {});
+}
+
+function renderArtifactPath(template, version) {
+  return String(template || '').replaceAll('{version}', normalizeSemver(version));
+}
+
+function expectedTargetMetadata(policy, versionValue) {
+  const version = normalizeSemver(versionValue);
+  const layout = policy && policy.artifactLayout && typeof policy.artifactLayout === 'object'
+    ? policy.artifactLayout
+    : {};
+  const rawRoot = String(layout.rawRoot || '').replace(/\/+$/u, '');
+  const systemReleasePath = renderArtifactPath(layout.systemRelease, version);
+  const releaseIntentPath = renderArtifactPath(layout.releaseIntent, version);
+  const assetPath = renderArtifactPath(layout.asset, version);
+  return {
+    version,
+    tag: semverToTag(version),
+    systemReleasePath,
+    systemReleaseUrl: systemReleasePath ? `${rawRoot}/${systemReleasePath}` : '',
+    releaseIntentPath,
+    releaseIntentUrl: releaseIntentPath ? `${rawRoot}/${releaseIntentPath}` : '',
+    assetPath,
+    assetName: path.posix.basename(assetPath),
+    assetUrl: assetPath ? `${rawRoot}/${assetPath}` : '',
+    latestReleaseIntentUrl: rawRoot ? `${rawRoot}/release-intent.json` : ''
+  };
+}
+
+function validatePolicy(policy) {
+  const failures = [];
+  if (!policy || typeof policy !== 'object') return ['release graph policy must be a JSON object'];
+  if (policy.schemaVersion !== 1) failures.push('release graph policy schemaVersion must be 1');
+  if (policy.type !== POLICY_TYPE) failures.push(`release graph policy type must be ${POLICY_TYPE}`);
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(String(policy.repository || ''))) {
+    failures.push('release graph policy repository must be an owner/name pair');
+  }
+  const support = policy.support && typeof policy.support === 'object' ? policy.support : {};
+  const floor = normalizeSemver(support.floor);
+  if (!floor) failures.push('release graph policy support.floor must be an exact semantic version');
+  if (support.updateStrategy !== 'latest-only') {
+    failures.push('release graph policy support.updateStrategy must be latest-only');
+  }
+  const sourceRanges = Array.isArray(support.sourceRanges) ? support.sourceRanges : [];
+  if (!sourceRanges.length || sourceRanges.some((range) => !isValidSemverRange(range))) {
+    failures.push('release graph policy support.sourceRanges must contain valid semantic-version ranges');
+  } else if (floor && !sourceRanges.some((range) => satisfiesSemverRange(floor, range))) {
+    failures.push(`release graph support floor ${floor} must be included in support.sourceRanges`);
+  }
+
+  const gate = policy.candidateGate && typeof policy.candidateGate === 'object' ? policy.candidateGate : {};
+  if (!['direct', 'recovery-required'].includes(gate.mode)) {
+    failures.push('release graph policy candidateGate.mode must be direct or recovery-required');
+  }
+  if (!normalizeSemver(gate.baselineVersion)) {
+    failures.push('release graph policy candidateGate.baselineVersion must be an exact semantic version');
+  }
+  if (!String(gate.reason || '').trim() || !String(gate.removalCondition || '').trim()) {
+    failures.push('release graph policy candidateGate must declare a reason and removalCondition');
+  }
+
+  const layout = policy.artifactLayout && typeof policy.artifactLayout === 'object'
+    ? policy.artifactLayout
+    : {};
+  ['systemRelease', 'releaseIntent', 'asset'].forEach((key) => {
+    if (!String(layout[key] || '').includes('{version}')) {
+      failures.push(`release graph policy artifactLayout.${key} must include {version}`);
+    }
+  });
+  const expectedRawRoot = policy.repository
+    ? `https://raw.githubusercontent.com/${policy.repository}/release-artifacts`
+    : '';
+  if (String(layout.rawRoot || '').replace(/\/+$/u, '') !== expectedRawRoot) {
+    failures.push(`release graph policy artifactLayout.rawRoot must be ${expectedRawRoot}`);
+  }
+
+  const exceptions = Array.isArray(policy.legacyExceptions) ? policy.legacyExceptions : [];
+  const ids = new Set();
+  const targets = new Set();
+  exceptions.forEach((exception, index) => {
+    const prefix = `release graph legacyExceptions[${index}]`;
+    const id = String(exception && exception.id || '').trim();
+    const from = normalizeSemver(exception && exception.from);
+    const target = normalizeSemver(exception && exception.to);
+    const unpublishedRange = String(exception && exception.unpublishedRange || '').trim();
+    const targetRanges = exception && Array.isArray(exception.targetRanges)
+      ? exception.targetRanges.map((range) => String(range || '').trim())
+      : [];
+    const missingSources = exception && Array.isArray(exception.missingSources)
+      ? exception.missingSources.map(normalizeSemver)
+      : [];
+    if (!id || ids.has(id)) failures.push(`${prefix}.id must be unique and non-empty`);
+    if (!from || !target || compareSemver(from, target) >= 0 || targets.has(target)) {
+      failures.push(`${prefix}.from and .to must be ordered unique exact versions`);
+    }
+    if (!exception || !['recovered', 'recovery-required'].includes(exception.status)) {
+      failures.push(`${prefix}.status must be recovered or recovery-required`);
+    }
+    const recoveredByVersion = normalizeSemver(exception && exception.recoveredByVersion);
+    if (exception && exception.status === 'recovered'
+      && (!recoveredByVersion || compareSemver(recoveredByVersion, target) <= 0)) {
+      failures.push(`${prefix}.recoveredByVersion must be newer than .to when status is recovered`);
+    }
+    if (exception && exception.status === 'recovery-required' && recoveredByVersion) {
+      failures.push(`${prefix}.recoveredByVersion is only valid when status is recovered`);
+    }
+    if (exception && exception.status === 'recovered' && gate.mode !== 'direct') {
+      failures.push(`${prefix}.status recovered requires candidateGate.mode direct`);
+    }
+    if (!missingSources.length || missingSources.some((source) => !source)) {
+      failures.push(`${prefix}.missingSources must contain exact semantic versions`);
+    }
+    if (!isValidSemverRange(unpublishedRange)
+      || !targetRanges.length
+      || targetRanges.some((range) => !isValidSemverRange(range))) {
+      failures.push(`${prefix} must declare valid unpublishedRange and targetRanges`);
+    }
+    if (!String(exception && exception.reason || '').trim()
+      || !String(exception && exception.removalCondition || '').trim()) {
+      failures.push(`${prefix} must declare a reason and removalCondition`);
+    }
+    ids.add(id);
+    targets.add(target);
+  });
+  return failures;
+}
+
+function validateUpgradeFrom(upgradeFrom, targetVersion, label) {
+  const failures = [];
+  const normalized = normalizeUpgradeFrom(upgradeFrom);
+  if (!normalized.ranges.length) failures.push(`${label} upgradeFrom.ranges must not be empty`);
+  normalized.ranges.forEach((range) => {
+    if (!isValidSemverRange(range)) failures.push(`${label} has invalid upgradeFrom range: ${range || '(empty)'}`);
+    if (satisfiesSemverRange(targetVersion, range)) {
+      failures.push(`${label} upgradeFrom range must not accept its own target version: ${range}`);
+    }
+    const targetParts = semverParts(targetVersion);
+    rangeIntervals(range).forEach((interval) => {
+      if (interval.empty) failures.push(`${label} has an unsatisfiable upgradeFrom clause: ${range}`);
+      else if (!interval.upper || compareParts(interval.upper, targetParts) > 0) {
+        failures.push(`${label} upgradeFrom range must not accept target or future versions: ${range}`);
+      }
+    });
+  });
+  if (!upgradeFrom || typeof upgradeFrom.allowUnknownSource !== 'boolean') {
+    failures.push(`${label} upgradeFrom.allowUnknownSource must be a boolean`);
+  }
+  return failures;
+}
+
+function validateDirectCandidateDomain(candidate, policy) {
+  const failures = [];
+  const candidateRanges = normalizeUpgradeFrom(candidate && candidate.upgradeFrom).ranges;
+  const supportIntervals = policy.support.sourceRanges.flatMap(rangeIntervals);
+  candidateRanges.flatMap(rangeIntervals).forEach((interval) => {
+    if (!intervalIsCovered(interval, supportIntervals)) {
+      failures.push(`candidate v${normalizeSemver(candidate && candidate.version)} upgradeFrom admits versions outside policy support.sourceRanges`);
+    }
+  });
+  return failures;
+}
+
+function validatePublishedRelease(release, policy, artifactPaths, githubReleases) {
+  const failures = [];
+  const manifest = release && release.manifest && typeof release.manifest === 'object'
+    ? release.manifest
+    : null;
+  const intent = release && release.intent && typeof release.intent === 'object'
+    ? release.intent
+    : null;
+  const sourceManifest = release && release.sourceManifest && typeof release.sourceManifest === 'object'
+    ? release.sourceManifest
+    : null;
+  const version = normalizeSemver(manifest && manifest.version || release && release.version);
+  const label = version ? `published release v${version}` : 'published release with unknown version';
+  if (!manifest) return [`${label} is missing a readable system-release.json`];
+  if (!intent) failures.push(`${label} is missing a readable release-intent.json`);
+  if (release.tagExists !== true) failures.push(`${label} is missing Git tag v${version}`);
+  if (!sourceManifest) failures.push(`${label} is missing assets/press-system.json at Git tag v${version}`);
+  if (!version) return [...failures, `${label} has an invalid version`];
+
+  const expected = expectedTargetMetadata(policy, version);
+  if (manifest.schemaVersion !== 1) failures.push(`${label} system-release schemaVersion must be 1`);
+  if (manifest.version !== version || manifest.tag !== expected.tag) {
+    failures.push(`${label} system-release version and tag must match ${expected.tag}`);
+  }
+  failures.push(...validateUpgradeFrom(manifest.upgradeFrom, version, label));
+  if (sourceManifest) {
+    if (sourceManifest.schemaVersion !== 1
+      || sourceManifest.type !== SYSTEM_RELEASE_TYPE
+      || sourceManifest.version !== version
+      || sourceManifest.tag !== expected.tag) {
+      failures.push(`${label} tagged Press system manifest identity is inconsistent`);
+    }
+    if (!jsonMatches(normalizeUpgradeFrom(sourceManifest.upgradeFrom), normalizeUpgradeFrom(manifest.upgradeFrom))
+      || !jsonMatches(sourceManifest.themeContractUpgrade, manifest.themeContractUpgrade)
+      || !jsonMatches(sourceManifest.contentModelUpgrade, manifest.contentModelUpgrade)) {
+      failures.push(`${label} tagged Press system compatibility metadata does not match system-release.json`);
+    }
+  }
+
+  const runtime = normalizeRuntime(manifest.runtime);
+  if (runtime.manifestPath !== 'assets/press-runtime-manifest.json'
+    || runtime.type !== 'press-runtime-assets'
+    || runtime.cacheKey !== `press-system-${expected.tag}`
+    || runtime.entryCount <= 0
+    || runtime.edgeCount <= 0) {
+    failures.push(`${label} runtime manifest metadata is incomplete or inconsistent`);
+  }
+
+  const asset = normalizeAsset(manifest.asset);
+  if (asset.name !== expected.assetName || asset.url !== expected.assetUrl) {
+    failures.push(`${label} asset name and URL must target ${expected.assetPath}`);
+  }
+  if (asset.size <= 0 || !SHA256_PATTERN.test(asset.digest)) {
+    failures.push(`${label} asset size and sha256 digest must be present`);
+  }
+  if (!artifactPaths.has(expected.assetPath)) failures.push(`${label} is missing artifact ${expected.assetPath}`);
+  if (!artifactPaths.has(expected.systemReleasePath)) {
+    failures.push(`${label} is missing manifest ${expected.systemReleasePath}`);
+  }
+  if (!artifactPaths.has(expected.releaseIntentPath)) {
+    failures.push(`${label} is missing manifest ${expected.releaseIntentPath}`);
+  }
+  if (Number.isFinite(release.actualAssetSize) && asset.size !== release.actualAssetSize) {
+    failures.push(`${label} asset size does not match the published ZIP`);
+  }
+  if (release.actualAssetDigest && asset.digest !== release.actualAssetDigest) {
+    failures.push(`${label} asset digest does not match the published ZIP`);
+  }
+  const githubRelease = githubReleases.get(expected.tag);
+  if (!githubRelease) {
+    failures.push(`${label} is missing a matching GitHub Release object`);
+  } else {
+    if (githubRelease.draft === true || githubRelease.prerelease === true) {
+      failures.push(`${label} GitHub Release must be published and non-prerelease`);
+    }
+    const releaseAssets = Array.isArray(githubRelease.assets) ? githubRelease.assets : [];
+    const matchingAssets = releaseAssets.filter((entry) => String(entry && entry.name || '') === expected.assetName);
+    if (matchingAssets.length !== 1) {
+      failures.push(`${label} GitHub Release must contain exactly one ${expected.assetName} asset`);
+    } else {
+      const releaseAsset = matchingAssets[0];
+      const releaseDigest = String(releaseAsset.digest || '').trim().toLowerCase();
+      if (Number(releaseAsset.size || 0) !== asset.size || releaseDigest !== asset.digest) {
+        failures.push(`${label} GitHub Release asset size or digest does not match system-release.json`);
+      }
+    }
+  }
+
+  const intentPointer = manifest.intent && typeof manifest.intent === 'object' ? manifest.intent : {};
+  if (intentPointer.type !== RELEASE_INTENT_TYPE
+    || intentPointer.path !== expected.releaseIntentPath
+    || intentPointer.url !== expected.releaseIntentUrl
+    || intentPointer.latestPath !== 'release-intent.json'
+    || intentPointer.latestUrl !== expected.latestReleaseIntentUrl) {
+    failures.push(`${label} system-release intent pointer is inconsistent with the artifact layout`);
+  }
+
+  if (intent) {
+    if (intent.schemaVersion !== 1
+      || intent.type !== RELEASE_INTENT_TYPE
+      || intent.repository !== policy.repository
+      || intent.version !== version
+      || intent.tag !== expected.tag
+      || intent.source !== expected.releaseIntentUrl
+      || intent.latestSource !== expected.latestReleaseIntentUrl) {
+      failures.push(`${label} release intent identity or source metadata is inconsistent`);
+    }
+    const systemRelease = intent.systemRelease && typeof intent.systemRelease === 'object'
+      ? intent.systemRelease
+      : {};
+    if (systemRelease.path !== expected.systemReleasePath
+      || systemRelease.source !== expected.systemReleaseUrl
+      || !SHA256_PATTERN.test(String(systemRelease.digest || '').toLowerCase())) {
+      failures.push(`${label} release intent system-release target metadata is inconsistent`);
+    }
+    if (release.manifestText && String(systemRelease.digest || '').toLowerCase() !== sha256(release.manifestText)) {
+      failures.push(`${label} release intent system-release digest does not match its manifest`);
+    }
+    const pressSystem = intent.pressSystem && typeof intent.pressSystem === 'object' ? intent.pressSystem : {};
+    if (!jsonMatches(normalizeAsset(pressSystem.asset), asset)) {
+      failures.push(`${label} release intent asset metadata does not match system-release.json`);
+    }
+    if (!jsonMatches(normalizeRuntime(pressSystem.runtime), runtime)) {
+      failures.push(`${label} release intent runtime metadata does not match system-release.json`);
+    }
+    if (!jsonMatches(normalizeUpgradeFrom(pressSystem.upgradeFrom), normalizeUpgradeFrom(manifest.upgradeFrom))) {
+      failures.push(`${label} release intent upgradeFrom does not match system-release.json`);
+    }
+    if (!jsonMatches(pressSystem.themeContractUpgrade, manifest.themeContractUpgrade)
+      || !jsonMatches(pressSystem.contentModelUpgrade, manifest.contentModelUpgrade)) {
+      failures.push(`${label} release intent migration compatibility metadata does not match system-release.json`);
+    }
+  }
+  return failures;
+}
+
+function validateCandidate(candidate, publishedByVersion) {
+  const failures = [];
+  const version = normalizeSemver(candidate && candidate.version);
+  const label = version ? `candidate v${version}` : 'release candidate';
+  if (!candidate || typeof candidate !== 'object') return ['release candidate manifest must be a JSON object'];
+  if (candidate.schemaVersion !== 1 || candidate.type !== SYSTEM_RELEASE_TYPE) {
+    failures.push(`${label} must use the press-system schemaVersion 1 manifest`);
+  }
+  if (!version || candidate.version !== version || candidate.tag !== semverToTag(version)) {
+    failures.push(`${label} version and tag must be matching exact semantic versions`);
+  }
+  if (version) failures.push(...validateUpgradeFrom(candidate.upgradeFrom, version, label));
+  if (normalizeUpgradeFrom(candidate.upgradeFrom).allowUnknownSource) {
+    failures.push(`${label} must not allow an unknown source version`);
+  }
+  const published = publishedByVersion.get(version);
+  if (published && published.manifest) {
+    if (!jsonMatches(normalizeUpgradeFrom(candidate.upgradeFrom), normalizeUpgradeFrom(published.manifest.upgradeFrom))
+      || !jsonMatches(candidate.themeContractUpgrade, published.manifest.themeContractUpgrade)
+      || !jsonMatches(candidate.contentModelUpgrade, published.manifest.contentModelUpgrade)) {
+      failures.push(`${label} does not match the published release compatibility metadata`);
+    }
+  }
+  return failures;
+}
+
+function normalizePressSystemCompatibility(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return {
+    schemaVersion: Number(source.schemaVersion || 0),
+    type: String(source.type || '').trim(),
+    version: normalizeSemver(source.version),
+    tag: semverToTag(source.tag || source.version),
+    upgradeFrom: normalizeUpgradeFrom(source.upgradeFrom),
+    themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
+      ? source.themeContractUpgrade
+      : {},
+    contentModelUpgrade: source.contentModelUpgrade && typeof source.contentModelUpgrade === 'object'
+      ? source.contentModelUpgrade
+      : {}
+  };
+}
+
+function validateCandidateArchive(candidate, candidateArchive) {
+  const failures = [];
+  const version = normalizeSemver(candidate && candidate.version);
+  const label = version ? `candidate v${version}` : 'release candidate';
+  if (!candidateArchive || typeof candidateArchive !== 'object') {
+    return [`${label} must be verified against a built system ZIP before release creation`];
+  }
+  const expectedName = `press-system-v${version}.zip`;
+  const expectedRoot = `press-system-v${version}/`;
+  const entries = Array.isArray(candidateArchive.entries)
+    ? candidateArchive.entries.map((entry) => String(entry || '').trim()).filter(Boolean)
+    : [];
+  if (String(candidateArchive.name || '') !== expectedName) {
+    failures.push(`${label} archive name must be ${expectedName}`);
+  }
+  if (Number(candidateArchive.size || 0) <= 0
+    || !SHA256_PATTERN.test(String(candidateArchive.digest || '').toLowerCase())) {
+    failures.push(`${label} archive must have a positive size and sha256 digest`);
+  }
+  if (!entries.length || entries.some((entry) => !entry.startsWith(expectedRoot))) {
+    failures.push(`${label} archive must contain exactly the ${expectedRoot} root`);
+  }
+  const embeddedPath = `${expectedRoot}assets/press-system.json`;
+  if (!entries.includes(embeddedPath)) failures.push(`${label} archive is missing ${embeddedPath}`);
+  if (!candidateArchive.embeddedManifest
+    || !jsonMatches(
+      normalizePressSystemCompatibility(candidateArchive.embeddedManifest),
+      normalizePressSystemCompatibility(candidate)
+    )) {
+    failures.push(`${label} archive Press system manifest does not match the worktree candidate`);
+  }
+  return failures;
+}
+
+function validateDirectCandidatePrerequisites(candidate) {
+  const failures = [];
+  const version = normalizeSemver(candidate && candidate.version);
+  const themeUpgrade = candidate && candidate.themeContractUpgrade
+    && typeof candidate.themeContractUpgrade === 'object'
+    ? candidate.themeContractUpgrade
+    : {};
+  const requiredThemeContract = Number(themeUpgrade.requiresInstalledThemeContractVersion || 0);
+  if (Number.isFinite(requiredThemeContract) && requiredThemeContract > 0) {
+    failures.push(`candidate v${version} cannot claim direct recovery while requiring installed theme contract v${Math.floor(requiredThemeContract)}`);
+  }
+  const contentUpgrade = candidate && candidate.contentModelUpgrade
+    && typeof candidate.contentModelUpgrade === 'object'
+    ? candidate.contentModelUpgrade
+    : {};
+  if (contentUpgrade.requiresUnifiedIndexTabs === true) {
+    failures.push(`candidate v${version} cannot claim direct recovery while requiring a pre-migrated unified content model`);
+  }
+  return failures;
+}
+
+function upgradeAllowsSource(targetManifest, sourceVersion) {
+  const upgradeFrom = normalizeUpgradeFrom(targetManifest && targetManifest.upgradeFrom);
+  return upgradeFrom.ranges.some((range) => satisfiesSemverRange(sourceVersion, range));
+}
+
+function analyzeReleaseGraph(input = {}) {
+  const policy = input.policy;
+  const publishedReleases = Array.isArray(input.publishedReleases) ? input.publishedReleases : [];
+  const artifactPaths = input.artifactPaths instanceof Set
+    ? input.artifactPaths
+    : new Set(input.artifactPaths || []);
+  const gitTags = input.gitTags instanceof Set ? input.gitTags : new Set(input.gitTags || []);
+  const githubReleases = input.githubReleases instanceof Map ? input.githubReleases : new Map();
+  const candidate = input.candidate;
+  const failures = validatePolicy(policy);
+  if (failures.length) return { failures, publishedVersions: [], supportedSources: [], directMissing: [] };
+
+  const requestedMode = String(input.validationMode || 'audit').trim();
+  if (!['audit', 'auto', 'candidate'].includes(requestedMode)) {
+    failures.push('release graph validationMode must be audit, auto, or candidate');
+  }
+
+  const floor = normalizeSemver(policy.support.floor);
+  const publishedByVersion = new Map();
+  publishedReleases.forEach((release) => {
+    const version = normalizeSemver(release && release.manifest && release.manifest.version || release && release.version);
+    if (!version) {
+      failures.push('published release registry contains an invalid version');
+      return;
+    }
+    if (compareSemver(version, floor) < 0) return;
+    if (publishedByVersion.has(version)) {
+      failures.push(`published release registry contains duplicate v${version}`);
+      return;
+    }
+    publishedByVersion.set(version, release);
+    failures.push(...validatePublishedRelease(release, policy, artifactPaths, githubReleases));
+  });
+
+  const publishedVersions = [...publishedByVersion.keys()].sort(compareSemver);
+  if (!publishedByVersion.has(floor)) failures.push(`support floor v${floor} is missing from the published release registry`);
+  if (!publishedVersions.length) {
+    failures.push('published release registry has no releases at or above the support floor');
+    return { failures, publishedVersions, supportedSources: [], directMissing: [] };
+  }
+
+  const sourceRanges = policy.support.sourceRanges;
+  publishedVersions.forEach((version) => {
+    if (!sourceRanges.some((range) => satisfiesSemverRange(version, range))) {
+      failures.push(`published release v${version} at or above the support floor is not declared by support.sourceRanges`);
+    }
+  });
+  const latestPublishedVersion = publishedVersions[publishedVersions.length - 1];
+  const latestPublishedRelease = publishedByVersion.get(latestPublishedVersion);
+  if (!artifactPaths.has('system-release.json') || !String(input.latestSystemReleaseText || '')) {
+    failures.push('release artifact registry is missing latest system-release.json');
+  } else if (input.latestSystemReleaseText !== latestPublishedRelease.manifestText) {
+    failures.push(`latest system-release.json does not match immutable v${latestPublishedVersion}/system-release.json`);
+  }
+  if (!artifactPaths.has('release-intent.json') || !String(input.latestReleaseIntentText || '')) {
+    failures.push('release artifact registry is missing latest release-intent.json');
+  } else if (input.latestReleaseIntentText !== latestPublishedRelease.intentText) {
+    failures.push(`latest release-intent.json does not match immutable v${latestPublishedVersion}/release-intent.json`);
+  }
+  const targetManifests = new Map(publishedVersions.map((version) => [version, publishedByVersion.get(version).manifest]));
+  const exceptionByTarget = new Map(policy.legacyExceptions.map((exception) => [
+    normalizeSemver(exception.to),
+    exception
+  ]));
+  publishedVersions.forEach((targetVersion) => {
+    if (targetVersion === floor) return;
+    const targetManifest = targetManifests.get(targetVersion);
+    const incoming = publishedVersions.filter((sourceVersion) => compareSemver(sourceVersion, targetVersion) < 0
+      && upgradeAllowsSource(targetManifest, sourceVersion));
+    const exception = exceptionByTarget.get(targetVersion);
+    if (incoming.length && exception) {
+      failures.push(`legacy exception ${exception.id} is stale because v${targetVersion} admits published source v${incoming[0]}`);
+      return;
+    }
+    if (incoming.length) return;
+    if (!exception) {
+      failures.push(`target v${targetVersion} has no published source admitted by upgradeFrom`);
+      return;
+    }
+    const missingSources = exception.missingSources.map(normalizeSemver);
+    missingSources.forEach((sourceVersion) => {
+      if (publishedByVersion.has(sourceVersion)) {
+        failures.push(`legacy exception ${exception.id} names published source v${sourceVersion} as missing`);
+      }
+      if (!satisfiesSemverRange(sourceVersion, exception.unpublishedRange)) {
+        failures.push(`legacy exception ${exception.id} missing source v${sourceVersion} is outside unpublishedRange`);
+      }
+      if (compareSemver(sourceVersion, targetVersion) >= 0 || !upgradeAllowsSource(targetManifest, sourceVersion)) {
+        failures.push(`legacy exception ${exception.id} missing source v${sourceVersion} is not admitted by v${targetVersion}`);
+      }
+    });
+  });
+
+  policy.legacyExceptions.forEach((exception) => {
+    const from = normalizeSemver(exception.from);
+    const target = normalizeSemver(exception.to);
+    const fromIndex = publishedVersions.indexOf(from);
+    const targetIndex = publishedVersions.indexOf(target);
+    if (fromIndex < 0 || targetIndex < 0) {
+      failures.push(`legacy exception ${exception.id} endpoints must both be published`);
+      return;
+    }
+    if (targetIndex !== fromIndex + 1) {
+      failures.push(`legacy exception ${exception.id} endpoints must be adjacent published releases`);
+    }
+    const targetManifest = targetManifests.get(target);
+    if (!jsonMatches(normalizeUpgradeFrom(targetManifest.upgradeFrom).ranges, exception.targetRanges)) {
+      failures.push(`legacy exception ${exception.id} targetRanges do not match v${target} upgradeFrom`);
+    }
+    const unexpectedPublished = publishedVersions.filter((version) => satisfiesSemverRange(version, exception.unpublishedRange));
+    const unexpectedTags = [...gitTags].map(normalizeSemver).filter((version) => version
+      && satisfiesSemverRange(version, exception.unpublishedRange));
+    if (unexpectedPublished.length || unexpectedTags.length) {
+      failures.push(`legacy exception ${exception.id} unpublishedRange contains a published tag or artifact`);
+    }
+  });
+
+  const outgoing = new Map(publishedVersions.map((version) => [version, []]));
+  publishedVersions.forEach((sourceVersion) => {
+    publishedVersions.forEach((targetVersion) => {
+      if (compareSemver(sourceVersion, targetVersion) < 0
+        && upgradeAllowsSource(targetManifests.get(targetVersion), sourceVersion)) {
+        outgoing.get(sourceVersion).push(targetVersion);
+      }
+    });
+  });
+  function canReachPublishedLatest(sourceVersion) {
+    if (sourceVersion === latestPublishedVersion) return true;
+    const pending = [sourceVersion];
+    const visited = new Set();
+    while (pending.length) {
+      const current = pending.shift();
+      if (current === latestPublishedVersion) return true;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      (outgoing.get(current) || []).forEach((target) => pending.push(target));
+    }
+    return false;
+  }
+  const exceptionSources = new Set(policy.legacyExceptions.map((exception) => normalizeSemver(exception.from)));
+  publishedVersions.filter((version) => version !== latestPublishedVersion
+    && sourceRanges.some((range) => satisfiesSemverRange(version, range)))
+    .forEach((sourceVersion) => {
+      if (!canReachPublishedLatest(sourceVersion) && !exceptionSources.has(sourceVersion)) {
+        failures.push(`published source v${sourceVersion} cannot reach published latest v${latestPublishedVersion}`);
+      }
+    });
+  const worktreeCandidateVersion = normalizeSemver(candidate && candidate.version);
+  policy.legacyExceptions.forEach((exception) => {
+    const from = normalizeSemver(exception.from);
+    const reachesLatest = canReachPublishedLatest(from);
+    if (exception.status === 'recovery-required') {
+      if (reachesLatest) {
+        failures.push(`legacy exception ${exception.id} recovery state is stale because v${from} can reach published latest v${latestPublishedVersion}`);
+      }
+      return;
+    }
+    const recoveredByVersion = normalizeSemver(exception.recoveredByVersion);
+    const recoveredRelease = targetManifests.get(recoveredByVersion);
+    const recoveredCandidate = worktreeCandidateVersion === recoveredByVersion ? candidate : null;
+    const recoveryTarget = recoveredRelease || recoveredCandidate;
+    if (!recoveryTarget) {
+      failures.push(`legacy exception ${exception.id} recoveredByVersion v${recoveredByVersion} is neither published nor the worktree candidate`);
+    } else if (!upgradeAllowsSource(recoveryTarget, from)) {
+      failures.push(`legacy exception ${exception.id} recoveredByVersion v${recoveredByVersion} does not directly admit v${from}`);
+    }
+    if (recoveredRelease && !reachesLatest) {
+      failures.push(`legacy exception ${exception.id} is marked recovered but v${from} cannot reach published latest v${latestPublishedVersion}`);
+    }
+  });
+
+  const inferredMode = worktreeCandidateVersion
+    && compareSemver(worktreeCandidateVersion, latestPublishedVersion) > 0
+    ? 'candidate'
+    : 'audit';
+  const validationMode = requestedMode === 'auto' ? inferredMode : requestedMode;
+  let candidateVersion = latestPublishedVersion;
+  let targetCandidate = targetManifests.get(latestPublishedVersion);
+  if (validationMode === 'audit') {
+    if (worktreeCandidateVersion && compareSemver(worktreeCandidateVersion, latestPublishedVersion) < 0) {
+      failures.push(`worktree Press system v${worktreeCandidateVersion} is older than published latest v${latestPublishedVersion}`);
+    } else if (worktreeCandidateVersion === latestPublishedVersion) {
+      failures.push(...validateCandidate(candidate, publishedByVersion));
+    }
+  } else {
+    failures.push(...validateCandidate(candidate, publishedByVersion));
+    candidateVersion = worktreeCandidateVersion;
+    targetCandidate = candidate;
+    if (!candidateVersion || compareSemver(candidateVersion, latestPublishedVersion) <= 0) {
+      failures.push(`release candidate must be newer than published latest v${latestPublishedVersion}`);
+    }
+    if (candidateVersion && gitTags.has(semverToTag(candidateVersion))) {
+      failures.push(`release candidate tag ${semverToTag(candidateVersion)} already exists`);
+    }
+    failures.push(...validateCandidateArchive(candidate, input.candidateArchive));
+    const candidateIncoming = candidateVersion
+      ? publishedVersions.filter((version) => compareSemver(version, candidateVersion) < 0
+        && upgradeAllowsSource(candidate, version))
+      : [];
+    if (!candidateIncoming.length) {
+      failures.push(`target v${candidateVersion || 'unknown'} has no published source admitted by upgradeFrom`);
+    }
+    if (exceptionByTarget.has(candidateVersion)) {
+      failures.push(`release candidate v${candidateVersion} cannot borrow a legacy graph exception`);
+    }
+  }
+
+  const supportedSources = candidateVersion && targetCandidate
+    ? publishedVersions.filter((version) => compareSemver(version, candidateVersion) < 0
+      && sourceRanges.some((range) => satisfiesSemverRange(version, range)))
+    : [];
+  const directMissing = targetCandidate
+    ? supportedSources.filter((version) => !upgradeAllowsSource(targetCandidate, version))
+    : [];
+  const gate = policy.candidateGate;
+  const baselineVersion = normalizeSemver(gate.baselineVersion);
+  if (validationMode === 'audit' && gate.mode === 'recovery-required'
+    && latestPublishedVersion !== baselineVersion) {
+    failures.push(`published latest v${latestPublishedVersion} does not match recovery baseline v${baselineVersion}`);
+  } else if (validationMode === 'audit' && gate.mode === 'direct'
+    && (!worktreeCandidateVersion || compareSemver(worktreeCandidateVersion, latestPublishedVersion) <= 0)
+    && directMissing.length) {
+    failures.push(`candidateGate.mode cannot switch to direct without a newer recovery candidate; published latest v${latestPublishedVersion} lacks direct edges from: ${directMissing.map((version) => `v${version}`).join(', ')}`);
+  } else if (validationMode === 'candidate' && gate.mode === 'recovery-required') {
+    failures.push(`candidate v${candidateVersion || 'unknown'} is blocked while candidateGate.mode is recovery-required; only published baseline v${baselineVersion} may pass`);
+  } else if (validationMode === 'candidate' && gate.mode === 'direct') {
+    failures.push(...validateDirectCandidatePrerequisites(candidate));
+    failures.push(...validateDirectCandidateDomain(candidate, policy));
+    policy.legacyExceptions.filter((exception) => exception.status === 'recovery-required')
+      .forEach((exception) => {
+        failures.push(`legacy exception ${exception.id} must be marked recovered with recoveredByVersion v${candidateVersion}`);
+      });
+    if (!supportedSources.length) failures.push('direct candidate gate has no declared supported published sources to verify');
+    if (directMissing.length) {
+      failures.push(`candidate v${candidateVersion} lacks latest-only direct upgrade edges from: ${directMissing.map((version) => `v${version}`).join(', ')}`);
+    }
+  }
+
+  return {
+    failures,
+    publishedVersions,
+    supportedSources,
+    directMissing,
+    candidateVersion,
+    latestPublishedVersion,
+    mode: gate.mode,
+    validationMode
+  };
+}
+
+function readJsonFile(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function gitOutput(args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: options.cwd || process.cwd(),
+    encoding: options.encoding === null ? null : 'utf8',
+    maxBuffer: options.maxBuffer || 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
+
+function parseJsonBlob(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error.message}`);
+  }
+}
+
+function loadPublishedReleaseRegistry(options = {}) {
+  const policy = options.policy;
+  const artifactRef = String(options.artifactRef || '').trim();
+  const cwd = options.cwd || process.cwd();
+  if (!artifactRef) throw new Error('release artifact ref is required');
+  try {
+    gitOutput(['rev-parse', '--verify', artifactRef], { cwd });
+  } catch (error) {
+    throw new Error(`release artifact ref ${artifactRef} is unavailable; fetch release-artifacts before verification`);
+  }
+  const tree = gitOutput(['ls-tree', '-r', '--name-only', artifactRef], { cwd });
+  const artifactPaths = new Set(tree.split(/\r?\n/u).map((value) => value.trim()).filter(Boolean));
+  const latestSystemReleaseText = artifactPaths.has('system-release.json')
+    ? gitOutput(['show', `${artifactRef}:system-release.json`], { cwd })
+    : '';
+  const latestReleaseIntentText = artifactPaths.has('release-intent.json')
+    ? gitOutput(['show', `${artifactRef}:release-intent.json`], { cwd })
+    : '';
+  const gitTags = new Set(gitOutput(['tag', '-l', 'v[0-9]*.[0-9]*.[0-9]*'], { cwd })
+    .split(/\r?\n/u)
+    .map((value) => value.trim())
+    .filter((value) => /^v\d+\.\d+\.\d+$/u.test(value)));
+  const floor = normalizeSemver(policy.support.floor);
+  const versions = new Set();
+  artifactPaths.forEach((artifactPath) => {
+    const match = artifactPath.match(/^v(\d+\.\d+\.\d+)\//u);
+    const version = normalizeSemver(match && match[1]);
+    if (version && compareSemver(version, floor) >= 0) versions.add(version);
+  });
+  gitTags.forEach((tag) => {
+    const version = normalizeSemver(tag);
+    if (version && compareSemver(version, floor) >= 0) versions.add(version);
+  });
+
+  const publishedReleases = [...versions].sort(compareSemver).map((version) => {
+    const expected = expectedTargetMetadata(policy, version);
+    const tag = semverToTag(version);
+    const manifestText = artifactPaths.has(expected.systemReleasePath)
+      ? gitOutput(['show', `${artifactRef}:${expected.systemReleasePath}`], { cwd })
+      : '';
+    const intentText = artifactPaths.has(expected.releaseIntentPath)
+      ? gitOutput(['show', `${artifactRef}:${expected.releaseIntentPath}`], { cwd })
+      : '';
+    const assetBuffer = artifactPaths.has(expected.assetPath)
+      ? gitOutput(['show', `${artifactRef}:${expected.assetPath}`], { cwd, encoding: null })
+      : null;
+    const sourceManifestText = gitTags.has(tag)
+      ? gitOutput(['show', `${tag}:assets/press-system.json`], { cwd })
+      : '';
+    return {
+      version,
+      tagExists: gitTags.has(tag),
+      sourceManifest: sourceManifestText
+        ? parseJsonBlob(sourceManifestText, `${tag}:assets/press-system.json`)
+        : null,
+      sourceManifestText,
+      manifest: manifestText ? parseJsonBlob(manifestText, expected.systemReleasePath) : null,
+      manifestText,
+      intent: intentText ? parseJsonBlob(intentText, expected.releaseIntentPath) : null,
+      intentText,
+      actualAssetSize: assetBuffer ? assetBuffer.length : 0,
+      actualAssetDigest: assetBuffer ? sha256(assetBuffer) : ''
+    };
+  });
+  return {
+    artifactRef,
+    artifactPaths,
+    gitTags,
+    latestReleaseIntentText,
+    latestSystemReleaseText,
+    publishedReleases
+  };
+}
+
+function loadGitHubReleaseRegistry(file) {
+  const input = readJsonFile(file);
+  const entries = Array.isArray(input) && input.every(Array.isArray) ? input.flat() : input;
+  if (!Array.isArray(entries)) throw new Error('GitHub Releases registry must be a JSON array or paginated array');
+  const releases = new Map();
+  entries.forEach((entry) => {
+    const tag = String(entry && (entry.tag_name || entry.tagName) || '').trim();
+    if (!/^v\d+\.\d+\.\d+$/u.test(tag)) return;
+    if (releases.has(tag)) throw new Error(`GitHub Releases registry contains duplicate ${tag}`);
+    releases.set(tag, {
+      draft: entry.draft === true,
+      prerelease: entry.prerelease === true,
+      assets: Array.isArray(entry.assets) ? entry.assets : []
+    });
+  });
+  return releases;
+}
+
+function loadCandidateArchive(archivePath, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const absolutePath = path.resolve(cwd, archivePath);
+  const archiveBuffer = fs.readFileSync(absolutePath);
+  execFileSync('unzip', ['-tqq', absolutePath], {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  const entries = execFileSync('unzip', ['-Z1', absolutePath], {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean);
+  const manifestEntries = entries.filter((entry) => entry.endsWith('/assets/press-system.json'));
+  const embeddedManifestText = manifestEntries.length === 1
+    ? execFileSync('unzip', ['-p', absolutePath, manifestEntries[0]], {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    : '';
+  return {
+    path: absolutePath,
+    name: path.basename(absolutePath),
+    size: archiveBuffer.length,
+    digest: sha256(archiveBuffer),
+    entries,
+    embeddedManifest: embeddedManifestText
+      ? parseJsonBlob(embeddedManifestText, `${archivePath}:assets/press-system.json`)
+      : null
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    policyPath: 'scripts/release-graph-policy.json',
+    candidatePath: 'assets/press-system.json',
+    artifactRef: 'origin/release-artifacts',
+    githubReleasesPath: '',
+    candidateArchivePath: '',
+    validationMode: 'audit',
+    quiet: false,
+    help: false
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--policy') options.policyPath = argv[++index] || '';
+    else if (arg === '--candidate') options.candidatePath = argv[++index] || '';
+    else if (arg === '--artifact-ref') options.artifactRef = argv[++index] || '';
+    else if (arg === '--github-releases') options.githubReleasesPath = argv[++index] || '';
+    else if (arg === '--candidate-archive') options.candidateArchivePath = argv[++index] || '';
+    else if (arg === '--mode') options.validationMode = argv[++index] || '';
+    else if (arg === '--quiet') options.quiet = true;
+    else if (arg === '--check') continue;
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log([
+    'usage: node scripts/release-graph.js [options]',
+    '',
+    'Options:',
+    '  --policy <path>       Release graph policy JSON',
+    '  --candidate <path>    Candidate assets/press-system.json',
+    '  --artifact-ref <ref>  Git ref containing published release artifacts',
+    '  --github-releases <path>  Paginated GitHub Releases API JSON (required)',
+    '  --candidate-archive <path>  Built candidate ZIP required in candidate mode',
+    '  --mode <mode>          audit, auto, or candidate (default: audit)',
+    '  --check               Validate and exit non-zero on failure',
+    '  --quiet               Suppress the success summary'
+  ].join('\n'));
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+  const policy = readJsonFile(options.policyPath);
+  const candidate = readJsonFile(options.candidatePath);
+  if (!options.githubReleasesPath) throw new Error('--github-releases is required');
+  const githubReleases = loadGitHubReleaseRegistry(options.githubReleasesPath);
+  const candidateArchive = options.candidateArchivePath
+    ? loadCandidateArchive(options.candidateArchivePath, { cwd: process.cwd() })
+    : null;
+  const registry = loadPublishedReleaseRegistry({
+    policy,
+    artifactRef: options.artifactRef,
+    cwd: process.cwd()
+  });
+  const result = analyzeReleaseGraph({
+    policy,
+    candidate,
+    candidateArchive,
+    validationMode: options.validationMode,
+    publishedReleases: registry.publishedReleases,
+    artifactPaths: registry.artifactPaths,
+    gitTags: registry.gitTags,
+    githubReleases,
+    latestReleaseIntentText: registry.latestReleaseIntentText,
+    latestSystemReleaseText: registry.latestSystemReleaseText
+  });
+  if (result.failures.length) {
+    result.failures.forEach((failure) => console.error(`release graph: ${failure}`));
+    return 1;
+  }
+  if (!options.quiet) {
+    const baselineNote = result.mode === 'recovery-required'
+      ? `; KNOWN LEGACY BREAK: ${result.directMissing.length} supported sources remain recovery-blocked`
+      : '';
+    const subject = result.validationMode === 'candidate' ? 'candidate' : 'published baseline';
+    console.log(`ok - verified ${result.publishedVersions.length} published releases and ${subject} v${result.candidateVersion}${baselineNote}`);
+  }
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error && error.message ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  analyzeReleaseGraph,
+  compareSemver,
+  expectedTargetMetadata,
+  isValidSemverRange,
+  loadCandidateArchive,
+  loadGitHubReleaseRegistry,
+  loadPublishedReleaseRegistry,
+  normalizeSemver,
+  normalizeUpgradeFrom,
+  satisfiesSemverRange,
+  sha256,
+  upgradeAllowsSource,
+  validateCandidateArchive,
+  validatePolicy
+};

--- a/scripts/system-release-transaction.mjs
+++ b/scripts/system-release-transaction.mjs
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RECEIPT_TYPE = 'press-system-release-candidate';
+const LEGACY_RECEIPT_CUTOFF = '3.4.133';
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+function sha256(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+function flattenReleasePages(value) {
+  if (!Array.isArray(value)) throw new Error('GitHub Releases response must be an array');
+  return value.length > 0 && value.every(Array.isArray) ? value.flat() : value;
+}
+
+function normalizeSourceManifest(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const version = String(source.version || '').trim();
+  const tag = String(source.tag || '').trim();
+  if (!/^\d+\.\d+\.\d+$/u.test(version) || tag !== `v${version}`) {
+    throw new Error('assets/press-system.json must declare matching version and tag');
+  }
+  return { source, version, tag };
+}
+
+function normalizeDigest(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function compareVersions(left, right) {
+  const leftParts = String(left || '').split('.').map(Number);
+  const rightParts = String(right || '').split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] === rightParts[index]) continue;
+    return leftParts[index] > rightParts[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+function releaseTag(release) {
+  return String(release && (release.tag_name || release.tagName) || '').trim();
+}
+
+function releaseId(release) {
+  const id = Number(release && release.id);
+  return Number.isInteger(id) && id > 0 ? id : 0;
+}
+
+function matchingAssets(release, assetName) {
+  return (Array.isArray(release && release.assets) ? release.assets : [])
+    .filter((asset) => String(asset && asset.name || '').trim() === assetName);
+}
+
+function validateReceipt(receipt, context) {
+  const failures = [];
+  const asset = receipt && receipt.asset && typeof receipt.asset === 'object'
+    ? receipt.asset
+    : {};
+  if (!receipt || typeof receipt !== 'object') return ['candidate receipt must be a JSON object'];
+  if (receipt.schemaVersion !== 1 || receipt.type !== RECEIPT_TYPE) {
+    failures.push(`candidate receipt must use ${RECEIPT_TYPE} schema version 1`);
+  }
+  if (receipt.repository !== context.repository
+    || receipt.version !== context.version
+    || receipt.tag !== context.tag) {
+    failures.push('candidate receipt repository, version, and tag must match the worktree candidate');
+  }
+  if (!SHA_PATTERN.test(String(receipt.sourceCommit || ''))
+    || receipt.sourceCommit !== context.expectedSourceCommit) {
+    failures.push('candidate receipt sourceCommit must match the release transaction commit');
+  }
+  if (!Number.isInteger(receipt.releaseId) || receipt.releaseId <= 0) {
+    failures.push('candidate receipt releaseId must be a positive integer');
+  }
+  if (asset.name !== context.assetName
+    || asset.path !== context.assetPath
+    || Number(asset.size || 0) <= 0
+    || !SHA256_PATTERN.test(normalizeDigest(asset.digest))) {
+    failures.push('candidate receipt asset identity, size, digest, and path are invalid');
+  }
+  if (!context.candidateArchive) {
+    failures.push('candidate receipt exists without its staged ZIP');
+  } else if (Number(asset.size) !== context.candidateArchive.size
+    || normalizeDigest(asset.digest) !== context.candidateArchive.digest) {
+    failures.push('candidate receipt does not match the staged ZIP bytes');
+  }
+  return failures;
+}
+
+export function validateReleaseAgainstReceipt(release, receipt, options = {}) {
+  const failures = [];
+  const expectedState = String(options.expectedState || '').trim();
+  const id = releaseId(release);
+  const tag = releaseTag(release);
+  if (!['draft', 'published'].includes(expectedState)) {
+    failures.push('expected release state must be draft or published');
+  }
+  if (!id || id !== Number(receipt && receipt.releaseId)) {
+    failures.push('GitHub Release id does not match the candidate receipt');
+  }
+  if (tag !== String(receipt && receipt.tag || '')) {
+    failures.push('GitHub Release tag does not match the candidate receipt');
+  }
+  if (release && release.prerelease === true) {
+    failures.push('candidate GitHub Release must not be a prerelease');
+  }
+  if (expectedState === 'draft' && release && release.draft !== true) {
+    failures.push('candidate GitHub Release is no longer a draft');
+  }
+  if (expectedState === 'published' && release && release.draft === true) {
+    failures.push('candidate GitHub Release is not published');
+  }
+  if (expectedState === 'published' && release && release.immutable !== true) {
+    failures.push('published candidate GitHub Release must be immutable');
+  }
+  const sourceCommit = String(receipt && receipt.sourceCommit || '');
+  const tagCommit = String(options.tagCommit || '').trim();
+  if (expectedState === 'draft') {
+    const target = String(release && release.target_commitish || '').trim();
+    if (tagCommit && tagCommit !== sourceCommit) {
+      failures.push('candidate tag commit does not match the candidate receipt sourceCommit');
+    } else if (!tagCommit && target !== sourceCommit) {
+      failures.push('draft GitHub Release target_commitish does not match the candidate receipt sourceCommit');
+    }
+  } else if (!tagCommit || tagCommit !== sourceCommit) {
+    failures.push('published candidate tag commit does not match the candidate receipt sourceCommit');
+  }
+  const receiptAsset = receipt && receipt.asset && typeof receipt.asset === 'object'
+    ? receipt.asset
+    : {};
+  const assets = matchingAssets(release, receiptAsset.name);
+  if (assets.length !== 1) {
+    failures.push(`GitHub Release must contain exactly one ${receiptAsset.name || '(unknown asset)'}`);
+  } else {
+    const asset = assets[0];
+    if (Number(asset.size || 0) !== Number(receiptAsset.size || 0)
+      || normalizeDigest(asset.digest) !== normalizeDigest(receiptAsset.digest)) {
+      failures.push('GitHub Release asset size or digest does not match the candidate receipt');
+    }
+  }
+  if (expectedState === 'published' && !String(release && release.published_at || '').trim()) {
+    failures.push('published GitHub Release must include published_at');
+  }
+  return failures;
+}
+
+export function classifySystemReleaseTransaction(input = {}) {
+  const failures = [];
+  let normalized;
+  try {
+    normalized = normalizeSourceManifest(input.sourceManifest);
+  } catch (error) {
+    return { action: 'blocked', failures: [error.message] };
+  }
+  const { version, tag } = normalized;
+  const repository = String(input.repository || '').trim();
+  const sourceCommit = String(input.sourceCommit || '').trim();
+  const rootTag = String(input.rootManifest && input.rootManifest.tag || '').trim();
+  const assetName = `press-system-${tag}.zip`;
+  const assetPath = `${tag}/${assetName}`;
+  const releases = flattenReleasePages(input.releases || []);
+  const matching = releases.filter((release) => releaseTag(release) === tag);
+  const receipt = input.candidateReceipt && typeof input.candidateReceipt === 'object'
+    ? input.candidateReceipt
+    : null;
+  const finalizedManifest = input.immutableManifestExists === true;
+  const finalizedIntent = input.immutableIntentExists === true;
+  const candidateArchive = input.candidateArchive || null;
+  const tagCommit = String(input.tagCommit || '').trim();
+
+  if (!repository || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+    failures.push('repository must be an owner/name pair');
+  }
+  if (!SHA_PATTERN.test(sourceCommit)) failures.push('sourceCommit must be a 40-character Git object id');
+  if (!rootTag) failures.push('release-artifacts root system-release.json is missing or invalid');
+  if (matching.length > 1) {
+    const ids = matching.map((release) => releaseId(release) || '?').join(', ');
+    failures.push(`candidate tag ${tag} has duplicate GitHub Release objects: ${ids}; manual recovery is required`);
+  }
+  if (finalizedManifest !== finalizedIntent) {
+    failures.push(`candidate ${tag} has a partial immutable manifest tuple`);
+  }
+  if ((finalizedManifest || finalizedIntent) && rootTag !== tag) {
+    failures.push(`candidate ${tag} immutable manifests exist before atomic latest promotion`);
+  }
+  if (receipt && !candidateArchive) failures.push(`candidate ${tag} receipt exists without its staged ZIP`);
+  if (rootTag !== tag && !receipt && candidateArchive) {
+    failures.push(`candidate ${tag} staged ZIP exists without its receipt`);
+  }
+
+  const release = matching.length === 1 ? matching[0] : null;
+  const canonicalCommit = receipt && String(receipt.sourceCommit || '').trim();
+  if (rootTag === tag) {
+    if (!receipt && compareVersions(version, LEGACY_RECEIPT_CUTOFF) > 0) {
+      failures.push(`finalized release ${tag} is newer than the receipt migration cutoff and must retain release-candidate.json`);
+    }
+    if (!finalizedManifest || !finalizedIntent) {
+      failures.push(`latest pointers expose ${tag} without a complete finalized transaction`);
+    }
+    if (!release || release.draft === true || release.prerelease === true) {
+      failures.push(`latest pointers expose ${tag} without one published non-prerelease GitHub Release`);
+    }
+    if (!tagCommit) failures.push(`latest release ${tag} is missing its Git tag`);
+    if (receipt) {
+      failures.push(...validateReceipt(receipt, {
+        repository,
+        version,
+        tag,
+        expectedSourceCommit: canonicalCommit,
+        assetName,
+        assetPath,
+        candidateArchive
+      }));
+    }
+    if (release && receipt) {
+      failures.push(...validateReleaseAgainstReceipt(release, receipt, {
+        expectedState: 'published',
+        tagCommit
+      }));
+    }
+    if (failures.length) return { action: 'blocked', failures, tag, version };
+    return {
+      action: receipt && canonicalCommit === sourceCommit ? 'dispatch' : 'settled',
+      failures: [],
+      tag,
+      version,
+      rootTag,
+      releaseId: releaseId(release),
+      assetName,
+      assetPath,
+      assetSize: receipt ? Number(receipt.asset.size) : 0,
+      assetDigest: receipt ? normalizeDigest(receipt.asset.digest) : '',
+      sourceCommit: canonicalCommit || tagCommit
+    };
+  }
+
+  if (receipt) {
+    failures.push(...validateReceipt(receipt, {
+      repository,
+      version,
+      tag,
+      expectedSourceCommit: sourceCommit,
+      assetName,
+      assetPath,
+      candidateArchive
+    }));
+  }
+  if (tagCommit && tagCommit !== sourceCommit) {
+    failures.push(`candidate tag ${tag} points at ${tagCommit}, not release transaction commit ${sourceCommit}`);
+  }
+  if (release && release.prerelease === true) failures.push(`candidate ${tag} is a prerelease`);
+  if (release && !releaseId(release)) failures.push(`candidate ${tag} GitHub Release id is invalid`);
+  if (release && release.draft === true && !tagCommit
+    && String(release.target_commitish || '').trim() !== sourceCommit) {
+    failures.push(`candidate ${tag} draft targets a different commit`);
+  }
+  if (release && release.draft !== true && !receipt) {
+    failures.push(`published candidate ${tag} has no staged receipt; manual recovery is required`);
+  }
+  if (receipt && !release) {
+    failures.push(`candidate ${tag} is staged without its GitHub Release; manual recovery is required`);
+  }
+  if (!release && tagCommit) {
+    failures.push(`candidate tag ${tag} has no GitHub Release; manual recovery is required`);
+  }
+  if (release && receipt) {
+    failures.push(...validateReleaseAgainstReceipt(release, receipt, {
+      expectedState: release.draft === true ? 'draft' : 'published',
+      tagCommit
+    }));
+  }
+  if (failures.length) return { action: 'blocked', failures, tag, version };
+
+  let action = 'new';
+  if (release && receipt && release.draft === true) action = 'resume-publish';
+  else if (release && receipt) action = 'resume-promote';
+  else if (release && release.draft === true) action = 'resume-stage';
+
+  return {
+    action,
+    failures: [],
+    tag,
+    version,
+    rootTag,
+    releaseId: releaseId(release),
+    assetName,
+    assetPath,
+    assetSize: receipt ? Number(receipt.asset.size) : 0,
+    assetDigest: receipt ? normalizeDigest(receipt.asset.digest) : '',
+    sourceCommit
+  };
+}
+
+export function createCandidateReceipt(input = {}) {
+  const normalized = normalizeSourceManifest(input.sourceManifest);
+  const repository = String(input.repository || '').trim();
+  const sourceCommit = String(input.sourceCommit || '').trim();
+  const archive = Buffer.isBuffer(input.archive) ? input.archive : Buffer.from(input.archive || '');
+  const assetName = `press-system-${normalized.tag}.zip`;
+  const digest = sha256(archive);
+  const release = input.release;
+  const tagCommit = String(input.tagCommit || '').trim();
+  const assets = matchingAssets(release, assetName);
+  const failures = [];
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) failures.push('repository must be an owner/name pair');
+  if (!SHA_PATTERN.test(sourceCommit)) failures.push('sourceCommit must be a 40-character Git object id');
+  if (releaseTag(release) !== normalized.tag || release && release.draft !== true || release && release.prerelease === true) {
+    failures.push('candidate receipt requires the matching draft non-prerelease GitHub Release');
+  }
+  if (tagCommit && tagCommit !== sourceCommit) {
+    failures.push('candidate tag commit must equal sourceCommit');
+  } else if (!tagCommit && String(release && release.target_commitish || '').trim() !== sourceCommit) {
+    failures.push('draft GitHub Release target_commitish must equal sourceCommit');
+  }
+  if (assets.length !== 1) {
+    failures.push(`GitHub Release must contain exactly one ${assetName}`);
+  } else if (Number(assets[0].size || 0) !== archive.length
+    || normalizeDigest(assets[0].digest) !== digest) {
+    failures.push('GitHub Release asset size or digest does not match the built archive');
+  }
+  if (!archive.length) failures.push('candidate archive must not be empty');
+  if (failures.length) throw new Error(failures.join('\n'));
+  return {
+    schemaVersion: 1,
+    type: RECEIPT_TYPE,
+    repository,
+    version: normalized.version,
+    tag: normalized.tag,
+    sourceCommit,
+    releaseId: releaseId(release),
+    stagedAt: String(input.stagedAt || new Date().toISOString()),
+    asset: {
+      name: assetName,
+      path: `${normalized.tag}/${assetName}`,
+      size: archive.length,
+      digest
+    }
+  };
+}
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: options.cwd || process.cwd(),
+    encoding: options.encoding === null ? null : 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
+
+function gitPathExists(ref, path, cwd) {
+  const result = spawnSync('git', ['cat-file', '-e', `${ref}:${path}`], { cwd, stdio: 'ignore' });
+  if (result.error) throw result.error;
+  if (result.status === 0) return true;
+  if (result.status === 1 || result.status === 128) return false;
+  throw new Error(`git cat-file exited ${result.status}`);
+}
+
+function readJsonAtRef(ref, path, cwd) {
+  if (!gitPathExists(ref, path, cwd)) return null;
+  return JSON.parse(git(['show', `${ref}:${path}`], { cwd }));
+}
+
+function readTagCommit(tag, cwd) {
+  const result = spawnSync('git', ['rev-parse', '--verify', `${tag}^{commit}`], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  });
+  if (result.error) throw result.error;
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readTransactionInput(options) {
+  const cwd = options.cwd || process.cwd();
+  const sourceManifest = JSON.parse(fs.readFileSync(options.sourceManifestPath, 'utf8'));
+  const normalized = normalizeSourceManifest(sourceManifest);
+  const assetPath = `${normalized.tag}/press-system-${normalized.tag}.zip`;
+  const archive = gitPathExists(options.artifactRef, assetPath, cwd)
+    ? git(['show', `${options.artifactRef}:${assetPath}`], { cwd, encoding: null })
+    : null;
+  return {
+    repository: options.repository,
+    sourceManifest,
+    sourceCommit: options.sourceCommit,
+    rootManifest: readJsonAtRef(options.artifactRef, 'system-release.json', cwd),
+    candidateReceipt: readJsonAtRef(options.artifactRef, `${normalized.tag}/release-candidate.json`, cwd),
+    candidateArchive: archive ? { size: archive.length, digest: sha256(archive) } : null,
+    immutableManifestExists: gitPathExists(options.artifactRef, `${normalized.tag}/system-release.json`, cwd),
+    immutableIntentExists: gitPathExists(options.artifactRef, `${normalized.tag}/release-intent.json`, cwd),
+    tagCommit: readTagCommit(normalized.tag, cwd),
+    releases: JSON.parse(fs.readFileSync(options.releasesPath, 'utf8'))
+  };
+}
+
+function parseArgs(argv) {
+  const command = argv[0] || '';
+  const options = {
+    command,
+    artifactRef: 'origin/release-artifacts',
+    sourceManifestPath: 'assets/press-system.json',
+    sourceCommit: process.env.GITHUB_SHA || '',
+    repository: process.env.GITHUB_REPOSITORY || '',
+    cwd: process.cwd()
+  };
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => argv[++index] || '';
+    if (arg === '--artifact-ref') options.artifactRef = value();
+    else if (arg === '--releases') options.releasesPath = value();
+    else if (arg === '--source-manifest') options.sourceManifestPath = value();
+    else if (arg === '--source-commit') options.sourceCommit = value();
+    else if (arg === '--repository') options.repository = value();
+    else if (arg === '--github-output') options.githubOutput = value();
+    else if (arg === '--release') options.releasePath = value();
+    else if (arg === '--receipt') options.receiptPath = value();
+    else if (arg === '--archive') options.archivePath = value();
+    else if (arg === '--out') options.outPath = value();
+    else if (arg === '--expected-state') options.expectedState = value();
+    else if (arg === '--tag-commit') options.tagCommit = value();
+    else if (arg === '--staged-at') options.stagedAt = value();
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function writeGitHubOutput(path, result) {
+  const lines = [
+    `action=${result.action}`,
+    `tag=${result.tag || ''}`,
+    `version=${result.version || ''}`,
+    `root_tag=${result.rootTag || ''}`,
+    `release_id=${result.releaseId || ''}`,
+    `asset_name=${result.assetName || ''}`,
+    `asset_path=${result.assetPath || ''}`,
+    `asset_size=${result.assetSize || ''}`,
+    `asset_digest=${result.assetDigest || ''}`,
+    `source_commit=${result.sourceCommit || ''}`
+  ];
+  fs.appendFileSync(path, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.command === 'inspect') {
+    if (!options.releasesPath) throw new Error('--releases is required');
+    const result = classifySystemReleaseTransaction(readTransactionInput(options));
+    if (result.failures.length) throw new Error(result.failures.join('\n'));
+    if (options.githubOutput) writeGitHubOutput(options.githubOutput, result);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  if (options.command === 'create-receipt') {
+    if (!options.releasePath || !options.archivePath || !options.outPath) {
+      throw new Error('create-receipt requires --release, --archive, and --out');
+    }
+    const receipt = createCandidateReceipt({
+      repository: options.repository,
+      sourceManifest: JSON.parse(fs.readFileSync(options.sourceManifestPath, 'utf8')),
+      sourceCommit: options.sourceCommit,
+      release: JSON.parse(fs.readFileSync(options.releasePath, 'utf8')),
+      archive: fs.readFileSync(options.archivePath),
+      tagCommit: options.tagCommit,
+      stagedAt: options.stagedAt
+    });
+    fs.writeFileSync(options.outPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    return;
+  }
+  if (options.command === 'verify-release') {
+    if (!options.releasePath || !options.receiptPath || !options.expectedState) {
+      throw new Error('verify-release requires --release, --receipt, and --expected-state');
+    }
+    const failures = validateReleaseAgainstReceipt(
+      JSON.parse(fs.readFileSync(options.releasePath, 'utf8')),
+      JSON.parse(fs.readFileSync(options.receiptPath, 'utf8')),
+      { expectedState: options.expectedState, tagCommit: options.tagCommit }
+    );
+    if (failures.length) throw new Error(failures.join('\n'));
+    return;
+  }
+  throw new Error('usage: system-release-transaction.mjs inspect|create-receipt|verify-release [options]');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test-release-graph.js
+++ b/scripts/test-release-graph.js
@@ -1,13 +1,51 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const test = require('node:test');
 
-const policySource = require('./release-graph-policy.json');
 const {
   analyzeReleaseGraph,
   expectedTargetMetadata,
+  loadPublishedReleaseRegistry,
   satisfiesSemverRange,
   sha256
 } = require('./release-graph.js');
+
+const recoveryDebtPolicySource = {
+  schemaVersion: 1,
+  type: 'press-release-graph-policy',
+  repository: 'EkilyHQ/Press',
+  support: {
+    floor: '3.4.64',
+    sourceRanges: ['>=3.4.64'],
+    updateStrategy: 'latest-only'
+  },
+  candidateGate: {
+    mode: 'recovery-required',
+    baselineVersion: '3.4.133',
+    reason: 'Historical fixture: v3.4.133 is not directly reachable from every supported source.',
+    removalCondition: 'The production policy may change after a direct recovery transition; this fixture must remain historical.'
+  },
+  legacyExceptions: [{
+    id: 'v3.4.108-missing-predecessor',
+    from: '3.4.64',
+    to: '3.4.108',
+    status: 'recovery-required',
+    unpublishedRange: '>3.4.64 <3.4.108',
+    targetRanges: ['>=3.4.107 <3.4.108'],
+    missingSources: ['3.4.107'],
+    reason: 'Historical fixture: v3.4.108 requires unpublished v3.4.107.',
+    removalCondition: 'Retain the immutable break while direct recovery behavior is tested separately.'
+  }],
+  artifactLayout: {
+    systemRelease: 'v{version}/system-release.json',
+    releaseIntent: 'v{version}/release-intent.json',
+    asset: 'v{version}/press-system-v{version}.zip',
+    rawRoot: 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts'
+  }
+};
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -129,6 +167,7 @@ function githubReleaseFor(release) {
   return {
     draft: false,
     prerelease: false,
+    immutable: true,
     assets: [{
       name: release.manifest.asset.name,
       size: release.manifest.asset.size,
@@ -138,7 +177,7 @@ function githubReleaseFor(release) {
 }
 
 function baselineFixture() {
-  const policy = clone(policySource);
+  const policy = clone(recoveryDebtPolicySource);
   const artifactPaths = new Set();
   const publishedReleases = [
     makePublishedRelease('3.4.64', '>=3.4.63 <3.4.64', policy, artifactPaths),
@@ -309,6 +348,15 @@ test('auto mode audits the baseline and validates a newer worktree as a candidat
   assert.equal(candidateResult.validationMode, 'candidate');
 });
 
+test('forced candidate mode rejects a release-surface change without a version bump', () => {
+  const fixture = baselineFixture();
+  fixture.validationMode = 'candidate';
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /release candidate must be newer than published latest v3\.4\.133/u);
+});
+
 test('direct recovery must close the active debt state in the same candidate policy', () => {
   const fixture = baselineFixture();
   fixture.policy.candidateGate.mode = 'direct';
@@ -339,6 +387,99 @@ test('recovered historical break remains auditable after the recovery release is
 
   assert.deepEqual(result.failures, []);
   assert.deepEqual(result.directMissing, []);
+});
+
+test('one explicit transient candidate tag can resume candidate validation without becoming latest', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  fixture.gitTags.add('v3.4.134');
+  fixture.githubReleases.set('v3.4.134', { draft: true, prerelease: false, immutable: false, assets: [] });
+
+  const blocked = analyzeReleaseGraph(fixture);
+  assert.match(blocked.failures.join('\n'), /release candidate tag v3\.4\.134 already exists/u);
+
+  fixture.transientCandidateVersion = '3.4.134';
+  const resumed = analyzeReleaseGraph(fixture);
+  assert.deepEqual(resumed.failures, []);
+  assert.equal(resumed.latestPublishedVersion, '3.4.133');
+});
+
+test('transient candidate exception must identify an exact worktree version', () => {
+  const fixture = baselineFixture();
+  fixture.transientCandidateVersion = 'not-a-version';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /transientCandidateVersion must be an exact semantic version/u);
+});
+
+test('transient candidate exception cannot hide a tag without a GitHub Release owner', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  fixture.gitTags.add('v3.4.134');
+  fixture.transientCandidateVersion = '3.4.134';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /must have one non-prerelease GitHub Release object/u);
+});
+
+test('registry loader keeps staged candidate bytes out of the published graph and rejects partial finalization', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'press-release-graph-'));
+  const run = (args) => execFileSync('git', args, { cwd, stdio: 'ignore' });
+  const writeJson = (relativePath, value) => {
+    const absolutePath = path.join(cwd, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, `${JSON.stringify(value, null, 2)}\n`);
+  };
+  run(['init', '-q']);
+  run(['config', 'user.name', 'Release Graph Test']);
+  run(['config', 'user.email', 'release-graph@example.test']);
+  writeJson('assets/press-system.json', candidateManifest('3.4.133', '>=3.4.132 <3.4.133'));
+  writeJson('v3.4.133/system-release.json', { version: '3.4.133', tag: 'v3.4.133' });
+  writeJson('v3.4.133/release-intent.json', { version: '3.4.133', tag: 'v3.4.133' });
+  writeJson('system-release.json', { version: '3.4.133', tag: 'v3.4.133' });
+  writeJson('release-intent.json', { version: '3.4.133', tag: 'v3.4.133' });
+  fs.writeFileSync(path.join(cwd, 'v3.4.133/press-system-v3.4.133.zip'), 'published');
+  run(['add', '.']);
+  run(['commit', '-qm', 'published baseline']);
+  run(['tag', 'v3.4.133']);
+
+  writeJson('assets/press-system.json', candidateManifest('3.4.134', '>=3.4.64 <3.4.134'));
+  writeJson('v3.4.134/release-candidate.json', { tag: 'v3.4.134' });
+  fs.mkdirSync(path.join(cwd, 'v3.4.134'), { recursive: true });
+  fs.writeFileSync(path.join(cwd, 'v3.4.134/press-system-v3.4.134.zip'), 'staged');
+  run(['add', '.']);
+  run(['commit', '-qm', 'staged candidate']);
+  run(['tag', 'v3.4.134']);
+
+  const policy = {
+    support: { floor: '3.4.133' },
+    artifactLayout: recoveryDebtPolicySource.artifactLayout
+  };
+  const registry = loadPublishedReleaseRegistry({
+    policy,
+    artifactRef: 'HEAD',
+    transientCandidateVersion: '3.4.134',
+    cwd
+  });
+  assert.deepEqual(registry.publishedReleases.map((release) => release.version), ['3.4.133']);
+  assert.equal(registry.gitTags.has('v3.4.134'), false);
+  assert.equal(registry.latestSystemReleaseText, `${JSON.stringify({ version: '3.4.133', tag: 'v3.4.133' }, null, 2)}\n`);
+
+  writeJson('v3.4.134/system-release.json', { version: '3.4.134', tag: 'v3.4.134' });
+  run(['add', '.']);
+  run(['commit', '-qm', 'partial finalization']);
+  assert.throws(() => loadPublishedReleaseRegistry({
+    policy,
+    artifactRef: 'HEAD',
+    transientCandidateVersion: '3.4.134',
+    cwd
+  }), /partial immutable manifest tuple/u);
 });
 
 test('v3.4.64 recovery candidate cannot retain cleanup-only migration prerequisites', () => {
@@ -433,7 +574,7 @@ test('published release requires a non-draft GitHub Release and matching asset',
   const failures = result.failures.join('\n');
 
   assert.match(failures, /v3\.4\.109 is missing a matching GitHub Release object/u);
-  assert.match(failures, /v3\.4\.132 GitHub Release must be published and non-prerelease/u);
+  assert.match(failures, /v3\.4\.132 GitHub Release must be published, non-prerelease, and immutable/u);
   assert.match(failures, /v3\.4\.133 GitHub Release asset size or digest does not match/u);
 });
 

--- a/scripts/test-release-graph.js
+++ b/scripts/test-release-graph.js
@@ -289,6 +289,26 @@ test('direct mode accepts a recovery candidate that admits every supported publi
   assert.deepEqual(result.directMissing, []);
 });
 
+test('auto mode audits the baseline and validates a newer worktree as a candidate', () => {
+  const baseline = baselineFixture();
+  baseline.validationMode = 'auto';
+  baseline.candidateArchive = candidateArchive(baseline.candidate);
+  const auditResult = analyzeReleaseGraph(baseline);
+
+  assert.deepEqual(auditResult.failures, []);
+  assert.equal(auditResult.validationMode, 'audit');
+
+  const recovery = baselineFixture();
+  enableDirectRecovery(recovery);
+  recovery.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  recovery.candidateArchive = candidateArchive(recovery.candidate);
+  recovery.validationMode = 'auto';
+  const candidateResult = analyzeReleaseGraph(recovery);
+
+  assert.deepEqual(candidateResult.failures, []);
+  assert.equal(candidateResult.validationMode, 'candidate');
+});
+
 test('direct recovery must close the active debt state in the same candidate policy', () => {
   const fixture = baselineFixture();
   fixture.policy.candidateGate.mode = 'direct';

--- a/scripts/test-release-graph.js
+++ b/scripts/test-release-graph.js
@@ -1,0 +1,452 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const policySource = require('./release-graph-policy.json');
+const {
+  analyzeReleaseGraph,
+  expectedTargetMetadata,
+  satisfiesSemverRange,
+  sha256
+} = require('./release-graph.js');
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function upgradeFrom(range) {
+  return {
+    ranges: [range],
+    allowUnknownSource: false,
+    message: 'Use the required recovery path.'
+  };
+}
+
+function candidateManifest(version, range) {
+  return {
+    schemaVersion: 1,
+    type: 'press-system',
+    version,
+    tag: `v${version}`,
+    upgradeFrom: upgradeFrom(range)
+  };
+}
+
+function candidateArchive(candidate) {
+  const version = candidate.version;
+  const root = `press-system-v${version}/`;
+  return {
+    name: `press-system-v${version}.zip`,
+    size: 100,
+    digest: `sha256:${'a'.repeat(64)}`,
+    entries: [
+      root,
+      `${root}index.html`,
+      `${root}assets/press-system.json`
+    ],
+    embeddedManifest: clone(candidate)
+  };
+}
+
+function makePublishedRelease(version, range, policy, artifactPaths) {
+  const expected = expectedTargetMetadata(policy, version);
+  const assetBuffer = Buffer.from(`press system archive ${version}`);
+  const asset = {
+    name: expected.assetName,
+    url: expected.assetUrl,
+    size: assetBuffer.length,
+    digest: sha256(assetBuffer)
+  };
+  const runtime = {
+    manifestPath: 'assets/press-runtime-manifest.json',
+    type: 'press-runtime-assets',
+    strategy: 'query-param',
+    cacheKey: `press-system-v${version}`,
+    entryCount: 10,
+    edgeCount: 12
+  };
+  const manifest = {
+    schemaVersion: 1,
+    tag: `v${version}`,
+    version,
+    upgradeFrom: upgradeFrom(range),
+    runtime,
+    asset,
+    intent: {
+      type: 'press-release-intent',
+      path: expected.releaseIntentPath,
+      url: expected.releaseIntentUrl,
+      latestPath: 'release-intent.json',
+      latestUrl: expected.latestReleaseIntentUrl
+    }
+  };
+  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`;
+  const intent = {
+    schemaVersion: 1,
+    type: 'press-release-intent',
+    repository: policy.repository,
+    version,
+    tag: `v${version}`,
+    source: expected.releaseIntentUrl,
+    latestSource: expected.latestReleaseIntentUrl,
+    systemRelease: {
+      path: expected.systemReleasePath,
+      source: expected.systemReleaseUrl,
+      digest: sha256(manifestText)
+    },
+    pressSystem: {
+      asset,
+      runtime,
+      upgradeFrom: manifest.upgradeFrom
+    }
+  };
+  artifactPaths.add(expected.systemReleasePath);
+  artifactPaths.add(expected.releaseIntentPath);
+  artifactPaths.add(expected.assetPath);
+  return {
+    version,
+    tagExists: true,
+    sourceManifest: candidateManifest(version, range),
+    manifest,
+    manifestText,
+    intent,
+    intentText: `${JSON.stringify(intent, null, 2)}\n`,
+    actualAssetSize: assetBuffer.length,
+    actualAssetDigest: sha256(assetBuffer)
+  };
+}
+
+function setPublishedUpgrade(release, range) {
+  const next = upgradeFrom(range);
+  release.sourceManifest.upgradeFrom = clone(next);
+  release.manifest.upgradeFrom = clone(next);
+  release.intent.pressSystem.upgradeFrom = clone(next);
+  release.manifestText = `${JSON.stringify(release.manifest, null, 2)}\n`;
+  release.intent.systemRelease.digest = sha256(release.manifestText);
+  release.intentText = `${JSON.stringify(release.intent, null, 2)}\n`;
+}
+
+function githubReleaseFor(release) {
+  return {
+    draft: false,
+    prerelease: false,
+    assets: [{
+      name: release.manifest.asset.name,
+      size: release.manifest.asset.size,
+      digest: release.manifest.asset.digest
+    }]
+  };
+}
+
+function baselineFixture() {
+  const policy = clone(policySource);
+  const artifactPaths = new Set();
+  const publishedReleases = [
+    makePublishedRelease('3.4.64', '>=3.4.63 <3.4.64', policy, artifactPaths),
+    makePublishedRelease('3.4.108', '>=3.4.107 <3.4.108', policy, artifactPaths),
+    makePublishedRelease('3.4.109', '>=3.4.108 <3.4.109', policy, artifactPaths),
+    makePublishedRelease('3.4.132', '>=3.4.109 <3.4.132', policy, artifactPaths),
+    makePublishedRelease('3.4.133', '>=3.4.132 <3.4.133', policy, artifactPaths)
+  ];
+  const latestRelease = publishedReleases[publishedReleases.length - 1];
+  artifactPaths.add('system-release.json');
+  artifactPaths.add('release-intent.json');
+  return {
+    policy,
+    artifactPaths,
+    publishedReleases,
+    gitTags: new Set(publishedReleases.map((release) => `v${release.version}`)),
+    githubReleases: new Map(publishedReleases.map((release) => [
+      `v${release.version}`,
+      githubReleaseFor(release)
+    ])),
+    latestReleaseIntentText: latestRelease.intentText,
+    latestSystemReleaseText: latestRelease.manifestText,
+    validationMode: 'audit',
+    candidate: candidateManifest('3.4.133', '>=3.4.132 <3.4.133')
+  };
+}
+
+function enableDirectRecovery(fixture, version = '3.4.134') {
+  fixture.policy.candidateGate.mode = 'direct';
+  fixture.policy.legacyExceptions[0].status = 'recovered';
+  fixture.policy.legacyExceptions[0].recoveredByVersion = version;
+}
+
+test('current v3.4.133 baseline is explicit recovery debt, not a healthy multi-hop graph', () => {
+  const result = analyzeReleaseGraph(baselineFixture());
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.mode, 'recovery-required');
+  assert.deepEqual(result.directMissing, ['3.4.64', '3.4.108', '3.4.109']);
+});
+
+test('release graph range checks stay aligned with the runtime Press version contract', async () => {
+  const runtime = await import('../assets/js/press-version.js');
+  const cases = [
+    ['3.4.64', '>=3.4.64 <3.4.108'],
+    ['3.4.107', '>=3.4.107 <3.4.108'],
+    ['3.4.108', '>=3.4.107 <3.4.108'],
+    ['3.4.133', '>=3.4.64 <3.4.134'],
+    ['3.5.0', '>=3.4.64 <3.5.0 || =4.0.0']
+  ];
+
+  cases.forEach(([version, range]) => {
+    assert.equal(satisfiesSemverRange(version, range), runtime.satisfiesSemverRange(version, range));
+  });
+});
+
+test('known v3.4.108 missing predecessor must remain explicitly registered', () => {
+  const fixture = baselineFixture();
+  fixture.policy.legacyExceptions = [];
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /target v3\.4\.108 has no published source admitted by upgradeFrom/u);
+});
+
+test('published audit rejects an unregistered source that cannot reach latest', () => {
+  const fixture = baselineFixture();
+  setPublishedUpgrade(fixture.publishedReleases[3], '=3.4.108');
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /published source v3\.4\.109 cannot reach published latest v3\.4\.133/u);
+});
+
+test('legacy exception becomes stale when its source can reach published latest', () => {
+  const fixture = baselineFixture();
+  setPublishedUpgrade(fixture.publishedReleases[1], '>=3.4.64 <3.4.108');
+  fixture.policy.legacyExceptions[0].targetRanges = ['>=3.4.64 <3.4.108'];
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /legacy exception v3\.4\.108-missing-predecessor is stale/u);
+});
+
+test('legacy exception must name a missing source that the target actually admits', () => {
+  const fixture = baselineFixture();
+  fixture.policy.legacyExceptions[0].missingSources = ['3.4.106'];
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /missing source v3\.4\.106 is not admitted by v3\.4\.108/u);
+});
+
+test('recovery-required mode blocks every candidate newer than the exact baseline', () => {
+  const fixture = baselineFixture();
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.133 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(
+    result.failures.join('\n'),
+    /candidate v3\.4\.134 is blocked while candidateGate\.mode is recovery-required/u
+  );
+});
+
+test('policy cannot switch to direct mode without a newer recovery candidate', () => {
+  const fixture = baselineFixture();
+  fixture.policy.candidateGate.mode = 'direct';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(
+    result.failures.join('\n'),
+    /candidateGate\.mode cannot switch to direct without a newer recovery candidate/u
+  );
+});
+
+test('candidate cannot point only at a predecessor that was never published', () => {
+  const fixture = baselineFixture();
+  fixture.candidate = candidateManifest('3.4.135', '>=3.4.134 <3.4.135');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /target v3\.4\.135 has no published source admitted by upgradeFrom/u);
+  assert.match(failures, /candidate v3\.4\.135 is blocked while candidateGate\.mode is recovery-required/u);
+});
+
+test('direct mode rejects multi-hop-only compatibility for the latest-only updater', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.133 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /lacks latest-only direct upgrade edges from: v3\.4\.64/u);
+  assert.ok(result.directMissing.includes('3.4.108'));
+  assert.ok(result.directMissing.includes('3.4.132'));
+});
+
+test('direct mode accepts a recovery candidate that admits every supported published source', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.directMissing, []);
+});
+
+test('direct recovery must close the active debt state in the same candidate policy', () => {
+  const fixture = baselineFixture();
+  fixture.policy.candidateGate.mode = 'direct';
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /must be marked recovered with recoveredByVersion v3\.4\.134/u);
+});
+
+test('recovered historical break remains auditable after the recovery release is published', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  const recoveryRelease = makePublishedRelease(
+    '3.4.134',
+    '>=3.4.64 <3.4.134',
+    fixture.policy,
+    fixture.artifactPaths
+  );
+  fixture.publishedReleases.push(recoveryRelease);
+  fixture.gitTags.add('v3.4.134');
+  fixture.githubReleases.set('v3.4.134', githubReleaseFor(recoveryRelease));
+  fixture.latestReleaseIntentText = recoveryRelease.intentText;
+  fixture.latestSystemReleaseText = recoveryRelease.manifestText;
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.directMissing, []);
+});
+
+test('v3.4.64 recovery candidate cannot retain cleanup-only migration prerequisites', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidate.themeContractUpgrade = {
+    requiresInstalledThemeContractVersion: 4,
+    message: 'Update themes first.'
+  };
+  fixture.candidate.contentModelUpgrade = {
+    requiresUnifiedIndexTabs: true,
+    message: 'Publish the content migration first.'
+  };
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /cannot claim direct recovery while requiring installed theme contract v4/u);
+  assert.match(failures, /cannot claim direct recovery while requiring a pre-migrated unified content model/u);
+});
+
+test('candidate release tag must not already exist', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.gitTags.add('v3.4.134');
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /release candidate tag v3\.4\.134 already exists/u);
+});
+
+test('candidate cannot treat an unknown installed Press version as compatible', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidate.upgradeFrom.allowUnknownSource = true;
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /candidate v3\.4\.134 must not allow an unknown source version/u);
+});
+
+test('candidate upgrade ranges cannot authorize future versions to install an older ZIP', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest(
+    '3.4.134',
+    '>=3.4.64 <3.4.134 || >3.4.134'
+  );
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /upgradeFrom range must not accept target or future versions/u);
+});
+
+test('candidate upgrade ranges cannot silently admit versions below the support floor', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=0.0.0 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /upgradeFrom admits versions outside policy support\.sourceRanges/u);
+});
+
+test('published artifact size, digest, and target manifest metadata are verified', () => {
+  const fixture = baselineFixture();
+  fixture.publishedReleases[2].actualAssetSize += 1;
+  fixture.publishedReleases[3].intent.systemRelease.path = 'v3.4.132/wrong.json';
+  fixture.artifactPaths.delete('v3.4.133/release-intent.json');
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /v3\.4\.109 asset size does not match the published ZIP/u);
+  assert.match(failures, /v3\.4\.132 release intent system-release target metadata is inconsistent/u);
+  assert.match(failures, /v3\.4\.133 is missing manifest v3\.4\.133\/release-intent\.json/u);
+});
+
+test('published release requires a non-draft GitHub Release and matching asset', () => {
+  const fixture = baselineFixture();
+  fixture.githubReleases.delete('v3.4.109');
+  fixture.githubReleases.get('v3.4.132').draft = true;
+  fixture.githubReleases.get('v3.4.133').assets[0].digest = `sha256:${'0'.repeat(64)}`;
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /v3\.4\.109 is missing a matching GitHub Release object/u);
+  assert.match(failures, /v3\.4\.132 GitHub Release must be published and non-prerelease/u);
+  assert.match(failures, /v3\.4\.133 GitHub Release asset size or digest does not match/u);
+});
+
+test('latest convenience manifests must match the highest immutable release', () => {
+  const fixture = baselineFixture();
+  fixture.latestSystemReleaseText = fixture.publishedReleases[3].manifestText;
+  fixture.artifactPaths.delete('release-intent.json');
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /latest system-release\.json does not match immutable v3\.4\.133/u);
+  assert.match(failures, /missing latest release-intent\.json/u);
+});
+
+test('published baseline compatibility metadata must match assets/press-system.json', () => {
+  const fixture = baselineFixture();
+  fixture.candidate.upgradeFrom = upgradeFrom('>=3.4.64 <3.4.133');
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /candidate v3\.4\.133 does not match the published release compatibility metadata/u);
+});
+
+test('candidate mode verifies the built ZIP root and embedded Press manifest', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.candidateArchive.entries.push('outside-root.txt');
+  fixture.candidateArchive.embeddedManifest.upgradeFrom = upgradeFrom('>=3.4.133 <3.4.134');
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /archive must contain exactly the press-system-v3\.4\.134\/ root/u);
+  assert.match(failures, /archive Press system manifest does not match the worktree candidate/u);
+});

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -29,6 +29,15 @@ if [[ ! -f "${zip_path}" ]]; then
   exit 1
 fi
 
+deterministic_zip_dir="${tmp_dir}/deterministic"
+mkdir -p "${deterministic_zip_dir}"
+sleep 2
+bash "${repo_root}/scripts/package-system-release.sh" "${version}" "${deterministic_zip_dir}" >/dev/null
+if ! cmp "${zip_path}" "${deterministic_zip_dir}/press-system-${version}.zip"; then
+  echo "system release package must be byte-for-byte reproducible for retry validation" >&2
+  exit 1
+fi
+
 subdir_zip_dir="${tmp_dir}/subdir"
 mkdir -p "${subdir_zip_dir}"
 (

--- a/scripts/test-system-release-transaction.mjs
+++ b/scripts/test-system-release-transaction.mjs
@@ -1,0 +1,322 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  classifySystemReleaseTransaction,
+  createCandidateReceipt,
+  validateReleaseAgainstReceipt
+} from './system-release-transaction.mjs';
+
+const SOURCE_SHA = '1'.repeat(40);
+const NEXT_SHA = '2'.repeat(40);
+const ARCHIVE = Buffer.from('candidate archive bytes');
+const DIGEST = `sha256:${crypto.createHash('sha256').update(ARCHIVE).digest('hex')}`;
+const TAG = 'v3.4.134';
+const ASSET_NAME = `press-system-${TAG}.zip`;
+
+function sourceManifest() {
+  return { schemaVersion: 1, type: 'press-system', version: '3.4.134', tag: TAG };
+}
+
+function release({ draft = true, id = 134, prerelease = false, sourceCommit = SOURCE_SHA } = {}) {
+  return {
+    id,
+    tag_name: TAG,
+    target_commitish: sourceCommit,
+    draft,
+    prerelease,
+    immutable: !draft,
+    published_at: draft ? null : '2026-07-10T00:00:00Z',
+    assets: [{ name: ASSET_NAME, size: ARCHIVE.length, digest: DIGEST }]
+  };
+}
+
+function receipt({ sourceCommit = SOURCE_SHA, id = 134 } = {}) {
+  return {
+    schemaVersion: 1,
+    type: 'press-system-release-candidate',
+    repository: 'EkilyHQ/Press',
+    version: '3.4.134',
+    tag: TAG,
+    sourceCommit,
+    releaseId: id,
+    stagedAt: '2026-07-10T00:00:00Z',
+    asset: {
+      name: ASSET_NAME,
+      path: `${TAG}/${ASSET_NAME}`,
+      size: ARCHIVE.length,
+      digest: DIGEST
+    }
+  };
+}
+
+function transaction(overrides = {}) {
+  return {
+    repository: 'EkilyHQ/Press',
+    sourceManifest: sourceManifest(),
+    sourceCommit: SOURCE_SHA,
+    rootManifest: { version: '3.4.133', tag: 'v3.4.133' },
+    candidateReceipt: null,
+    candidateArchive: null,
+    immutableManifestExists: false,
+    immutableIntentExists: false,
+    tagCommit: '',
+    releases: [],
+    ...overrides
+  };
+}
+
+test('fresh source commit starts a new append-only release transaction', () => {
+  const result = classifySystemReleaseTransaction(transaction());
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'new');
+});
+
+test('an existing same-commit draft is resumed without deleting it', () => {
+  const result = classifySystemReleaseTransaction(transaction({ releases: [release()] }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'resume-stage');
+  assert.equal(result.releaseId, 134);
+});
+
+test('staged draft resumes publication while root latest remains on the baseline', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    releases: [release()]
+  }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'resume-publish');
+  assert.equal(result.rootTag, 'v3.4.133');
+});
+
+test('published staged candidate resumes atomic latest promotion', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    tagCommit: SOURCE_SHA,
+    releases: [release({ draft: false })]
+  }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'resume-promote');
+});
+
+test('promoted same-commit transaction re-dispatches idempotently', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    rootManifest: { version: '3.4.134', tag: TAG },
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    immutableManifestExists: true,
+    immutableIntentExists: true,
+    tagCommit: SOURCE_SHA,
+    releases: [release({ draft: false })]
+  }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'dispatch');
+});
+
+test('a later main commit sees the promoted release as settled, not as a retry', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    sourceCommit: NEXT_SHA,
+    rootManifest: { version: '3.4.134', tag: TAG },
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    immutableManifestExists: true,
+    immutableIntentExists: true,
+    tagCommit: SOURCE_SHA,
+    releases: [release({ draft: false })]
+  }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'settled');
+});
+
+test('pre-transaction finalized releases remain valid settled history', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    sourceManifest: { schemaVersion: 1, type: 'press-system', version: '3.4.133', tag: 'v3.4.133' },
+    rootManifest: { version: '3.4.133', tag: 'v3.4.133' },
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    immutableManifestExists: true,
+    immutableIntentExists: true,
+    tagCommit: SOURCE_SHA,
+    releases: [{
+      ...release({ draft: false }),
+      tag_name: 'v3.4.133',
+      assets: [{ name: 'press-system-v3.4.133.zip', size: ARCHIVE.length, digest: DIGEST }]
+    }]
+  }));
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.action, 'settled');
+});
+
+test('post-migration finalized releases cannot lose their durable candidate receipt', () => {
+  const result = classifySystemReleaseTransaction(transaction({
+    rootManifest: { version: '3.4.134', tag: TAG },
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    immutableManifestExists: true,
+    immutableIntentExists: true,
+    tagCommit: SOURCE_SHA,
+    releases: [release({ draft: false })]
+  }));
+  assert.equal(result.action, 'blocked');
+  assert.match(result.failures.join('\n'), /must retain release-candidate\.json/u);
+});
+
+test('all duplicate release combinations fail closed with release ids', () => {
+  for (const pair of [
+    [release({ id: 1 }), release({ id: 2 })],
+    [release({ id: 1 }), release({ id: 2, draft: false })],
+    [release({ id: 1, draft: false }), release({ id: 2, draft: false })]
+  ]) {
+    const result = classifySystemReleaseTransaction(transaction({ releases: pair }));
+    assert.equal(result.action, 'blocked');
+    assert.match(result.failures.join('\n'), /duplicate GitHub Release objects: 1, 2/u);
+  }
+});
+
+test('partial staging and premature latest exposure fail closed', () => {
+  const partial = classifySystemReleaseTransaction(transaction({
+    immutableManifestExists: true
+  }));
+  assert.match(partial.failures.join('\n'), /partial immutable manifest tuple/u);
+
+  const exposed = classifySystemReleaseTransaction(transaction({
+    rootManifest: { version: '3.4.134', tag: TAG },
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    tagCommit: SOURCE_SHA,
+    releases: [release()]
+  }));
+  assert.match(exposed.failures.join('\n'), /without one published non-prerelease GitHub Release/u);
+});
+
+test('orphan tags, missing receipts, and wrong commits require manual recovery', () => {
+  const orphanTag = classifySystemReleaseTransaction(transaction({ tagCommit: SOURCE_SHA }));
+  assert.match(orphanTag.failures.join('\n'), /has no GitHub Release/u);
+
+  const publishedWithoutReceipt = classifySystemReleaseTransaction(transaction({
+    tagCommit: SOURCE_SHA,
+    releases: [release({ draft: false })]
+  }));
+  assert.match(publishedWithoutReceipt.failures.join('\n'), /has no staged receipt/u);
+
+  const wrongCommit = classifySystemReleaseTransaction(transaction({
+    candidateReceipt: receipt(),
+    candidateArchive: { size: ARCHIVE.length, digest: DIGEST },
+    tagCommit: NEXT_SHA,
+    releases: [release()]
+  }));
+  assert.match(wrongCommit.failures.join('\n'), /not release transaction commit/u);
+});
+
+test('candidate receipt binds the draft release, source commit, and archive digest', () => {
+  const created = createCandidateReceipt({
+    repository: 'EkilyHQ/Press',
+    sourceManifest: sourceManifest(),
+    sourceCommit: SOURCE_SHA,
+    release: release(),
+    archive: ARCHIVE,
+    stagedAt: '2026-07-10T00:00:00Z'
+  });
+  assert.equal(created.asset.digest, DIGEST);
+  assert.equal(created.releaseId, 134);
+
+  const existingTagReceipt = createCandidateReceipt({
+    repository: 'EkilyHQ/Press',
+    sourceManifest: sourceManifest(),
+    sourceCommit: SOURCE_SHA,
+    tagCommit: SOURCE_SHA,
+    release: { ...release(), target_commitish: 'main' },
+    archive: ARCHIVE
+  });
+  assert.equal(existingTagReceipt.sourceCommit, SOURCE_SHA);
+
+  assert.throws(() => createCandidateReceipt({
+    repository: 'EkilyHQ/Press',
+    sourceManifest: sourceManifest(),
+    sourceCommit: SOURCE_SHA,
+    release: { ...release(), assets: [{ name: ASSET_NAME, size: ARCHIVE.length, digest: `sha256:${'0'.repeat(64)}` }] },
+    archive: ARCHIVE
+  }), /does not match the built archive/u);
+});
+
+test('fresh pre- and post-publication snapshots must match the immutable receipt', () => {
+  assert.deepEqual(validateReleaseAgainstReceipt(release(), receipt(), {
+    expectedState: 'draft'
+  }), []);
+  assert.deepEqual(validateReleaseAgainstReceipt(release({ draft: false }), receipt(), {
+    expectedState: 'published',
+    tagCommit: SOURCE_SHA
+  }), []);
+  assert.match(validateReleaseAgainstReceipt(release(), receipt(), {
+    expectedState: 'published',
+    tagCommit: SOURCE_SHA
+  }).join('\n'), /is not published/u);
+  assert.match(validateReleaseAgainstReceipt({
+    ...release({ draft: false }),
+    immutable: false
+  }, receipt(), {
+    expectedState: 'published',
+    tagCommit: SOURCE_SHA
+  }).join('\n'), /must be immutable/u);
+});
+
+test('release automation contains no destructive Release or tag cleanup path', () => {
+  const workflow = fs.readFileSync(new URL('../.github/workflows/system-release.yml', import.meta.url), 'utf8');
+  const helper = fs.readFileSync(new URL('./system-release-transaction.mjs', import.meta.url), 'utf8');
+  for (const source of [workflow, helper]) {
+    assert.doesNotMatch(source, /--method\s+DELETE\b/u);
+    assert.doesNotMatch(source, /gh\s+release\s+delete\b/u);
+    assert.doesNotMatch(source, /git\s+push\s+--delete\b/u);
+    assert.doesNotMatch(source, /(?:\s|["']):refs\/tags\//u);
+  }
+});
+
+test('atomic artifact promotion refuses a moved tag without updating latest pointers', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'press-release-promotion-'));
+  const remote = path.join(root, 'remote.git');
+  const first = path.join(root, 'first');
+  const second = path.join(root, 'second');
+  const git = (cwd, args) => execFileSync('git', args, { cwd, stdio: 'ignore' });
+  git(root, ['init', '-q', '--bare', remote]);
+  git(root, ['clone', '-q', remote, first]);
+  git(first, ['config', 'user.name', 'Release Transaction Test']);
+  git(first, ['config', 'user.email', 'release-transaction@example.test']);
+  fs.writeFileSync(path.join(first, 'artifact'), 'baseline');
+  git(first, ['add', 'artifact']);
+  git(first, ['commit', '-qm', 'baseline']);
+  git(first, ['tag', TAG]);
+  git(first, ['push', '-q', 'origin', 'HEAD:release-artifacts', `refs/tags/${TAG}:refs/tags/${TAG}`]);
+  const expectedTag = execFileSync('git', ['rev-parse', `refs/tags/${TAG}`], { cwd: first, encoding: 'utf8' }).trim();
+
+  fs.writeFileSync(path.join(first, 'artifact'), 'candidate');
+  git(first, ['commit', '-qam', 'candidate']);
+  git(root, ['clone', '-q', remote, second]);
+  git(second, ['config', 'user.name', 'Concurrent Publisher']);
+  git(second, ['config', 'user.email', 'concurrent@example.test']);
+  git(second, ['fetch', '-q', 'origin', 'release-artifacts']);
+  git(second, ['checkout', '-q', '-B', 'race', 'FETCH_HEAD']);
+  fs.writeFileSync(path.join(second, 'race'), 'moved tag');
+  git(second, ['add', 'race']);
+  git(second, ['commit', '-qm', 'move tag']);
+  git(second, ['tag', '-f', TAG]);
+  git(second, ['push', '-q', '--force', 'origin', `refs/tags/${TAG}:refs/tags/${TAG}`]);
+
+  const branchBefore = execFileSync('git', [`--git-dir=${remote}`, 'rev-parse', 'release-artifacts'], { encoding: 'utf8' }).trim();
+  const result = spawnSync('git', [
+    'push',
+    '--atomic',
+    `--force-with-lease=refs/tags/${TAG}:${expectedTag}`,
+    'origin',
+    'HEAD:release-artifacts',
+    `refs/tags/${TAG}:refs/tags/${TAG}`
+  ], { cwd: first, stdio: 'ignore' });
+  assert.notEqual(result.status, 0);
+  const branchAfter = execFileSync('git', [`--git-dir=${remote}`, 'rev-parse', 'release-artifacts'], { encoding: 'utf8' }).trim();
+  assert.equal(branchAfter, branchBefore);
+  fs.rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -235,9 +235,10 @@ if ! grep -F 'node scripts/release-graph.js --mode audit --artifact-ref origin/r
 fi
 
 if ! grep -F 'node scripts/test-release-graph.js' "${main_workflow}" >/dev/null \
-  || ! grep -F 'node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check' "${main_workflow}" >/dev/null \
+  || ! grep -F 'candidate_archive="$(PRESS_PACKAGE_SOURCE=worktree bash scripts/package-system-release.sh "${candidate_tag}" "${RUNNER_TEMP}/release-graph-candidate")"' "${main_workflow}" >/dev/null \
+  || ! grep -F 'node scripts/release-graph.js --mode auto --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check' "${main_workflow}" >/dev/null \
   || ! grep -F 'bash scripts/test-system-release-workflow.sh' "${main_workflow}" >/dev/null; then
-  echo "main guard must run focused release graph tests, live audit, and workflow wiring checks" >&2
+  echo "main guard must run focused release graph tests, package the worktree, validate audit-or-candidate state, and check workflow wiring" >&2
   exit 1
 fi
 

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -229,27 +229,54 @@ if ! grep -F -- '--github-releases "${RUNNER_TEMP}/press-github-releases.json"' 
   exit 1
 fi
 
-if ! grep -F 'node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check' "${workflow}" >/dev/null; then
+if ! grep -F -- '--mode audit' "${workflow}" >/dev/null \
+  || ! grep -F 'node scripts/release-graph.js "${graph_args[@]}"' "${workflow}" >/dev/null; then
   echo "system release workflow must audit the published release graph before planning a release" >&2
   exit 1
 fi
 
 if ! grep -F 'node scripts/test-release-graph.js' "${main_workflow}" >/dev/null \
   || ! grep -F 'candidate_archive="$(PRESS_PACKAGE_SOURCE=worktree bash scripts/package-system-release.sh "${candidate_tag}" "${RUNNER_TEMP}/release-graph-candidate")"' "${main_workflow}" >/dev/null \
-  || ! grep -F 'node scripts/release-graph.js --mode auto --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check' "${main_workflow}" >/dev/null \
+  || ! grep -F 'node scripts/release-graph.js --mode "${validation_mode}" --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --candidate-archive "${candidate_archive}" --check' "${main_workflow}" >/dev/null \
   || ! grep -F 'bash scripts/test-system-release-workflow.sh' "${main_workflow}" >/dev/null; then
   echo "main guard must run focused release graph tests, package the worktree, validate audit-or-candidate state, and check workflow wiring" >&2
   exit 1
 fi
+if ! grep -F 'validation_mode="candidate"' "${main_workflow}" >/dev/null \
+  || ! grep -F 'github.event.pull_request.base.sha' "${main_workflow}" >/dev/null \
+  || ! grep -F 'release_plan_paths[@]' "${main_workflow}" >/dev/null; then
+  echo "main guard must force candidate validation whenever the release-plan surface changes" >&2
+  exit 1
+fi
+if grep -F '${{ steps.plan.outputs.changed_files }}' "${workflow}" >/dev/null \
+  || ! grep -F 'dist/release-changed-files.txt' "${workflow}" >/dev/null; then
+  echo "release notes must pass changed paths through a file instead of shell expression interpolation" >&2
+  exit 1
+fi
 
-if ! grep -F -- '--mode candidate' "${workflow}" >/dev/null || ! grep -F -- '--candidate-archive "${{ steps.package.outputs.archive_path }}"' "${workflow}" >/dev/null; then
+if ! grep -F 'node scripts/test-system-release-transaction.mjs' "${main_workflow}" >/dev/null; then
+  echo "main guard must run the append-only release transaction tests" >&2
+  exit 1
+fi
+if ! grep -F 'bash scripts/test-system-release-package.sh' "${main_workflow}" >/dev/null; then
+  echo "main guard must prove system packages are reproducible before merge" >&2
+  exit 1
+fi
+if grep -F 'git push' "${main_workflow}" >/dev/null; then
+  echo "main guard transient tag handling must remain read-only on the remote" >&2
+  exit 1
+fi
+
+if ! grep -F -- '--mode candidate' "${workflow}" >/dev/null \
+  || ! grep -F -- '--candidate-archive "${CANDIDATE_ARCHIVE}"' "${workflow}" >/dev/null \
+  || ! grep -F 'steps.package.outputs.archive_path || steps.staged_package.outputs.archive_path' "${workflow}" >/dev/null; then
   echo "system release workflow must verify the built candidate archive against the release graph" >&2
   exit 1
 fi
 
 build_line="$(grep -nF -- '- name: Build system update package' "${workflow}" | cut -d: -f1)"
 candidate_line="$(grep -nF -- '- name: Verify release graph candidate' "${workflow}" | cut -d: -f1)"
-draft_line="$(grep -nF -- '- name: Create draft release' "${workflow}" | cut -d: -f1)"
+draft_line="$(grep -nF -- '- name: Ensure draft release and asset' "${workflow}" | cut -d: -f1)"
 if [[ -z "${build_line}" || -z "${candidate_line}" || -z "${draft_line}"
   || "${candidate_line}" -le "${build_line}" || "${candidate_line}" -ge "${draft_line}" ]]; then
   echo "release graph candidate verification must run after package build and before draft release creation" >&2
@@ -301,8 +328,8 @@ if grep -F 'releases/tags/${NEXT_TAG}' "${workflow}" >/dev/null; then
   exit 1
 fi
 
-if ! grep -F 'steps.create.outputs.release_id' "${workflow}" >/dev/null; then
-  echo "system release workflow must validate and publish the draft release by release id" >&2
+if ! grep -F 'repos/${GITHUB_REPOSITORY}/releases/${release_id}' "${workflow}" >/dev/null; then
+  echo "system release workflow must validate and publish the draft release by immutable release id" >&2
   exit 1
 fi
 
@@ -336,28 +363,28 @@ if ! grep -F 'uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_i
   exit 1
 fi
 
-if ! grep -F 'stale-draft-release-ids.txt' "${workflow}" >/dev/null; then
-  echo "system release workflow must clean stale draft releases for retry safety" >&2
+if ! grep -F 'node scripts/system-release-transaction.mjs inspect' "${workflow}" >/dev/null \
+  || ! grep -F 'node scripts/test-system-release-transaction.mjs' "${workflow}" >/dev/null; then
+  echo "release workflows must run the tested append-only transaction state machine" >&2
   exit 1
 fi
 
-if grep -F 'release.get("name") == next_tag' "${workflow}" >/dev/null; then
-  echo "system release workflow must identify stale releases by tag_name, not editable release names" >&2
+transaction_step_line="$(grep -nF -- '- name: Inspect release transaction' "${workflow}" | head -n 1 | cut -d: -f1)"
+graph_audit_step_line="$(grep -nF -- '- name: Verify release package boundary' "${workflow}" | head -n 1 | cut -d: -f1)"
+if [[ -z "${transaction_step_line}" || -z "${graph_audit_step_line}" \
+  || "${transaction_step_line}" -ge "${graph_audit_step_line}" ]]; then
+  echo "system release workflow must classify retries before graph audit" >&2
   exit 1
 fi
 
-if ! grep -F 'release.get("tag_name") == next_tag' "${workflow}" >/dev/null; then
-  echo "system release workflow must match stale draft releases by tag_name" >&2
+if ! grep -F -- '--transient-candidate-version "${CANDIDATE_VERSION}"' "${workflow}" >/dev/null; then
+  echo "interrupted transactions must audit the canonical baseline without promoting the candidate" >&2
   exit 1
 fi
 
-if ! grep -F 'git push --delete origin "${next_tag}"' "${workflow}" >/dev/null; then
-  echo "system release workflow must delete stale release tags before retrying" >&2
-  exit 1
-fi
-
-if ! grep -F 'git tag -d "${next_tag}"' "${workflow}" >/dev/null; then
-  echo "system release workflow must delete stale local release tags before retrying" >&2
+if grep -F -- '--method DELETE' "${workflow}" >/dev/null \
+  || grep -F 'git push --delete' "${workflow}" >/dev/null; then
+  echo "system release retries must never delete Release or tag state" >&2
   exit 1
 fi
 
@@ -366,8 +393,26 @@ if grep -F 'Update static release manifest' "${workflow}" >/dev/null; then
   exit 1
 fi
 
-if ! grep -F 'Publish fetchable artifact' "${workflow}" >/dev/null; then
-  echo "system release workflow must publish a CORS-readable system package artifact" >&2
+if ! grep -F 'Stage candidate artifact' "${workflow}" >/dev/null \
+  || ! grep -F 'Promote latest release artifacts' "${workflow}" >/dev/null; then
+  echo "system release workflow must stage candidate bytes separately from latest promotion" >&2
+  exit 1
+fi
+
+stage_step="$(awk '
+  /- name: Stage candidate artifact/ { in_step = 1 }
+  /- name: Publish release/ { in_step = 0 }
+  in_step { print }
+' "${workflow}")"
+if grep -F 'system-release.json' <<< "${stage_step}" >/dev/null \
+  || grep -F 'release-intent.json' <<< "${stage_step}" >/dev/null \
+  || grep -F 'product-state' <<< "${stage_step}" >/dev/null; then
+  echo "candidate staging must not expose final manifests or root latest pointers" >&2
+  exit 1
+fi
+if ! grep -F 'release-candidate.json' <<< "${stage_step}" >/dev/null \
+  || ! grep -F 'git -C artifacts-worktree add "${artifact_path}" "${receipt_path}"' <<< "${stage_step}" >/dev/null; then
+  echo "candidate staging must commit only the ZIP and its transaction receipt" >&2
   exit 1
 fi
 
@@ -381,27 +426,22 @@ if ! grep -F 'artifact_url="https://raw.githubusercontent.com/${GITHUB_REPOSITOR
   exit 1
 fi
 
-if ! grep -F 'manifest_path="system-release.json"' "${workflow}" >/dev/null; then
-  echo "system release workflow must publish the static manifest at the release-artifacts root" >&2
-  exit 1
-fi
-
 if ! grep -F 'immutable_manifest_path="${tag}/system-release.json"' "${workflow}" >/dev/null; then
   echo "system release workflow must publish an immutable tag-scoped system-release manifest" >&2
   exit 1
 fi
 
-if ! grep -F 'release_intent_path="release-intent.json"' "${workflow}" >/dev/null || ! grep -F 'immutable_release_intent_path="${tag}/release-intent.json"' "${workflow}" >/dev/null; then
+if ! grep -F 'immutable_release_intent_path="${tag}/release-intent.json"' "${workflow}" >/dev/null; then
   echo "system release workflow must publish latest and immutable release intent manifests" >&2
   exit 1
 fi
 
-if ! grep -F 'product_state_path="product-state.json"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/product-state.json artifacts-worktree/product-state.json' "${workflow}" >/dev/null; then
   echo "system release workflow must publish the product-state ledger at the release-artifacts root" >&2
   exit 1
 fi
 
-if ! grep -F 'product_state_dashboard_path="product-state.html"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/product-state.html artifacts-worktree/product-state.html' "${workflow}" >/dev/null; then
   echo "system release workflow must publish the product-state dashboard at the release-artifacts root" >&2
   exit 1
 fi
@@ -423,6 +463,12 @@ fi
 
 if ! grep -F '"version": version' "${workflow}" >/dev/null; then
   echo "system release manifest must publish the explicit Press version" >&2
+  exit 1
+fi
+
+if ! grep -F '"publishedAt": published_at' "${workflow}" >/dev/null \
+  || grep -F 'release.get("published_at") or release.get("created_at")' "${workflow}" >/dev/null; then
+  echo "final immutable manifests must record the actual GitHub publication time" >&2
   exit 1
 fi
 
@@ -501,7 +547,7 @@ if ! grep -F -- '--out dist/product-state.html' "${workflow}" >/dev/null; then
   exit 1
 fi
 
-if ! grep -F 'cp dist/system-release.json "artifacts-worktree/${manifest_path}"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/system-release.json artifacts-worktree/system-release.json' "${workflow}" >/dev/null; then
   echo "system release workflow must copy the manifest into release-artifacts" >&2
   exit 1
 fi
@@ -511,36 +557,58 @@ if ! grep -F 'cp dist/system-release.json "artifacts-worktree/${immutable_manife
   exit 1
 fi
 
-if ! grep -F 'cp dist/release-intent.json "artifacts-worktree/${immutable_release_intent_path}"' "${workflow}" >/dev/null || ! grep -F 'cp dist/release-intent.json "artifacts-worktree/${release_intent_path}"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/release-intent.json "artifacts-worktree/${immutable_release_intent_path}"' "${workflow}" >/dev/null || ! grep -F 'cp dist/release-intent.json artifacts-worktree/release-intent.json' "${workflow}" >/dev/null; then
   echo "system release workflow must copy immutable and latest release intent manifests into release-artifacts" >&2
   exit 1
 fi
 
-if ! grep -F 'cp dist/product-state.json "artifacts-worktree/${product_state_path}"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/product-state.json artifacts-worktree/product-state.json' "${workflow}" >/dev/null; then
   echo "system release workflow must copy the product-state ledger into release-artifacts" >&2
   exit 1
 fi
 
-if ! grep -F 'cp dist/product-state.html "artifacts-worktree/${product_state_dashboard_path}"' "${workflow}" >/dev/null; then
+if ! grep -F 'cp dist/product-state.html artifacts-worktree/product-state.html' "${workflow}" >/dev/null; then
   echo "system release workflow must copy the product-state dashboard into release-artifacts" >&2
   exit 1
 fi
 
-if ! grep -F 'git -C artifacts-worktree add "${artifact_path}" "${manifest_path}" "${immutable_manifest_path}" "${immutable_release_intent_path}" "${release_intent_path}" "${product_state_path}" "${product_state_dashboard_path}"' "${workflow}" >/dev/null; then
-  echo "system release workflow must commit the ZIP, manifest, release intent, product-state ledger, and dashboard together on release-artifacts" >&2
+if ! grep -F 'git -C artifacts-worktree add "${artifact_path}" "${receipt_path}"' "${workflow}" >/dev/null \
+  || ! grep -F 'git -C artifacts-worktree add \' "${workflow}" >/dev/null; then
+  echo "system release workflow must use separate candidate-stage and latest-promotion commits" >&2
   exit 1
 fi
 
 publish_line="$(grep -nF -- '- name: Publish release' "${workflow}" | head -n 1 | cut -d: -f1)"
-artifact_line="$(grep -nF -- '- name: Publish fetchable artifact' "${workflow}" | head -n 1 | cut -d: -f1)"
+artifact_line="$(grep -nF -- '- name: Stage candidate artifact' "${workflow}" | head -n 1 | cut -d: -f1)"
+promote_line="$(grep -nF -- '- name: Promote latest release artifacts' "${workflow}" | head -n 1 | cut -d: -f1)"
 dispatch_line="$(grep -nF -- '- name: Dispatch release targets' "${workflow}" | head -n 1 | cut -d: -f1)"
 theme_contract_package_line="$(grep -nF -- '- name: Publish theme contract package' "${workflow}" | head -n 1 | cut -d: -f1)"
-if [[ -z "${publish_line}" || -z "${artifact_line}" || -z "${dispatch_line}" || "${publish_line}" -ge "${artifact_line}" || "${artifact_line}" -ge "${dispatch_line}" ]]; then
-  echo "system release workflow must publish the release-artifacts manifest after release publication and before release dispatches" >&2
+if [[ -z "${publish_line}" || -z "${artifact_line}" || -z "${promote_line}" || -z "${dispatch_line}" \
+  || "${artifact_line}" -ge "${publish_line}" || "${publish_line}" -ge "${promote_line}" \
+  || "${promote_line}" -ge "${dispatch_line}" ]]; then
+  echo "system release workflow must stage, publish, promote, then dispatch in order" >&2
   exit 1
 fi
-if [[ -z "${theme_contract_package_line}" || "${theme_contract_package_line}" -ge "${publish_line}" ]]; then
-  echo "system release workflow must publish the theme contract package before publishing the GitHub Release" >&2
+if [[ -z "${theme_contract_package_line}" || "${theme_contract_package_line}" -ge "${artifact_line}" ]]; then
+  echo "system release workflow must publish the theme contract package before staging release artifacts" >&2
+  exit 1
+fi
+
+if ! grep -F '{"draft":false,"make_latest":"true"}' "${workflow}" >/dev/null \
+  || grep -F -- '- name: Mark GitHub Release latest' "${workflow}" >/dev/null \
+  || grep -F -- '- name: Reconcile finalized GitHub latest' "${workflow}" >/dev/null; then
+  echo "immutable GitHub Releases must choose latest status in the publication request" >&2
+  exit 1
+fi
+if ! grep -F 'published candidate GitHub Release must be immutable' scripts/system-release-transaction.mjs >/dev/null; then
+  echo "root promotion must require the repository immutable-release policy" >&2
+  exit 1
+fi
+if ! grep -F -- '--artifact-ref "${promotion_commit}"' "${workflow}" >/dev/null \
+  || ! grep -F 'releases-before-artifact-push.json' "${workflow}" >/dev/null \
+  || ! grep -F -- '--atomic' "${workflow}" >/dev/null \
+  || ! grep -F -- '--force-with-lease="refs/tags/${tag}:${tag_ref_oid}"' "${workflow}" >/dev/null; then
+  echo "local promotion must pass a fresh full audit and atomically assert the release tag before push" >&2
   exit 1
 fi
 
@@ -703,9 +771,8 @@ if grep -F 'git push origin "HEAD:${GITHUB_REF_NAME}"' "${workflow}" >/dev/null;
   exit 1
 fi
 
-stale_cleanup_line="$(grep -nF 'stale-draft-release-ids.txt' "${workflow}" | head -n 1 | cut -d: -f1)"
-tag_refusal_line="$(grep -nF 'Refusing to overwrite existing tag' "${workflow}" | head -n 1 | cut -d: -f1)"
-if [[ -n "${tag_refusal_line}" && -n "${stale_cleanup_line}" && "${tag_refusal_line}" -lt "${stale_cleanup_line}" ]]; then
-  echo "system release workflow must clean stale drafts and tags before refusing an existing tag" >&2
+if ! grep -F 'candidate receipt' scripts/system-release-transaction.mjs >/dev/null \
+  || ! grep -F 'manual recovery is required' scripts/system-release-transaction.mjs >/dev/null; then
+  echo "unsafe or ambiguous retry states must fail closed with a manual recovery signal" >&2
   exit 1
 fi

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 workflow=".github/workflows/system-release.yml"
+main_workflow=".github/workflows/main-guard.yml"
 
 if [[ ! -f "${workflow}" ]]; then
   echo "expected ${workflow} to exist" >&2
@@ -210,6 +211,47 @@ fi
 
 if ! grep -F 'node scripts/test-release-intent.js' "${workflow}" >/dev/null; then
   echo "system release workflow must verify release intent helpers before publishing" >&2
+  exit 1
+fi
+
+if ! grep -F "git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'" "${workflow}" >/dev/null; then
+  echo "system release workflow must fetch the versioned release artifact registry before graph verification" >&2
+  exit 1
+fi
+
+if ! grep -F 'node scripts/test-release-graph.js' "${workflow}" >/dev/null; then
+  echo "system release workflow must run focused release graph policy tests before publishing" >&2
+  exit 1
+fi
+
+if ! grep -F -- '--github-releases "${RUNNER_TEMP}/press-github-releases.json"' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify published GitHub Release objects" >&2
+  exit 1
+fi
+
+if ! grep -F 'node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check' "${workflow}" >/dev/null; then
+  echo "system release workflow must audit the published release graph before planning a release" >&2
+  exit 1
+fi
+
+if ! grep -F 'node scripts/test-release-graph.js' "${main_workflow}" >/dev/null \
+  || ! grep -F 'node scripts/release-graph.js --mode audit --artifact-ref origin/release-artifacts --github-releases "${RUNNER_TEMP}/press-github-releases.json" --check' "${main_workflow}" >/dev/null \
+  || ! grep -F 'bash scripts/test-system-release-workflow.sh' "${main_workflow}" >/dev/null; then
+  echo "main guard must run focused release graph tests, live audit, and workflow wiring checks" >&2
+  exit 1
+fi
+
+if ! grep -F -- '--mode candidate' "${workflow}" >/dev/null || ! grep -F -- '--candidate-archive "${{ steps.package.outputs.archive_path }}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must verify the built candidate archive against the release graph" >&2
+  exit 1
+fi
+
+build_line="$(grep -nF -- '- name: Build system update package' "${workflow}" | cut -d: -f1)"
+candidate_line="$(grep -nF -- '- name: Verify release graph candidate' "${workflow}" | cut -d: -f1)"
+draft_line="$(grep -nF -- '- name: Create draft release' "${workflow}" | cut -d: -f1)"
+if [[ -z "${build_line}" || -z "${candidate_line}" || -z "${draft_line}"
+  || "${candidate_line}" -le "${build_line}" || "${candidate_line}" -ge "${draft_line}" ]]; then
+  echo "release graph candidate verification must run after package build and before draft release creation" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

- add a versioned release-graph policy with a supported floor of `v3.4.64`
- record the unpublished `v3.4.65`–`v3.4.107` gap as explicit recovery debt
- audit Git tags, tagged Press manifests, immutable release manifests, root latest manifests, immutable GitHub Release objects, and ZIP size/digests
- block every candidate newer than `v3.4.133` until a dedicated direct recovery transition closes the recorded debt
- make System Release append-only and retry-safe with explicit `new`, `resume-stage`, `resume-publish`, `resume-promote`, `dispatch`, and `settled` states
- stage only the candidate ZIP and SHA-bound receipt before publication; publish final tag-scoped manifests and root latest pointers only after the GitHub Release is immutable
- audit the local promotion commit against a fresh Release/tag snapshot, then atomically push `release-artifacts` while asserting the release tag OID with a lease
- make system ZIPs byte-for-byte reproducible and reuse the staged ZIP on publication retries
- force Main Guard into candidate mode whenever the shared release-plan surface changes, so a missing version bump fails before merge

## Why

The browser updater is latest-only. The published sequence jumps from `v3.4.64` to `v3.4.108`, while `v3.4.108` requires unpublished `v3.4.107`. Older sites therefore have no installable path to the current release.

The release workflow also needed a safe answer for interrupted runs. Automatic deletion of draft Releases or tags cannot be made race-free against publication, so retries now reuse only state that is provably bound to the same source commit, Release id, asset size, and SHA-256 digest. Ambiguous, duplicate, orphaned, or cross-SHA state fails closed for manual recovery.

## Impact

This is release tooling only. It does not modify `assets/**`, the Press runtime, the system package surface, or the Press version. It intentionally stops the next release-bearing candidate until the recovery transition is implemented and verified.

## Verification

- `node scripts/test-release-graph.js` — 29/29
- `node scripts/test-system-release-transaction.mjs` — 15/15
- `bash scripts/test-system-release-package.sh` — includes an interval-separated byte reproducibility check
- `bash scripts/test-system-release-workflow.sh`
- live audit of 27 supported GitHub Releases and `origin/release-artifacts`
- System Release boundary suite
- `actionlint` on Main Guard and System Release
- YAML parse plus `bash -n` for every embedded run step
- `git diff --check`

The live audit reports the expected state: `KNOWN LEGACY BREAK: 25 supported sources remain recovery-blocked`.

## Review

Three independent review passes covered the transaction state matrix, GitHub immutable-release semantics, tag/Release races, candidate gate behavior, shell injection, artifact promotion ordering, and retry recovery. No P0–P2 blockers remain locally; the PR stays draft until latest-head CI and automated review clear.
