### PR TITLE
Restore direct update recovery

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js 22.18.0

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -77,10 +77,7 @@ jobs:
           next_tag="v${source_version}"
 
           case "${TRANSACTION_ACTION}" in
-            resume-stage|resume-publish)
-              changed_files="Resume interrupted ${next_tag} release transaction"
-              ;;
-            resume-promote|dispatch)
+            dispatch)
               {
                 echo "should_release=false"
                 echo "latest_tag=${latest_tag}"
@@ -89,7 +86,7 @@ jobs:
               } >> "${GITHUB_OUTPUT}"
               exit 0
               ;;
-            new|settled)
+            new|settled|resume-stage|resume-publish|resume-promote)
               release_plan_paths_file="$(mktemp)"
               node scripts/print-press-system-surface.mjs release-plan-paths > "${release_plan_paths_file}"
               release_plan_paths=()
@@ -110,6 +107,16 @@ jobs:
 
           mkdir -p dist
           printf '%s\n' "${changed_files}" > dist/release-changed-files.txt
+
+          if [[ "${TRANSACTION_ACTION}" == "resume-promote" ]]; then
+            {
+              echo "should_release=false"
+              echo "latest_tag=${latest_tag}"
+              echo "next_tag=${next_tag}"
+              echo "asset_name=press-system-${next_tag}.zip"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
 
           if [[ -z "${changed_files}" ]]; then
             {
@@ -186,6 +193,53 @@ jobs:
           esac
           node scripts/release-graph.js "${graph_args[@]}"
 
+      - name: Prepare deterministic release presentation
+        if: steps.plan.outputs.should_release == 'true' || steps.transaction.outputs.action == 'resume-promote'
+        id: presentation
+        env:
+          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
+          LATEST_TAG: ${{ steps.plan.outputs.latest_tag }}
+          ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
+          ARCHIVE_DIGEST: ${{ steps.package.outputs.archive_sha256 || steps.staged_package.outputs.archive_sha256 || steps.transaction.outputs.asset_digest }}
+        run: |
+          set -euo pipefail
+          archive_sha256="${ARCHIVE_DIGEST#sha256:}"
+          if [[ ! "${archive_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "release presentation requires a valid SHA-256 digest" >&2
+            exit 1
+          fi
+          security_update="$(node -e "const system = require('./assets/press-system.json'); if (typeof system.securityUpdate !== 'boolean') throw new Error('assets/press-system.json securityUpdate must be an explicit boolean'); process.stdout.write(system.securityUpdate ? 'true' : 'false');")"
+          release_title="${NEXT_TAG}"
+          if [[ "${security_update}" == "true" ]]; then
+            release_title="Press Security Update ${NEXT_TAG}"
+          fi
+
+          notes_file="dist/release-notes.md"
+          {
+            if [[ "${security_update}" == "true" ]]; then
+              echo '> [!IMPORTANT]'
+              echo '> **Security update.** Apply this release promptly through the Press System Updates tool.'
+              echo
+            fi
+            echo "## Migration Guide"
+            echo
+            echo "Use the System Updates tool in Markdown Editor to download and apply \`${ASSET_NAME}\`."
+            echo
+            echo "## System Package"
+            echo
+            echo "- Asset: \`${ASSET_NAME}\`"
+            echo "- SHA-256: \`${archive_sha256}\`"
+            echo
+            echo "## Changed System Files"
+            echo
+            while IFS= read -r changed_file; do
+              printf -- '- %s\n' "${changed_file}"
+            done < dist/release-changed-files.txt
+            echo
+            echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${LATEST_TAG}...${NEXT_TAG}"
+          } > "${notes_file}"
+          echo "release_title=${release_title}" >> "${GITHUB_OUTPUT}"
+
       - name: Ensure draft release and asset
         if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage')
         id: draft
@@ -197,28 +251,10 @@ jobs:
           ARCHIVE_PATH: ${{ steps.package.outputs.archive_path }}
           ARCHIVE_SIZE: ${{ steps.package.outputs.archive_size }}
           ARCHIVE_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+          RELEASE_TITLE: ${{ steps.presentation.outputs.release_title }}
+          RELEASE_NOTES_FILE: dist/release-notes.md
         run: |
           set -euo pipefail
-          notes_file="dist/release-notes.md"
-          {
-            echo "## Migration Guide"
-            echo
-            echo "Use the System Updates tool in Markdown Editor to download and apply \`${ASSET_NAME}\`."
-            echo
-            echo "## System Package"
-            echo
-            echo "- Asset: \`${ASSET_NAME}\`"
-            echo "- SHA-256: \`${ARCHIVE_SHA256}\`"
-            echo
-            echo "## Changed System Files"
-            echo
-            while IFS= read -r changed_file; do
-              printf -- '- %s\n' "${changed_file}"
-            done < dist/release-changed-files.txt
-            echo
-            echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${LATEST_TAG}...${NEXT_TAG}"
-          } > "${notes_file}"
-
           git fetch --no-tags origin '+refs/heads/release-artifacts:refs/remotes/origin/release-artifacts'
           git fetch --force --tags origin
           gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-draft.json
@@ -232,7 +268,6 @@ jobs:
           release_id="$(node -e "const state = require('./dist/pre-draft-transaction.json'); process.stdout.write(String(state.releaseId || ''));")"
 
           if [[ "${current_action}" == "new" ]]; then
-            export RELEASE_NOTES_FILE="${notes_file}"
             python3 - <<'PY' > dist/create-release.json
           import json
           import os
@@ -241,7 +276,7 @@ jobs:
           print(json.dumps({
               "tag_name": os.environ["NEXT_TAG"],
               "target_commitish": os.environ["GITHUB_SHA"],
-              "name": os.environ["NEXT_TAG"],
+              "name": os.environ["RELEASE_TITLE"],
               "body": Path(os.environ["RELEASE_NOTES_FILE"]).read_text(encoding="utf-8"),
               "draft": True,
               "prerelease": False
@@ -255,6 +290,7 @@ jobs:
           fi
 
           gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-before-asset.json
+          node -e "const fs = require('node:fs'); const release = require('./dist/release-before-asset.json'); const expectedBody = fs.readFileSync(process.env.RELEASE_NOTES_FILE, 'utf8'); if (String(release.name || '') !== process.env.RELEASE_TITLE || String(release.body || '') !== expectedBody) throw new Error('draft release title or body does not match deterministic presentation metadata');"
           asset_count="$(EXPECTED_ASSET="${ASSET_NAME}" node -e "const release = require('./dist/release-before-asset.json'); const matches = (release.assets || []).filter((asset) => asset.name === process.env.EXPECTED_ASSET); process.stdout.write(String(matches.length));")"
           if [[ "${asset_count}" == "0" ]]; then
             curl --fail-with-body --silent --show-error --request POST \
@@ -336,6 +372,8 @@ jobs:
         if: steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TITLE: ${{ steps.presentation.outputs.release_title }}
+          RELEASE_NOTES_FILE: dist/release-notes.md
         run: |
           set -euo pipefail
           tag="${{ steps.plan.outputs.next_tag }}"
@@ -354,6 +392,7 @@ jobs:
 
           if [[ "${publish_action}" == "resume-publish" ]]; then
             gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-before-publish.json
+            node -e "const fs = require('node:fs'); const release = require('./dist/release-before-publish.json'); const expectedBody = fs.readFileSync(process.env.RELEASE_NOTES_FILE, 'utf8'); if (String(release.name || '') !== process.env.RELEASE_TITLE || String(release.body || '') !== expectedBody) throw new Error('draft release title or body does not match deterministic presentation metadata');"
             tag_commit="$(git rev-parse -q --verify "${tag}^{commit}" 2>/dev/null || true)"
             node scripts/system-release-transaction.mjs verify-release \
               --release dist/release-before-publish.json \
@@ -385,6 +424,8 @@ jobs:
         if: (steps.plan.outputs.should_release == 'true' && (steps.transaction.outputs.action == 'new' || steps.transaction.outputs.action == 'resume-stage' || steps.transaction.outputs.action == 'resume-publish')) || steps.transaction.outputs.action == 'resume-promote'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TITLE: ${{ steps.presentation.outputs.release_title }}
+          RELEASE_NOTES_FILE: dist/release-notes.md
         run: |
           set -euo pipefail
           tag="${{ steps.transaction.outputs.tag }}"
@@ -424,6 +465,7 @@ jobs:
             exit 1
           fi
           gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > dist/release-published.json
+          node -e "const fs = require('node:fs'); const release = require('./dist/release-published.json'); const expectedBody = fs.readFileSync(process.env.RELEASE_NOTES_FILE, 'utf8'); if (String(release.name || '') !== process.env.RELEASE_TITLE || String(release.body || '') !== expectedBody) throw new Error('published release title or body does not match deterministic presentation metadata');"
           tag_commit="$(git rev-parse --verify "${tag}^{commit}")"
           node scripts/system-release-transaction.mjs verify-release \
             --release dist/release-published.json \
@@ -470,6 +512,7 @@ jobs:
               "version": version,
               "publishedAt": published_at,
               "notes": release.get("body") or "",
+              "securityUpdate": system.get("securityUpdate") is True,
               "upgradeFrom": system.get("upgradeFrom") or {},
               "themeContractUpgrade": system.get("themeContractUpgrade") or {},
               "contentModelUpgrade": system.get("contentModelUpgrade") or {},

--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -876,11 +876,6 @@ const translations = {
             untitled: '未命名文件'
           }
         },
-        dialogs: {
-          cancel: '取消',
-          confirm: '确认',
-          close: '关闭'
-        },
         addEntryPrompt: {
           hint: '仅使用英文字母和数字。',
           confirm: '添加条目',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -876,11 +876,6 @@ const translations = {
             untitled: '未命名檔案'
           }
         },
-        dialogs: {
-          cancel: '取消',
-          confirm: '確認',
-          close: '關閉'
-        },
         addEntryPrompt: {
           hint: '僅使用英文字母和數字。',
           confirm: '新增條目',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -912,11 +912,6 @@ const translations = {
             untitled: 'Untitled file'
           }
         },
-        dialogs: {
-          cancel: 'Cancel',
-          confirm: 'Confirm',
-          close: 'Close'
-        },
         addEntryPrompt: {
           hint: 'Use only English letters and numbers.',
           confirm: 'Add Entry',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -876,11 +876,6 @@ const translations = {
             untitled: '無題のファイル'
           }
         },
-        dialogs: {
-          cancel: 'キャンセル',
-          confirm: '確認',
-          close: '閉じる'
-        },
         addEntryPrompt: {
           hint: '英数字のみを使用してください。',
           confirm: 'エントリーを追加',

--- a/assets/js/composer-bootstrap.js
+++ b/assets/js/composer-bootstrap.js
@@ -233,7 +233,8 @@ export async function loadInitialComposerState({
         migration = await loadContentModelMigration({
           contentRoot: root,
           indexRaw: idx || {},
-          tabsRaw: tbs || {}
+          tabsRaw: tbs || {},
+          defaultLang: String(effectiveSite && effectiveSite.defaultLanguage || 'en')
         });
       } catch (err) {
         if (consoleRef && typeof consoleRef.warn === 'function') {

--- a/assets/js/composer-runtime.js
+++ b/assets/js/composer-runtime.js
@@ -182,7 +182,8 @@ export function createComposerRuntime(options = {}) {
 
   function initializeEditorSessionState({
     editorSessionStateStore = null,
-    editorStateVersion = null
+    editorStateVersion = null,
+    legacySystemTreeNodeId = 'system'
   } = {}) {
     hasEditorStateV3Snapshot = false;
     try {
@@ -194,6 +195,14 @@ export function createComposerRuntime(options = {}) {
     } catch (_) {
       hasEditorStateV3Snapshot = false;
     }
+    try {
+      if (!hasEditorStateV3Snapshot
+        && editorSessionStateStore
+        && typeof editorSessionStateStore.readLegacySystemTreeExpanded === 'function'
+        && editorSessionStateStore.readLegacySystemTreeExpanded()) {
+        expandedEditorTreeNodeIds.add(String(legacySystemTreeNodeId || 'system'));
+      }
+    } catch (_) {}
     return hasEditorStateV3Snapshot;
   }
 

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -202,7 +202,8 @@ export function createComposerController(editorRuntime = createComposerRuntime()
   // --- Persisted UI state keys ---
   const LS_KEYS = {
     cfile: 'press_composer_file',           // 'index' | 'tabs' | 'site'
-    editorState: 'press_composer_editor_state' // persisted dynamic editor info
+    editorState: 'press_composer_editor_state', // persisted dynamic editor info
+    systemTreeExpanded: 'press_editor_system_tree_expanded'
   };
   const EDITOR_STATE_VERSION = 3;
 

--- a/assets/js/content-model-migration.js
+++ b/assets/js/content-model-migration.js
@@ -169,6 +169,9 @@ function cloneRawConfig(raw, options = {}) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { __order: [] };
   const base = options.base === 'tabs' ? 'tabs' : 'index';
   const defaultLang = normalizeLanguageCode(options.defaultLang || 'en') || 'en';
+  const flatLanguageSlots = options.flatLanguageSlots instanceof Set
+    ? options.flatLanguageSlots
+    : null;
   const languageSet = new Set(getLegacyContentLanguageCandidates(options));
   const cloned = deepClone(raw) || {};
   if (!Array.isArray(cloned.__order)) {
@@ -180,11 +183,13 @@ function cloneRawConfig(raw, options = {}) {
     if (base === 'tabs') {
       if (!isUnifiedTabsEntry(value, languageSet)) {
         cloned[key] = { [defaultLang]: normalizeTabsDefaultValue(key, value) };
+        flatLanguageSlots?.add(`${key}\u0000${defaultLang}`);
       }
       return;
     }
     if (!isUnifiedIndexEntry(value, languageSet)) {
       cloned[key] = { [defaultLang]: normalizeIndexDefaultValue(key, value) };
+      flatLanguageSlots?.add(`${key}\u0000${defaultLang}`);
     }
   });
   return cloned;
@@ -279,11 +284,13 @@ function normalizeLegacyIndexValue(stableKey, sourceKey, value) {
   return deepClone(value);
 }
 
-function mergeLegacyIndex(raw, lang, parsed) {
+function mergeLegacyIndex(raw, lang, parsed, flatLanguageSlots = null) {
   orderedLegacyEntries(parsed).forEach(([key, value], position) => {
     const stableKey = chooseMergeKey(raw, key, value, position, getIndexValueLocation);
     const entry = ensureUnifiedEntry(raw, stableKey);
-    if (Object.prototype.hasOwnProperty.call(entry, lang)) return;
+    const slot = `${stableKey}\u0000${lang}`;
+    if (Object.prototype.hasOwnProperty.call(entry, lang)
+      && !(flatLanguageSlots && flatLanguageSlots.delete(slot))) return;
     entry[lang] = normalizeLegacyIndexValue(stableKey, key, value);
   });
 }
@@ -300,11 +307,13 @@ function normalizeLegacyTabsValue(key, value) {
   };
 }
 
-function mergeLegacyTabs(raw, lang, parsed) {
+function mergeLegacyTabs(raw, lang, parsed, flatLanguageSlots = null) {
   orderedLegacyEntries(parsed).forEach(([key, value], position) => {
     const stableKey = chooseMergeKey(raw, key, value, position, getTabsValueLocation);
     const entry = ensureUnifiedEntry(raw, stableKey);
-    if (Object.prototype.hasOwnProperty.call(entry, lang)) return;
+    const slot = `${stableKey}\u0000${lang}`;
+    if (Object.prototype.hasOwnProperty.call(entry, lang)
+      && !(flatLanguageSlots && flatLanguageSlots.delete(slot))) return;
     entry[lang] = normalizeLegacyTabsValue(key, value);
   });
 }
@@ -316,8 +325,8 @@ function legacyFileEntry(path) {
     category: 'legacy-content-model',
     label,
     path,
-    state: 'deleted',
-    deleted: true
+    state: 'preserved',
+    deleted: false
   };
 }
 
@@ -346,8 +355,20 @@ export async function loadLegacyContentModelMigration(options = {}) {
     currentLang: options.currentLang,
     defaultLang: options.defaultLang
   };
-  const indexRaw = cloneRawConfig(options.indexRaw, { ...languageOptions, base: 'index' });
-  const tabsRaw = cloneRawConfig(options.tabsRaw, { ...languageOptions, base: 'tabs' });
+  const flatIndexLanguageSlots = new Set();
+  const flatTabsLanguageSlots = new Set();
+  const baseIndexRaw = cloneRawConfig(options.indexRaw, {
+    ...languageOptions,
+    base: 'index',
+    flatLanguageSlots: flatIndexLanguageSlots
+  });
+  const baseTabsRaw = cloneRawConfig(options.tabsRaw, {
+    ...languageOptions,
+    base: 'tabs',
+    flatLanguageSlots: flatTabsLanguageSlots
+  });
+  const indexRaw = deepClone(baseIndexRaw);
+  const tabsRaw = deepClone(baseTabsRaw);
   const legacyFiles = [];
   if (!fetchImpl) {
     return {
@@ -366,12 +387,17 @@ export async function loadLegacyContentModelMigration(options = {}) {
     const result = await fetchYamlObject(fetchImpl, candidate.path);
     if (!result.found) continue;
     legacyFiles.push(legacyFileEntry(candidate.path));
-    if (candidate.base === 'tabs') mergeLegacyTabs(tabsRaw, candidate.lang, result.value);
-    else mergeLegacyIndex(indexRaw, candidate.lang, result.value);
+    if (candidate.base === 'tabs') {
+      mergeLegacyTabs(tabsRaw, candidate.lang, result.value, flatTabsLanguageSlots);
+    } else {
+      mergeLegacyIndex(indexRaw, candidate.lang, result.value, flatIndexLanguageSlots);
+    }
   }
 
   return {
-    hasLegacyContentModel: legacyFiles.length > 0,
+    hasLegacyContentModel: legacyFiles.length > 0
+      && (JSON.stringify(indexRaw) !== JSON.stringify(baseIndexRaw)
+        || JSON.stringify(tabsRaw) !== JSON.stringify(baseTabsRaw)),
     contentRoot,
     indexRaw,
     tabsRaw,
@@ -380,11 +406,14 @@ export async function loadLegacyContentModelMigration(options = {}) {
 }
 
 export function getLegacyContentModelMigrationFiles(migration) {
+  // Recovery writes the unified base model but preserves every sidecar source.
+  // Historical transition state may still carry explicit deletion records, so
+  // only honor entries that already opted into deletion semantics.
   const files = Array.isArray(migration && migration.legacyFiles)
     ? migration.legacyFiles
     : (Array.isArray(migration && migration.files) ? migration.files : []);
   return files
-    .filter(file => file && file.path)
+    .filter(file => file && file.path && (file.deleted === true || file.state === 'deleted'))
     .map(file => ({
       ...file,
       kind: file.kind || CONTENT_MODEL_MIGRATION_KIND,

--- a/assets/js/editor-content-tree.js
+++ b/assets/js/editor-content-tree.js
@@ -201,7 +201,6 @@ function explicitArticleVersionLabel(path) {
   const candidate = String(segments[segments.length - 1] || '').trim();
   if (!/^v\d+(?:\.\d+)*$/i.test(candidate)) return '';
   return candidate;
-  return '';
 }
 
 function versionLabel(path, index) {

--- a/assets/js/editor-main-shell-service.js
+++ b/assets/js/editor-main-shell-service.js
@@ -16,7 +16,6 @@ export function createEditorMainShellService(options = {}) {
       }
       if (!textarea) return false;
       textarea.style.height = '0px';
-      // eslint-disable-next-line no-unused-expressions
       textarea.offsetHeight;
       textarea.style.height = `${textarea.scrollHeight}px`;
       return true;

--- a/assets/js/editor-session-state.js
+++ b/assets/js/editor-session-state.js
@@ -10,6 +10,12 @@ export function createEditorSessionStateStore({
     catch (_) { return ''; }
   }
 
+  function removeItem(key) {
+    try {
+      if (storage && storage.removeItem) storage.removeItem(scoped(key));
+    } catch (_) {}
+  }
+
   function readJson(key) {
     try {
       const raw = getItem(key);
@@ -32,7 +38,12 @@ export function createEditorSessionStateStore({
 
   return {
     readEditorState: () => readJson(keys.editorState),
-    writeEditorState: (state) => writeJson(keys.editorState, state),
+    writeEditorState: (state) => {
+      const written = writeJson(keys.editorState, state);
+      if (written && keys.systemTreeExpanded) removeItem(keys.systemTreeExpanded);
+      return written;
+    },
+    readLegacySystemTreeExpanded: () => !!keys.systemTreeExpanded && getItem(keys.systemTreeExpanded) === '1',
     readUnscopedNumber(key, fallback = 0) {
       try {
         const raw = storage && storage.getItem ? storage.getItem(key) : null;

--- a/assets/js/hieditor.js
+++ b/assets/js/hieditor.js
@@ -818,7 +818,6 @@ function makeEditor(targetTextarea, language, readOnly, options = {}) {
     // Collapse first to force reflow, then grow to scrollHeight
     ta.style.height = '0px';
     // Force reflow to ensure scrollHeight is recalculated
-    // eslint-disable-next-line no-unused-expressions
     ta.offsetHeight;
     const minH = 0; // grow exactly with content height
     let h = Math.max(minH, ta.scrollHeight);

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -70,6 +70,28 @@ async function fetchConfigWithYamlFallbackForRuntime(runtime, names) {
   return {};
 }
 
+// Recovery releases keep legacy per-language sidecars readable for sites that
+// update directly from the declared v3.4.64 support floor. This fallback may be
+// removed only after the support floor advances beyond sidecar-era sites.
+async function loadRecoveryContentSidecarWithRuntime(runtime, basePath, baseName, languageCandidates = null) {
+  const state = runtime.state;
+  const languages = (Array.isArray(languageCandidates)
+    ? languageCandidates
+    : [state.currentLang, state.baseDefaultLang, DEFAULT_LANG])
+    .map(normalizeLangKey)
+    .filter((value, index, list) => value && list.indexOf(value) === index);
+  for (const lang of languages) {
+    const raw = await fetchConfigWithYamlFallbackForRuntime(runtime, [
+      `${basePath}/${baseName}.${lang}.yaml`,
+      `${basePath}/${baseName}.${lang}.yml`
+    ]);
+    if (raw && typeof raw === 'object' && Object.keys(raw).length) {
+      return { lang, raw };
+    }
+  }
+  return null;
+}
+
 // Limit for concurrent front matter fetches when resolving simplified content entries.
 // Set to a positive integer to chunk requests; falsy values disable the limit.
 const FRONTMATTER_FETCH_BATCH_SIZE = 6;
@@ -880,8 +902,9 @@ async function loadContentFromFrontMatter(runtime, obj, lang) {
 }
 
 
-// Load unified YAML (`base.yaml`) or simplified content mappings. Legacy
-// per-language sidecars are intentionally retired by the content-model clean release.
+// Load unified YAML (`base.yaml`) or simplified content mappings. Recovery
+// reads the exact current-language sidecar over a flat base, or falls back to
+// a bounded sidecar search when no usable base exists.
 async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
   // YAML only (unified or simplified)
   let raw = null;
@@ -921,6 +944,12 @@ async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
       if (isSimplified) {
         // Handle simplified format - load metadata from front matter
         const current = getCurrentLangWithRuntime(runtime);
+        const legacy = await loadRecoveryContentSidecarWithRuntime(runtime, basePath, baseName, [current]);
+        if (legacy) {
+          const { entries } = await loadContentFromFrontMatter(runtime, legacy.raw, current);
+          setContentLangs(runtime, [legacy.lang]);
+          return { entries, raw };
+        }
         const { entries, availableLangs } = await loadContentFromFrontMatter(runtime, obj, current);
         setContentLangs(runtime, availableLangs);
         return { entries, raw };
@@ -934,7 +963,15 @@ async function loadContentJsonWithRawWithRuntime(runtime, basePath, baseName) {
         return { entries, raw };
       }
     }
-  } catch (_) { /* return empty content */ }
+  } catch (_) { /* try the bounded recovery fallback */ }
+
+  const legacy = await loadRecoveryContentSidecarWithRuntime(runtime, basePath, baseName);
+  if (legacy) {
+    const current = getCurrentLangWithRuntime(runtime);
+    const { entries } = await loadContentFromFrontMatter(runtime, legacy.raw, current);
+    setContentLangs(runtime, [legacy.lang]);
+    return { entries, raw };
+  }
 
   return { entries: {}, raw };
 }
@@ -1015,9 +1052,8 @@ function transformFlatTabs(obj) {
   return out;
 }
 
-// Load unified tabs YAML and the supported base flat tabs shape. Legacy
-// per-language sidecars are migrated by the transition editor release and are
-// not read by the clean runtime.
+// Load unified tabs YAML and the supported base flat tabs shape, with the same
+// bounded Recovery sidecar behavior used for index content.
 async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
   try {
     const obj = await fetchConfigWithYamlFallbackForRuntime(runtime, [
@@ -1042,11 +1078,30 @@ async function loadTabsJsonWithRuntime(runtime, basePath, baseName) {
       }
       const entries = transformFlatTabs(obj);
       if (entries && Object.keys(entries).length) {
+        const legacy = await loadRecoveryContentSidecarWithRuntime(
+          runtime,
+          basePath,
+          baseName,
+          [getCurrentLangWithRuntime(runtime)]
+        );
+        if (legacy) {
+          const legacyEntries = transformFlatTabs(legacy.raw);
+          if (Object.keys(legacyEntries).length) {
+            setContentLangs(runtime, [legacy.lang]);
+            return legacyEntries;
+          }
+        }
         setContentLangs(runtime, [normalizeLangKey(runtime.state.baseDefaultLang || 'en')]);
+        return entries;
       }
-      return entries;
     }
-  } catch (_) { /* return empty tabs */ }
+  } catch (_) { /* try the bounded recovery fallback */ }
+  const legacy = await loadRecoveryContentSidecarWithRuntime(runtime, basePath, baseName);
+  if (legacy) {
+    const entries = transformFlatTabs(legacy.raw);
+    if (Object.keys(entries).length) setContentLangs(runtime, [legacy.lang]);
+    return entries;
+  }
   return {};
 }
 

--- a/assets/js/press-system-surface.mjs
+++ b/assets/js/press-system-surface.mjs
@@ -70,6 +70,7 @@ export function getPressSystemReleasePlanPaths(options = {}) {
   const paths = new Set([...SYSTEM_PACKAGE_PATHS, ...SYSTEM_RELEASE_PLAN_ONLY_PATHS]);
   if (options.includePagesMaterializer) {
     paths.add('scripts/build-pages-artifact.sh');
+    paths.add('scripts/resolve-pages-output-path.mjs');
     paths.add('scripts/sync-runtime-cache-keys.mjs');
   }
   return [...paths];

--- a/assets/js/press-version.js
+++ b/assets/js/press-version.js
@@ -1,4 +1,5 @@
 export const PRESS_SYSTEM_MANIFEST_PATH = 'assets/press-system.json';
+export const SECURITY_UPDATE_REQUIRED_VERSION = '3.4.134';
 
 export function normalizeSemver(value) {
   const raw = String(value || '').trim();
@@ -94,11 +95,16 @@ export function normalizePressSystemManifest(input) {
   if (!version || tag !== semverToTag(version)) {
     throw new Error('Press system manifest version and tag must be matching SemVer values.');
   }
+  if (compareSemver(version, SECURITY_UPDATE_REQUIRED_VERSION) >= 0
+    && typeof input.securityUpdate !== 'boolean') {
+    throw new Error(`Press system manifest securityUpdate must be an explicit boolean from v${SECURITY_UPDATE_REQUIRED_VERSION}.`);
+  }
   return {
     schemaVersion: 1,
     type: 'press-system',
     version,
     tag,
+    securityUpdate: input.securityUpdate === true,
     upgradeFrom: normalizeUpgradeFrom(input.upgradeFrom),
     themeContractUpgrade: normalizeThemeContractUpgrade(input.themeContractUpgrade),
     contentModelUpgrade: normalizeContentModelUpgrade(input.contentModelUpgrade)

--- a/assets/js/publish/settings-store.js
+++ b/assets/js/publish/settings-store.js
@@ -5,6 +5,7 @@ import {
 
 export const GITHUB_PAT_STORAGE_KEY = 'press_fg_pat_cache';
 export const CONNECT_PUBLISH_GRANT_STORAGE_KEY = 'press_connect_publish_grant_cache';
+export const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';
 export const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';
 export const PUBLISH_TRANSPORT_MODE_STORAGE_KEY = 'press_publish_transport_mode';
 export const CONNECT_PUBLISH_MESSAGE_TYPE = 'press-connect-publish-authorized';
@@ -99,12 +100,24 @@ export function createPublishSettingsStore(options = {}) {
     try {
       const storage = local();
       const modeRaw = storage.getItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY));
+      let migratedLegacyMode = false;
       if (modeRaw === 'connect' || modeRaw === 'pat') {
         settings.mode = modeRaw;
         settings.enabled = modeRaw === 'connect';
+      } else {
+        const enabledRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+        if (enabledRaw === '0' || enabledRaw === '1') {
+          settings.mode = enabledRaw === '0' ? 'pat' : 'connect';
+          settings.enabled = settings.mode === 'connect';
+          migratedLegacyMode = true;
+        }
       }
       const baseUrlRaw = storage.getItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY));
       if (typeof baseUrlRaw === 'string' && baseUrlRaw.trim()) settings.baseUrl = baseUrlRaw.trim();
+      if (migratedLegacyMode
+        && storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode)) {
+        storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+      }
     } catch (_) {
       /* ignore unavailable storage */
     }
@@ -129,7 +142,9 @@ export function createPublishSettingsStore(options = {}) {
     cachedConnectPublishSettingsMemory = { ...settings };
     try {
       const storage = local();
-      storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode);
+      if (storage.setItem(scopedKey(PUBLISH_TRANSPORT_MODE_STORAGE_KEY), settings.mode)) {
+        storage.removeItem(scopedKey(CONNECT_PUBLISH_ENABLED_STORAGE_KEY));
+      }
       storage.setItem(scopedKey(CONNECT_PUBLISH_BASE_URL_STORAGE_KEY), settings.baseUrl);
     } catch (_) {
       /* ignore storage errors */

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -8,6 +8,7 @@ import { buildConnectStatusUrl, CONNECT_SYSTEM_RELEASE_PATH } from './connect-st
 import { PRESS_GITHUB_PROVIDER } from './provider-adapters.js';
 import { parseYAML } from './yaml.js';
 import {
+  compareSemver,
   isUpgradeAllowed,
   loadPressSystemManifest,
   normalizeContentModelUpgrade,
@@ -15,6 +16,7 @@ import {
   normalizePressSystemManifest,
   normalizeSemver,
   normalizeUpgradeFrom,
+  SECURITY_UPDATE_REQUIRED_VERSION,
   semverToTag
 } from './press-version.js';
 import { isPressSystemUpdatePath } from './press-system-surface.mjs';
@@ -379,6 +381,10 @@ function requireManifestString(manifest, key) {
   return value;
 }
 
+export function isSecurityUpdateReleaseName(value) {
+  return /^(?:press\s+)?security update\b/i.test(String(value || '').trim());
+}
+
 function normalizeReleaseCache(data) {
   const asset = selectSystemUpdateAsset(data);
   const version = normalizeSemver(data.version || data.tag_name || '');
@@ -388,6 +394,7 @@ function normalizeReleaseCache(data) {
     version,
     publishedAt: data.published_at || data.created_at || '',
     notes: data.body || '',
+    securityUpdate: data.securityUpdate === true || isSecurityUpdateReleaseName(data.name),
     upgradeFrom: normalizeUpgradeFrom(data.upgradeFrom),
     themeContractUpgrade: normalizeThemeContractUpgrade(data.themeContractUpgrade),
     contentModelUpgrade: normalizeContentModelUpgrade(data.contentModelUpgrade),
@@ -409,6 +416,12 @@ export function normalizeSystemReleaseManifest(manifest) {
   const publishedAt = requireManifestString(manifest, 'publishedAt');
   const notes = requireManifestString(manifest, 'notes');
   const htmlUrl = requireManifestString(manifest, 'htmlUrl');
+  if ((compareSemver(version, SECURITY_UPDATE_REQUIRED_VERSION) >= 0
+      && typeof manifest.securityUpdate !== 'boolean')
+    || (Object.prototype.hasOwnProperty.call(manifest, 'securityUpdate')
+      && typeof manifest.securityUpdate !== 'boolean')) {
+    throw new Error('Invalid system release manifest: securityUpdate must be boolean');
+  }
   if (!isObject(manifest.asset)) {
     throw new Error('Invalid system release manifest: missing asset');
   }
@@ -430,6 +443,7 @@ export function normalizeSystemReleaseManifest(manifest) {
     version,
     publishedAt,
     notes,
+    securityUpdate: manifest.securityUpdate === true,
     upgradeFrom: normalizeUpgradeFrom(manifest.upgradeFrom),
     themeContractUpgrade: normalizeThemeContractUpgrade(manifest.themeContractUpgrade),
     contentModelUpgrade: normalizeContentModelUpgrade(manifest.contentModelUpgrade),
@@ -802,7 +816,21 @@ async function assertContentModelCompatibility(runtime, release, archiveSystem) 
     contentRoot,
     fetchImpl: runtime.getFetch()
   });
-  const legacyFiles = getLegacyContentModelMigrationFiles(migration);
+  // Historical cleanup-gated releases must still refuse to proceed while any
+  // legacy sidecar exists. Recovery preserves those source files intentionally,
+  // so this compatibility check must inspect discovery state rather than the
+  // narrower list of files selected for deletion/staging.
+  const discoveredLegacyFiles = Array.isArray(migration && migration.legacyFiles)
+    ? migration.legacyFiles
+      .filter(file => file && file.path)
+      .map(file => ({
+        ...file,
+        path: String(file.path).replace(/[\\]/g, '/').replace(/^\/+/, '')
+      }))
+    : [];
+  const legacyFiles = discoveredLegacyFiles.length
+    ? discoveredLegacyFiles
+    : getLegacyContentModelMigrationFiles(migration);
   if (legacyFiles.length) {
     createContentModelUpgradeError(targetVersion, requirement, legacyFiles, 'legacy');
   }
@@ -968,6 +996,8 @@ async function assertInstalledThemeContractCompatibility(runtime, release, archi
 }
 
 function renderRelease(runtime) {
+  const { root } = runtime.state.elements;
+  if (root) root.dataset.securityUpdate = runtime.state.releaseCache && runtime.state.releaseCache.securityUpdate ? 'true' : 'false';
   renderReleaseMeta(runtime);
   renderNotes(runtime, getDisplayReleaseNotes(runtime.state.releaseCache));
   updateDownloadLink(runtime);

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -455,13 +455,9 @@ function resolveModuleEntry(pack, entry, manifest) {
 async function loadThemeModule(pack, entry, manifest) {
   const path = resolveModuleEntry(pack, entry, manifest);
   if (!path) return null;
-  try {
-    if (typeof window !== 'undefined' && typeof window.__pressThemeModuleLoader === 'function') {
-      const mod = await window.__pressThemeModuleLoader(path, { pack, entry, manifest });
-      return { entry, mod };
-    }
-  } catch (err) {
-    throw err;
+  if (typeof window !== 'undefined' && typeof window.__pressThemeModuleLoader === 'function') {
+    const mod = await window.__pressThemeModuleLoader(path, { pack, entry, manifest });
+    return { entry, mod };
   }
   const mod = await import(path);
   return { entry, mod };

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -420,6 +420,9 @@ async function loadManifest(pack) {
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   const data = await resp.json();
   if (!data || typeof data !== 'object') throw new Error('Invalid manifest');
+  if (pack !== DEFAULT_PACK && !isPressThemeContractVersionSupported(data.contractVersion)) {
+    throw new Error(`Unsupported theme contract version: ${data.contractVersion || 'unknown'}`);
+  }
   const list = Array.isArray(data.modules) ? data.modules : [];
   if (!list.length) throw new Error('Empty module list');
   const manifest = { ...data, modules: list.map(x => String(x)) };

--- a/assets/press-system.json
+++ b/assets/press-system.json
@@ -1,21 +1,14 @@
 {
   "schemaVersion": 1,
   "type": "press-system",
-  "version": "3.4.133",
-  "tag": "v3.4.133",
+  "version": "3.4.134",
+  "tag": "v3.4.134",
+  "securityUpdate": false,
   "upgradeFrom": {
     "ranges": [
-      ">=3.4.132 <3.4.133"
+      ">=3.4.64 <3.4.134"
     ],
     "allowUnknownSource": false,
-    "message": "Update to v3.4.132 before installing v3.4.133."
-  },
-  "themeContractUpgrade": {
-    "requiresInstalledThemeContractVersion": 4,
-    "message": "Update installed themes to contract v4 before installing v3.4.133."
-  },
-  "contentModelUpgrade": {
-    "requiresUnifiedIndexTabs": true,
-    "message": "Install v3.4.132 and publish the content model migration before installing v3.4.133."
+    "message": "Press v3.4.64 through v3.4.133 can update directly to v3.4.134."
   }
 }

--- a/packages/press-theme-contract/package.json
+++ b/packages/press-theme-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekilyhq/press-theme-contract",
-  "version": "3.4.133",
+  "version": "3.4.134",
   "description": "Press theme contract helpers and packaged theme validation rules.",
   "type": "module",
   "license": "UNLICENSED",

--- a/scripts/build-pages-artifact.sh
+++ b/scripts/build-pages-artifact.sh
@@ -4,23 +4,9 @@ set -euo pipefail
 output_dir="${1:-dist/pages}"
 explicit_tag="${2:-}"
 
-repo_root="$(git rev-parse --show-toplevel)"
+repo_root="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
 cd "${repo_root}"
-output_dir="$(node -e "const path = require('path'); process.stdout.write(path.resolve(process.argv[1]));" "${output_dir}")"
-tmp_root="$(node -e "const os = require('os'); const path = require('path'); process.stdout.write(path.resolve(os.tmpdir()));")"
-home_root="$(node -e "const path = require('path'); process.stdout.write(process.env.HOME ? path.resolve(process.env.HOME) : '');")"
-if [[ "${output_dir}" == "/" || "${output_dir}" == "${repo_root}" || "${output_dir}" == "${repo_root}/dist" || ( -n "${home_root}" && "${output_dir}" == "${home_root}" ) || "${output_dir}" == "${tmp_root}" ]]; then
-  echo "Pages artifact output directory is too broad to remove safely" >&2
-  exit 2
-fi
-if [[ "${output_dir}" == "${repo_root}"/* && "${output_dir}" != "${repo_root}/dist/"* ]]; then
-  echo "Pages artifact output directory inside the repository must be under dist/" >&2
-  exit 2
-fi
-if [[ "${output_dir}" != "${repo_root}/dist/"* && "${output_dir}" != "${tmp_root}/"* ]]; then
-  echo "Pages artifact output directory outside the repository must be under the system temporary directory" >&2
-  exit 2
-fi
+output_dir="$(node scripts/resolve-pages-output-path.mjs "${output_dir}" "${repo_root}")"
 
 source_tag="$(node -e "const manifest = require('./assets/press-system.json'); const version = String(manifest.version || '').trim(); const tag = String(manifest.tag || '').trim(); if (!/^\\d+\\.\\d+\\.\\d+$/.test(version) || tag !== \`v\${version}\`) { throw new Error('assets/press-system.json must declare matching version and tag'); } process.stdout.write(tag);")"
 tag="${explicit_tag:-${source_tag}}"

--- a/scripts/release-graph-policy.json
+++ b/scripts/release-graph-policy.json
@@ -10,17 +10,18 @@
     "updateStrategy": "latest-only"
   },
   "candidateGate": {
-    "mode": "recovery-required",
+    "mode": "direct",
     "baselineVersion": "3.4.133",
-    "reason": "The current latest-only updater cannot move every supported published source directly to v3.4.133.",
-    "removalCondition": "Publish a recovery transition whose upgradeFrom ranges directly admit every declared supported published source, then change this mode to direct."
+    "reason": "Recovery transition v3.4.134 directly admits every declared supported published source.",
+    "removalCondition": "Retain direct coverage while Press uses a latest-only update strategy; change this mode only with an explicit support-policy migration."
   },
   "legacyExceptions": [
     {
       "id": "v3.4.108-missing-predecessor",
       "from": "3.4.64",
       "to": "3.4.108",
-      "status": "recovery-required",
+      "status": "recovered",
+      "recoveredByVersion": "3.4.134",
       "unpublishedRange": ">3.4.64 <3.4.108",
       "targetRanges": [
         ">=3.4.107 <3.4.108"
@@ -29,7 +30,7 @@
         "3.4.107"
       ],
       "reason": "v3.4.108 requires v3.4.107, but releases v3.4.65 through v3.4.107 were never published.",
-      "removalCondition": "After a recovery transition restores a direct path from the support floor, set status to recovered and record recoveredByVersion while retaining this immutable history."
+      "removalCondition": "Retain this immutable exception while v3.4.64 remains inside the declared support domain."
     }
   ],
   "artifactLayout": {

--- a/scripts/release-graph.js
+++ b/scripts/release-graph.js
@@ -8,6 +8,7 @@ const { isDeepStrictEqual } = require('node:util');
 const POLICY_TYPE = 'press-release-graph-policy';
 const RELEASE_INTENT_TYPE = 'press-release-intent';
 const SYSTEM_RELEASE_TYPE = 'press-system';
+const SECURITY_UPDATE_REQUIRED_VERSION = '3.4.134';
 const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/u;
 
 function normalizeSemver(value) {
@@ -33,6 +34,20 @@ function compareSemver(leftValue, rightValue) {
     return leftParts[index] > rightParts[index] ? 1 : -1;
   }
   return 0;
+}
+
+function normalizeSecurityUpdate(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return source.securityUpdate === true;
+}
+
+function validateSecurityUpdate(input, versionValue, label) {
+  const version = normalizeSemver(versionValue);
+  if (!version || compareSemver(version, SECURITY_UPDATE_REQUIRED_VERSION) < 0) return [];
+  if (!input || typeof input !== 'object' || typeof input.securityUpdate !== 'boolean') {
+    return [`${label} securityUpdate must be an explicit boolean`];
+  }
+  return [];
 }
 
 function testComparator(version, token) {
@@ -312,13 +327,33 @@ function validateUpgradeFrom(upgradeFrom, targetVersion, label) {
 
 function validateDirectCandidateDomain(candidate, policy) {
   const failures = [];
+  const candidateVersion = normalizeSemver(candidate && candidate.version);
   const candidateRanges = normalizeUpgradeFrom(candidate && candidate.upgradeFrom).ranges;
+  const candidateIntervals = candidateRanges.flatMap(rangeIntervals);
   const supportIntervals = policy.support.sourceRanges.flatMap(rangeIntervals);
-  candidateRanges.flatMap(rangeIntervals).forEach((interval) => {
+  candidateIntervals.forEach((interval) => {
     if (!intervalIsCovered(interval, supportIntervals)) {
-      failures.push(`candidate v${normalizeSemver(candidate && candidate.version)} upgradeFrom admits versions outside policy support.sourceRanges`);
+      failures.push(`candidate v${candidateVersion} upgradeFrom admits versions outside policy support.sourceRanges`);
     }
   });
+  const candidateUpper = semverParts(candidateVersion);
+  if (candidateUpper) {
+    const requiredIntervals = supportIntervals.map((interval) => {
+      const upper = !interval.upper || compareParts(interval.upper, candidateUpper) > 0
+        ? candidateUpper
+        : interval.upper;
+      return {
+        lower: interval.lower,
+        upper,
+        empty: interval.empty || compareParts(interval.lower, upper) >= 0
+      };
+    }).filter((interval) => !interval.empty);
+    requiredIntervals.forEach((interval) => {
+      if (!intervalIsCovered(interval, candidateIntervals)) {
+        failures.push(`candidate v${candidateVersion} upgradeFrom must cover the complete declared support domain below the candidate`);
+      }
+    });
+  }
   return failures;
 }
 
@@ -347,6 +382,7 @@ function validatePublishedRelease(release, policy, artifactPaths, githubReleases
     failures.push(`${label} system-release version and tag must match ${expected.tag}`);
   }
   failures.push(...validateUpgradeFrom(manifest.upgradeFrom, version, label));
+  failures.push(...validateSecurityUpdate(manifest, version, `${label} system-release`));
   if (sourceManifest) {
     if (sourceManifest.schemaVersion !== 1
       || sourceManifest.type !== SYSTEM_RELEASE_TYPE
@@ -354,10 +390,14 @@ function validatePublishedRelease(release, policy, artifactPaths, githubReleases
       || sourceManifest.tag !== expected.tag) {
       failures.push(`${label} tagged Press system manifest identity is inconsistent`);
     }
+    failures.push(...validateSecurityUpdate(sourceManifest, version, `${label} tagged Press system manifest`));
     if (!jsonMatches(normalizeUpgradeFrom(sourceManifest.upgradeFrom), normalizeUpgradeFrom(manifest.upgradeFrom))
       || !jsonMatches(sourceManifest.themeContractUpgrade, manifest.themeContractUpgrade)
       || !jsonMatches(sourceManifest.contentModelUpgrade, manifest.contentModelUpgrade)) {
       failures.push(`${label} tagged Press system compatibility metadata does not match system-release.json`);
+    }
+    if (normalizeSecurityUpdate(sourceManifest) !== normalizeSecurityUpdate(manifest)) {
+      failures.push(`${label} tagged Press system securityUpdate does not match system-release.json`);
     }
   }
 
@@ -441,6 +481,7 @@ function validatePublishedRelease(release, policy, artifactPaths, githubReleases
       failures.push(`${label} release intent system-release digest does not match its manifest`);
     }
     const pressSystem = intent.pressSystem && typeof intent.pressSystem === 'object' ? intent.pressSystem : {};
+    failures.push(...validateSecurityUpdate(pressSystem, version, `${label} release intent pressSystem`));
     if (!jsonMatches(normalizeAsset(pressSystem.asset), asset)) {
       failures.push(`${label} release intent asset metadata does not match system-release.json`);
     }
@@ -453,6 +494,9 @@ function validatePublishedRelease(release, policy, artifactPaths, githubReleases
     if (!jsonMatches(pressSystem.themeContractUpgrade, manifest.themeContractUpgrade)
       || !jsonMatches(pressSystem.contentModelUpgrade, manifest.contentModelUpgrade)) {
       failures.push(`${label} release intent migration compatibility metadata does not match system-release.json`);
+    }
+    if (normalizeSecurityUpdate(pressSystem) !== normalizeSecurityUpdate(manifest)) {
+      failures.push(`${label} release intent securityUpdate does not match system-release.json`);
     }
   }
   return failures;
@@ -470,6 +514,7 @@ function validateCandidate(candidate, publishedByVersion) {
     failures.push(`${label} version and tag must be matching exact semantic versions`);
   }
   if (version) failures.push(...validateUpgradeFrom(candidate.upgradeFrom, version, label));
+  failures.push(...validateSecurityUpdate(candidate, version, label));
   if (normalizeUpgradeFrom(candidate.upgradeFrom).allowUnknownSource) {
     failures.push(`${label} must not allow an unknown source version`);
   }
@@ -479,6 +524,9 @@ function validateCandidate(candidate, publishedByVersion) {
       || !jsonMatches(candidate.themeContractUpgrade, published.manifest.themeContractUpgrade)
       || !jsonMatches(candidate.contentModelUpgrade, published.manifest.contentModelUpgrade)) {
       failures.push(`${label} does not match the published release compatibility metadata`);
+    }
+    if (normalizeSecurityUpdate(candidate) !== normalizeSecurityUpdate(published.manifest)) {
+      failures.push(`${label} securityUpdate does not match the published release`);
     }
   }
   return failures;
@@ -491,6 +539,7 @@ function normalizePressSystemCompatibility(input = {}) {
     type: String(source.type || '').trim(),
     version: normalizeSemver(source.version),
     tag: semverToTag(source.tag || source.version),
+    securityUpdate: normalizeSecurityUpdate(source),
     upgradeFrom: normalizeUpgradeFrom(source.upgradeFrom),
     themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
       ? source.themeContractUpgrade
@@ -525,6 +574,13 @@ function validateCandidateArchive(candidate, candidateArchive) {
   }
   const embeddedPath = `${expectedRoot}assets/press-system.json`;
   if (!entries.includes(embeddedPath)) failures.push(`${label} archive is missing ${embeddedPath}`);
+  if (candidateArchive.embeddedManifest) {
+    failures.push(...validateSecurityUpdate(
+      candidateArchive.embeddedManifest,
+      version,
+      `${label} archive Press system manifest`
+    ));
+  }
   if (!candidateArchive.embeddedManifest
     || !jsonMatches(
       normalizePressSystemCompatibility(candidateArchive.embeddedManifest),
@@ -801,9 +857,12 @@ function analyzeReleaseGraph(input = {}) {
     && latestPublishedVersion !== baselineVersion) {
     failures.push(`published latest v${latestPublishedVersion} does not match recovery baseline v${baselineVersion}`);
   } else if (validationMode === 'audit' && gate.mode === 'direct'
-    && (!worktreeCandidateVersion || compareSemver(worktreeCandidateVersion, latestPublishedVersion) <= 0)
-    && directMissing.length) {
-    failures.push(`candidateGate.mode cannot switch to direct without a newer recovery candidate; published latest v${latestPublishedVersion} lacks direct edges from: ${directMissing.map((version) => `v${version}`).join(', ')}`);
+    && (!worktreeCandidateVersion || compareSemver(worktreeCandidateVersion, latestPublishedVersion) <= 0)) {
+    failures.push(...validateDirectCandidatePrerequisites(targetCandidate));
+    failures.push(...validateDirectCandidateDomain(targetCandidate, policy));
+    if (directMissing.length) {
+      failures.push(`candidateGate.mode cannot switch to direct without a newer recovery candidate; published latest v${latestPublishedVersion} lacks direct edges from: ${directMissing.map((version) => `v${version}`).join(', ')}`);
+    }
   } else if (validationMode === 'candidate' && gate.mode === 'recovery-required') {
     failures.push(`candidate v${candidateVersion || 'unknown'} is blocked while candidateGate.mode is recovery-required; only published baseline v${baselineVersion} may pass`);
   } else if (validationMode === 'candidate' && gate.mode === 'direct') {

--- a/scripts/release-intent.js
+++ b/scripts/release-intent.js
@@ -10,6 +10,7 @@ const {
 
 const DEFAULT_PRESS_REPOSITORY = 'EkilyHQ/Press';
 const RELEASE_INTENT_TYPE = 'press-release-intent';
+const SECURITY_UPDATE_REQUIRED_VERSION = '3.4.134';
 const THEME_DEMO_OBSERVED_CHANNELS = ['themeManifest', 'themePacks', 'demoLock'];
 
 function normalizeSemver(value) {
@@ -22,6 +23,29 @@ function normalizeSemver(value) {
 function semverToTag(value) {
   const version = normalizeSemver(value);
   return version ? `v${version}` : '';
+}
+
+function compareSemver(leftValue, rightValue) {
+  const left = normalizeSemver(leftValue);
+  const right = normalizeSemver(rightValue);
+  if (!left || !right) return null;
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] === rightParts[index]) continue;
+    return leftParts[index] > rightParts[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+function normalizeSecurityUpdate(input = {}) {
+  const source = input && typeof input === 'object' ? input : {};
+  return source.securityUpdate === true;
+}
+
+function requiresExplicitSecurityUpdate(version) {
+  const comparison = compareSemver(version, SECURITY_UPDATE_REQUIRED_VERSION);
+  return comparison !== null && comparison >= 0;
 }
 
 function normalizeThemeContractUpgrade(input = {}) {
@@ -142,6 +166,7 @@ function normalizeSystemRelease(input = {}) {
     tag,
     version,
     publishedAt: String(source.publishedAt || source.published_at || '').trim(),
+    securityUpdate: normalizeSecurityUpdate(source),
     upgradeFrom: source.upgradeFrom && typeof source.upgradeFrom === 'object' ? source.upgradeFrom : {},
     themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
       ? source.themeContractUpgrade
@@ -226,6 +251,7 @@ function buildReleaseIntent(options = {}) {
     pressSystem: {
       asset: systemRelease.asset,
       runtime: systemRelease.runtime,
+      securityUpdate: systemRelease.securityUpdate,
       upgradeFrom: systemRelease.upgradeFrom,
       themeContractUpgrade: systemRelease.themeContractUpgrade,
       contentModelUpgrade: systemRelease.contentModelUpgrade
@@ -274,6 +300,7 @@ function normalizeReleaseIntent(input = {}) {
         entryCount: Number(runtime.entryCount || 0),
         edgeCount: Number(runtime.edgeCount || 0)
       },
+      securityUpdate: normalizeSecurityUpdate(pressSystem),
       upgradeFrom: pressSystem.upgradeFrom && typeof pressSystem.upgradeFrom === 'object'
         ? pressSystem.upgradeFrom
         : {},
@@ -325,6 +352,12 @@ function validateReleaseIntent(intentInput, options = {}) {
   if (!intent.version || intent.tag !== semverToTag(intent.version)) failures.push('release intent must declare matching version and tag');
   if (!intent.createdAt) failures.push('release intent must declare createdAt');
   if (!intent.repository) failures.push('release intent must declare repository');
+  const rawPressSystem = intentInput && intentInput.pressSystem && typeof intentInput.pressSystem === 'object'
+    ? intentInput.pressSystem
+    : {};
+  if (requiresExplicitSecurityUpdate(intent.version) && typeof rawPressSystem.securityUpdate !== 'boolean') {
+    failures.push('release intent pressSystem.securityUpdate must be an explicit boolean');
+  }
   if (!intent.pressSystem.asset.name || !intent.pressSystem.asset.url || !intent.pressSystem.asset.digest || !(intent.pressSystem.asset.size > 0)) {
     failures.push('release intent pressSystem.asset must declare name, url, size, and digest');
   }
@@ -382,6 +415,10 @@ function validateReleaseIntent(intentInput, options = {}) {
 
   if (options.systemRelease) {
     const systemRelease = normalizeSystemRelease(options.systemRelease);
+    if (requiresExplicitSecurityUpdate(systemRelease.version)
+      && typeof options.systemRelease.securityUpdate !== 'boolean') {
+      failures.push('system-release.json securityUpdate must be an explicit boolean');
+    }
     if (systemRelease.version !== intent.version || systemRelease.tag !== intent.tag) {
       failures.push('release intent version and tag must match system-release.json');
     }
@@ -395,6 +432,9 @@ function validateReleaseIntent(intentInput, options = {}) {
       || systemRelease.runtime.entryCount !== intent.pressSystem.runtime.entryCount
       || systemRelease.runtime.edgeCount !== intent.pressSystem.runtime.edgeCount) {
       failures.push('release intent runtime metadata must match system-release.json');
+    }
+    if (systemRelease.securityUpdate !== intent.pressSystem.securityUpdate) {
+      failures.push('release intent securityUpdate must match system-release.json');
     }
     if (!themeContractUpgradesMatch(systemRelease.themeContractUpgrade, intent.pressSystem.themeContractUpgrade)) {
       failures.push('release intent themeContractUpgrade must match system-release.json');

--- a/scripts/resolve-pages-output-path.mjs
+++ b/scripts/resolve-pages-output-path.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function realpath(value) {
+  return typeof realpathSync.native === 'function'
+    ? realpathSync.native(value)
+    : realpathSync(value);
+}
+
+export function canonicalizePath(value, { cwd = process.cwd() } = {}) {
+  let current = resolve(cwd, String(value || ''));
+  const missing = [];
+
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) {
+      throw new Error(`Cannot resolve an existing ancestor for ${value}`);
+    }
+    missing.unshift(current.slice(parent.length + (parent.endsWith(sep) ? 0 : 1)));
+    current = parent;
+  }
+
+  return join(realpath(current), ...missing);
+}
+
+function isChildPath(parent, candidate) {
+  const value = relative(parent, candidate);
+  return Boolean(value)
+    && value !== '..'
+    && !value.startsWith(`..${sep}`)
+    && !isAbsolute(value);
+}
+
+export function resolvePagesOutputPath(value, {
+  repoRoot,
+  homeRoot = homedir(),
+  temporaryRoot = tmpdir()
+} = {}) {
+  const lexicalOutputPath = resolve(String(value || ''));
+  const lexicalRepositoryPath = resolve(String(repoRoot || ''));
+  const lexicalDistPath = join(lexicalRepositoryPath, 'dist');
+  const outputPath = canonicalizePath(value);
+  const repositoryPath = canonicalizePath(repoRoot);
+  const distPath = canonicalizePath(join(repositoryPath, 'dist'));
+  const temporaryPath = canonicalizePath(temporaryRoot);
+  const homePath = homeRoot ? canonicalizePath(homeRoot) : '';
+
+  if (distPath !== join(repositoryPath, 'dist')) {
+    throw new Error('Pages artifact dist directory must not resolve through a symlink or path alias');
+  }
+
+  if (outputPath === '/'
+    || outputPath === repositoryPath
+    || outputPath === distPath
+    || (homePath && outputPath === homePath)
+    || outputPath === temporaryPath) {
+    throw new Error('Pages artifact output directory is too broad to remove safely');
+  }
+  const lexicallyInsideRepository = lexicalOutputPath === lexicalRepositoryPath
+    || isChildPath(lexicalRepositoryPath, lexicalOutputPath);
+  if (lexicallyInsideRepository) {
+    if (!isChildPath(lexicalDistPath, lexicalOutputPath)
+      || !isChildPath(distPath, outputPath)) {
+      throw new Error('Pages artifact output directory inside the repository must remain under dist/ after path resolution');
+    }
+  } else if (!isChildPath(temporaryPath, outputPath)) {
+    throw new Error('Pages artifact output directory outside the repository must be under the system temporary directory');
+  }
+
+  return outputPath;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    process.stdout.write(resolvePagesOutputPath(process.argv[2], {
+      repoRoot: process.argv[3]
+    }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
+}

--- a/scripts/test-composer-bootstrap.js
+++ b/scripts/test-composer-bootstrap.js
@@ -204,14 +204,14 @@ class FakeDocument {
   const calls = [];
   const state = await loadInitialComposerState({
     t: key => key,
-    fetchTrackedSiteConfig: async () => ({ contentRoot: 'docs', siteTitle: 'Legacy' }),
+    fetchTrackedSiteConfig: async () => ({ contentRoot: 'docs', siteTitle: 'Legacy', defaultLanguage: 'chs' }),
     applyEffectiveSiteConfig: site => ({ ...site, contentRoot: site.contentRoot || 'wwwroot' }),
     fetchConfigWithYamlFallback: async (paths) => {
       calls.push(['fetchConfig', paths]);
       return {};
     },
-    loadContentModelMigration: async ({ contentRoot, indexRaw, tabsRaw }) => {
-      calls.push(['contentMigration', contentRoot, indexRaw, tabsRaw]);
+    loadContentModelMigration: async ({ contentRoot, indexRaw, tabsRaw, defaultLang }) => {
+      calls.push(['contentMigration', contentRoot, indexRaw, tabsRaw, defaultLang]);
       return {
         hasLegacyContentModel: true,
         indexRaw: {
@@ -231,7 +231,8 @@ class FakeDocument {
           {
             kind: 'content-model-migration',
             path: 'docs/index.en.yaml',
-            deleted: true
+            state: 'preserved',
+            deleted: false
           }
         ]
       };
@@ -249,8 +250,8 @@ class FakeDocument {
 
   assert.deepEqual(
     calls.find(call => call[0] === 'contentMigration'),
-    ['contentMigration', 'docs', {}, {}],
-    'composer bootstrap should offer the remote unified YAML as migration input'
+    ['contentMigration', 'docs', {}, {}, 'chs'],
+    'composer bootstrap should offer the remote unified YAML and effective site language as migration input'
   );
   assert.deepEqual(remoteBaseline.index, { preparedIndex: true });
   assert.deepEqual(state.index, {
@@ -273,15 +274,11 @@ class FakeDocument {
     false,
     'content migration metadata should not be enumerable editor state'
   );
-  assert.deepEqual(state.__contentModelMigration.legacyFiles, [
-    {
-      category: 'legacy-content-model',
-      state: 'deleted',
-      kind: 'content-model-migration',
-      path: 'docs/index.en.yaml',
-      deleted: true
-    }
-  ]);
+  assert.deepEqual(
+    state.__contentModelMigration.legacyFiles,
+    [],
+    'Recovery should stage unified base files without deleting preserved sidecars'
+  );
 }
 
 {

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -3608,15 +3608,16 @@ function createMemoryStorage(seed = {}) {
     storage: localStorage,
     scopeKey: (key) => `${key}:scope`,
     keys: {
-      editorState: 'press_composer_editor_state'
+      editorState: 'press_composer_editor_state',
+      systemTreeExpanded: 'press_editor_system_tree_expanded'
     }
   });
-  assert.equal(typeof store.readLegacySystemTreeExpanded, 'undefined', 'cleanup release should not expose legacy system-tree readers');
+  assert.equal(store.readLegacySystemTreeExpanded(), true, 'Recovery should read the legacy system-tree state before a current snapshot exists');
   assert.equal(store.writeEditorState({ v: 3, mode: 'editor', expandedNodeIds: ['system'] }), true, 'current editor state should persist through the v3 store');
   assert.equal(
     localStorage.dump()['press_editor_system_tree_expanded:scope'],
-    '1',
-    'current editor-state writes should not mutate the retired legacy system-tree key'
+    undefined,
+    'Recovery should remove the legacy system-tree key only after the current state write succeeds'
   );
   assert.equal(store.readUnscopedNumber('press_editor_rail_width', 340), 340, 'missing rail width should preserve the default width');
   localStorage.setItem('press_editor_rail_width', '420');
@@ -3634,12 +3635,48 @@ function createMemoryStorage(seed = {}) {
     windowRef: { localStorage, sessionStorage },
     scopeKey: (key) => `${key}:scope`
   });
-  assert.equal(store.getStoredConnectPublishSettings().mode, 'connect', 'retired legacy Connect opt-out should no longer change the current default mode');
-  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], undefined, 'retired legacy opt-out should not be normalized by the cleanup release');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'cleanup release should leave retired legacy publish keys untouched');
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat', 'Recovery should preserve the legacy Connect opt-out');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'pat', 'Recovery should normalize the legacy opt-out into the current transport key');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'Recovery should remove the legacy publish key only after writing the current mode');
   store.setStoredConnectPublishSettings({ baseUrl: 'http://127.0.0.1:8788' });
-  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'connect', 'saving current publish settings should write the current transport mode key');
-  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], '0', 'saving current publish settings should not remove or rewrite the retired key');
+  assert.equal(localStorage.dump()['press_publish_transport_mode:scope'], 'pat', 'saving current publish settings should preserve the migrated transport mode');
+  assert.equal(localStorage.dump()['press_connect_publish_enabled:scope'], undefined, 'saving current publish settings should not restore the retired key');
+}
+
+{
+  const data = new Map([['press_editor_system_tree_expanded:scope', '1']]);
+  const store = createEditorSessionStateStore({
+    storage: {
+      getItem: (key) => data.get(key) || null,
+      setItem: () => false,
+      removeItem: (key) => data.delete(key)
+    },
+    scopeKey: (key) => `${key}:scope`,
+    keys: {
+      editorState: 'press_composer_editor_state',
+      systemTreeExpanded: 'press_editor_system_tree_expanded'
+    }
+  });
+  assert.equal(store.writeEditorState({ v: 3 }), false);
+  assert.equal(data.get('press_editor_system_tree_expanded:scope'), '1', 'failed current-state writes must preserve the legacy editor key');
+}
+
+{
+  const data = new Map([['press_connect_publish_enabled:scope', '0']]);
+  const localStorage = {
+    getItem: (key) => data.get(key) || null,
+    setItem(key, value) {
+      if (key === 'press_publish_transport_mode:scope') throw new Error('storage full');
+      data.set(key, String(value));
+    },
+    removeItem: (key) => data.delete(key)
+  };
+  const store = createPublishSettingsStore({
+    windowRef: { localStorage, sessionStorage: createMemoryStorage() },
+    scopeKey: (key) => `${key}:scope`
+  });
+  assert.equal(store.getStoredConnectPublishSettings().mode, 'pat');
+  assert.equal(data.get('press_connect_publish_enabled:scope'), '0', 'failed mode writes must preserve the legacy publish preference');
 }
 
 {
@@ -7795,10 +7832,10 @@ assert.match(
   'Connect publish settings should keep the current transport key and Connect presets explicit'
 );
 
-assert.doesNotMatch(
+assert.match(
   publishSettingsSource,
-  /CONNECT_PUBLISH_ENABLED_STORAGE_KEY|press_connect_publish_enabled|enabledRaw|migratedLegacyMode/,
-  'cleanup release should remove the retired Connect publish storage bridge'
+  /CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled'[\s\S]*enabledRaw[\s\S]*migratedLegacyMode[\s\S]*storage\.setItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\), settings\.mode\)[\s\S]*storage\.removeItem\(scopedKey\(CONNECT_PUBLISH_ENABLED_STORAGE_KEY\)\)/,
+  'Recovery should migrate the legacy Connect preference with write-before-delete semantics'
 );
 
 assert.match(
@@ -7816,7 +7853,7 @@ assert.match(
 assert.match(
   publishSettingsSource,
   /mode: 'connect'[\s\S]*const modeRaw = storage\.getItem\(scopedKey\(PUBLISH_TRANSPORT_MODE_STORAGE_KEY\)\)[\s\S]*modeRaw === 'connect' \|\| modeRaw === 'pat'[\s\S]*function resolvePublishTransport/,
-  'Publish transport should default to Connect and read only the current transport mode key'
+  'Publish transport should default to Connect and prefer the current transport mode key'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-runtime.js
+++ b/scripts/test-composer-runtime.js
@@ -192,14 +192,12 @@ const legacyStateRuntime = createComposerRuntime({ windowRef, documentRef, navig
 assert.equal(legacyStateRuntime.initializeEditorSessionState({
   editorSessionStateStore: {
     readEditorState: () => ({ v: 2 }),
-    readLegacySystemTreeExpanded: () => {
-      throw new Error('legacy tree state should no longer be read');
-    }
+    readLegacySystemTreeExpanded: () => true
   },
   editorStateVersion: 3
 }), false);
 assert.equal(legacyStateRuntime.hasEditorStateSnapshot(), false);
-assert.deepEqual(legacyStateRuntime.getExpandedEditorTreeNodeIdsSnapshot(), ['articles', 'pages']);
+assert.deepEqual(legacyStateRuntime.getExpandedEditorTreeNodeIdsSnapshot(), ['articles', 'pages', 'system']);
 assert.equal(runtime.getAllowEditorStatePersist(), false);
 assert.equal(runtime.setAllowEditorStatePersist(true), true);
 assert.equal(runtime.getAllowEditorStatePersist(), true);

--- a/scripts/test-content-model-migration.js
+++ b/scripts/test-content-model-migration.js
@@ -57,13 +57,10 @@ function textResponse(text, options = {}) {
   });
   assert.deepEqual(
     getLegacyContentModelMigrationFiles(migration).map(file => [file.path, file.deleted]),
-    [
-      ['docs/index.en.yaml', true],
-      ['docs/index.chs.yaml', true],
-      ['docs/tabs.en.yaml', true],
-      ['docs/tabs.chs.yaml', true]
-    ]
+    [],
+    'Recovery should never stage destructive sidecar deletion automatically'
   );
+  assert.equal(migration.legacyFiles.every(file => file.deleted === false && file.state === 'preserved'), true);
   assert.equal(requests.includes('docs/index.ja.yaml'), true, 'registered/default sidecar languages should still be probed');
 }
 
@@ -137,9 +134,9 @@ function textResponse(text, options = {}) {
 
   assert.deepEqual(migration.indexRaw['Guide FR'].fr, 'posts/guide-fr.md');
   assert.equal(
-    getLegacyContentModelMigrationFiles(migration).some(file => file.path === 'docs/index.fr.yaml'),
+    migration.legacyFiles.some(file => file.path === 'docs/index.fr.yaml'),
     true,
-    'registered custom language sidecars should be migrated'
+    'registered custom language sidecars should be migrated without being deleted'
   );
 }
 
@@ -158,7 +155,9 @@ function textResponse(text, options = {}) {
     },
     fetchImpl: async (input) => {
       const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.en.yaml') return textResponse('Guide: posts/sidecar-default.md\n');
       if (url === 'docs/index.chs.yaml') return textResponse('指南: posts/guide-zh.md\n');
+      if (url === 'docs/tabs.en.yaml') return textResponse('Docs: docs/sidecar-default.md\n');
       if (url === 'docs/tabs.chs.yaml') return textResponse('文档: docs/index-zh.md\n');
       return textResponse('', { ok: false, status: 404 });
     }
@@ -166,7 +165,7 @@ function textResponse(text, options = {}) {
 
   assert.deepEqual(migration.indexRaw.__order, ['Guide']);
   assert.deepEqual(migration.indexRaw.Guide, {
-    en: 'posts/guide.md',
+    en: 'posts/sidecar-default.md',
     chs: {
       title: '指南',
       location: 'posts/guide-zh.md'
@@ -176,13 +175,14 @@ function textResponse(text, options = {}) {
   assert.deepEqual(migration.tabsRaw.Docs, {
     en: {
       title: 'Docs',
-      location: 'docs/index.md'
+      location: 'docs/sidecar-default.md'
     },
     chs: {
       title: '文档',
       location: 'docs/index-zh.md'
     }
   });
+  assert.equal(migration.hasLegacyContentModel, true, 'authoritative default-language sidecars should replace flat-origin defaults during normalization');
 }
 
 {
@@ -219,6 +219,32 @@ function textResponse(text, options = {}) {
       location: 'docs/index.md'
     }
   });
+}
+
+{
+  const migration = await loadLegacyContentModelMigration({
+    contentRoot: 'docs',
+    currentLang: 'en',
+    defaultLang: 'en',
+    indexRaw: {
+      __order: ['Guide'],
+      Guide: { en: 'posts/guide.md' }
+    },
+    tabsRaw: {
+      __order: ['Docs'],
+      Docs: { en: { title: 'Docs', location: 'docs/index.md' } }
+    },
+    fetchImpl: async (input) => {
+      const url = String(input || '').split('?')[0];
+      if (url === 'docs/index.en.yaml') return textResponse('Guide: posts/guide.md\n');
+      if (url === 'docs/tabs.en.yaml') return textResponse('Docs: docs/index.md\n');
+      return textResponse('', { ok: false, status: 404 });
+    }
+  });
+
+  assert.equal(migration.hasLegacyContentModel, false, 'already-normalized base files should not stage a duplicate recovery migration');
+  assert.deepEqual(getLegacyContentModelMigrationFiles(migration), []);
+  assert.equal(migration.legacyFiles.length, 2, 'preserved sidecars should remain observable without becoming deletions');
 }
 
 console.log('content model migration tests passed');

--- a/scripts/test-i18n-content-raw.js
+++ b/scripts/test-i18n-content-raw.js
@@ -201,6 +201,78 @@ globalThis.fetch = async (url) => {
       ].join('\n')
     };
   }
+  if (textUrl.endsWith('/legacy-only.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Legacy Guide: post/legacy.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-tabs.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Legacy Docs: docs/legacy.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-flat.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Guide: post/default.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-flat.chs.yaml')) {
+    return {
+      ok: true,
+      text: async () => '指南: post/chs.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-current-missing.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Current Base: post/default.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-current-missing.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Stale English Sidecar: post/legacy.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-tabs-current-missing.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Current Tabs: docs/index.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-tabs-current-missing.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Stale English Tabs: docs/legacy.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-default.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Stale Base: post/default.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-default.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Authoritative Default: post/legacy.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-tabs-default.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Stale Base Tab: docs/index.md\n'
+    };
+  }
+  if (textUrl.endsWith('/legacy-tabs-default.en.yaml')) {
+    return {
+      ok: true,
+      text: async () => 'Authoritative Default Tab: docs/legacy.md\n'
+    };
+  }
   if (textUrl.endsWith('/post/demo.md')) {
     return {
       ok: true,
@@ -225,6 +297,24 @@ globalThis.fetch = async (url) => {
         'Flat body.',
         ''
       ].join('\n')
+    };
+  }
+  if (textUrl.endsWith('/post/legacy.md')) {
+    return {
+      ok: true,
+      text: async () => '---\ntitle: Legacy Guide\n---\nLegacy body.\n'
+    };
+  }
+  if (textUrl.endsWith('/post/chs.md')) {
+    return {
+      ok: true,
+      text: async () => '---\ntitle: 指南\n---\n中文内容。\n'
+    };
+  }
+  if (textUrl.endsWith('/post/default.md')) {
+    return {
+      ok: true,
+      text: async () => '---\ntitle: Current Base\n---\nDefault content.\n'
     };
   }
   if (textUrl.endsWith('/post/secret.md')) {
@@ -315,20 +405,20 @@ assert.equal(result.entries['Secret Title'].protected, true);
 
 const beforeLegacyContentRequests = requests.length;
 const legacyContent = await loadContentJsonWithRaw('wwwroot', 'legacy-only');
-assert.deepEqual(legacyContent.entries, {});
+assert.equal(legacyContent.entries['Legacy Guide'].location, 'post/legacy.md');
 assert.equal(
   requests.slice(beforeLegacyContentRequests).some(url => /legacy-only\.[a-z0-9-]+\.ya?ml$/i.test(url)),
-  false,
-  'clean content runtime should not probe legacy per-language index YAML sidecars'
+  true,
+  'recovery runtime should read a legacy per-language index YAML sidecar when the base file is absent'
 );
 
 const beforeLegacyTabsRequests = requests.length;
 const legacyTabs = await loadTabsJson('wwwroot', 'legacy-tabs');
-assert.deepEqual(legacyTabs, {});
+assert.deepEqual(legacyTabs, { 'Legacy Docs': 'docs/legacy.md' });
 assert.equal(
   requests.slice(beforeLegacyTabsRequests).some(url => /legacy-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
-  false,
-  'clean content runtime should not probe legacy per-language tabs YAML sidecars'
+  true,
+  'recovery runtime should read a legacy per-language tabs YAML sidecar when the base file is absent'
 );
 
 const beforeFlatTabsRequests = requests.length;
@@ -339,8 +429,8 @@ assert.deepEqual(flatTabs, {
 });
 assert.equal(
   requests.slice(beforeFlatTabsRequests).some(url => /flat-tabs\.[a-z0-9-]+\.ya?ml$/i.test(url)),
-  false,
-  'clean content runtime should keep base flat tabs without probing legacy per-language tabs YAML sidecars'
+  true,
+  'Recovery should probe the exact current-language tabs sidecar before keeping a flat base'
 );
 
 const beforeFlatIndexRequests = requests.length;
@@ -349,9 +439,40 @@ assert.deepEqual(flatIndex.raw, { Guide: 'post/flat.md' });
 assert.equal(flatIndex.entries.Guide.location, 'post/flat.md');
 assert.equal(
   requests.slice(beforeFlatIndexRequests).some(url => /flat-index\.[a-z0-9-]+\.ya?ml$/i.test(url)),
-  false,
-  'clean content runtime should keep base flat index string entries without probing legacy per-language index YAML sidecars'
+  true,
+  'Recovery should probe the exact current-language index sidecar before keeping a flat base'
 );
+
+const recoveredDefaultIndex = await loadContentJsonWithRaw('wwwroot', 'legacy-default');
+assert.equal(recoveredDefaultIndex.entries['Legacy Guide'].location, 'post/legacy.md');
+assert.equal(recoveredDefaultIndex.entries['Stale Base'], undefined, 'the historical default-language sidecar must remain authoritative over a flat base');
+
+const recoveredDefaultTabs = await loadTabsJson('wwwroot', 'legacy-tabs-default');
+assert.deepEqual(recoveredDefaultTabs, { 'Authoritative Default Tab': 'docs/legacy.md' });
+
+const recoveryController = createI18nController({
+  windowRef: {
+    location: { href: 'https://example.test/', pathname: '/' },
+    navigator: { language: 'chs' },
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return true; }
+  },
+  documentRef: globalThis.document,
+  localStorageRef: globalThis.localStorage,
+  fetchImpl: globalThis.fetch
+});
+await recoveryController.init({ lang: 'chs', defaultLang: 'en', persist: false });
+const recoveredFlatIndex = await recoveryController.loadContentJsonWithRaw('wwwroot', 'legacy-flat');
+assert.equal(recoveredFlatIndex.entries['指南'].location, 'post/chs.md');
+assert.deepEqual(recoveredFlatIndex.raw, { Guide: 'post/default.md' });
+
+const currentMissingIndex = await recoveryController.loadContentJsonWithRaw('wwwroot', 'legacy-current-missing');
+assert.equal(currentMissingIndex.entries['Current Base'].location, 'post/default.md');
+assert.equal(currentMissingIndex.entries['Stale English Sidecar'], undefined, 'a stale default-language sidecar must not override a usable base file when the current-language sidecar is absent');
+
+const currentMissingTabs = await recoveryController.loadTabsJson('wwwroot', 'legacy-tabs-current-missing');
+assert.deepEqual(currentMissingTabs, { 'Current Tabs': 'docs/index.md' });
 
 const unified = await loadContentJsonWithRaw('wwwroot', 'unified');
 assert.equal(unified.entries['Unified Secret'].protected, true);

--- a/scripts/test-manifest.json
+++ b/scripts/test-manifest.json
@@ -2,13 +2,14 @@
   "schemaVersion": 1,
   "timeoutUnit": "milliseconds",
   "expected": {
-    "logical": 176,
-    "physical": 177,
+    "logical": 177,
+    "physical": 178,
     "aliases": 1
   },
   "tierOrder": {
     "guard": [
       "release-graph",
+      "recovery-updater-compatibility",
       "system-release-transaction",
       "system-release-package",
       "system-release-workflow",
@@ -36,6 +37,7 @@
     ],
     "release": [
       "release-graph",
+      "recovery-updater-compatibility",
       "system-release-transaction",
       "composer-action-contract",
       "composer-root-contract",
@@ -2714,6 +2716,29 @@
       "exclusive": false,
       "requires": [
         "node"
+      ],
+      "alias": []
+    },
+    {
+      "id": "recovery-updater-compatibility",
+      "file": "scripts/test-recovery-updater-compatibility.mjs",
+      "command": [
+        "node",
+        "scripts/test-recovery-updater-compatibility.mjs"
+      ],
+      "tier": [
+        "guard",
+        "release",
+        "full"
+      ],
+      "timeout": 300000,
+      "exclusive": false,
+      "requires": [
+        "bash",
+        "git",
+        "node",
+        "tar",
+        "zip"
       ],
       "alias": []
     },

--- a/scripts/test-pages-artifact.sh
+++ b/scripts/test-pages-artifact.sh
@@ -6,7 +6,8 @@ tmp_dir="$(mktemp -d)"
 untracked_paths=()
 
 cleanup() {
-  for untracked_path in "${untracked_paths[@]}"; do
+  for untracked_path in "${untracked_paths[@]:-}"; do
+    [[ -n "${untracked_path}" ]] || continue
     rm -f "${repo_root}/${untracked_path}"
   done
   rm -rf "${tmp_dir}"
@@ -34,6 +35,60 @@ printf 'local\n' > wwwroot/__untracked-pages-artifact-probe.md
 
 if bash scripts/build-pages-artifact.sh "${repo_root}" "${version}" >/dev/null 2>&1; then
   echo "Pages artifact builder must reject the repository root as an output directory" >&2
+  exit 1
+fi
+
+alias_root="${tmp_dir}/repository-parent-alias"
+ln -s "$(dirname "${repo_root}")" "${alias_root}"
+alias_repo="${alias_root}/$(basename "${repo_root}")"
+if node scripts/resolve-pages-output-path.mjs "${alias_repo}" "${repo_root}" >/dev/null 2>&1; then
+  echo "Pages artifact output validation must reject a repository-root path through a symlinked parent" >&2
+  exit 1
+fi
+if [[ ! -d "${repo_root}/.git" || ! -f "${repo_root}/assets/press-system.json" ]]; then
+  echo "Pages artifact output validation must not remove the repository through a path alias" >&2
+  exit 1
+fi
+
+fake_repo="${tmp_dir}/symlinked-dist-repo"
+mkdir -p "${fake_repo}/assets/js"
+printf 'keep\n' > "${fake_repo}/assets/js/sentinel.txt"
+ln -s assets "${fake_repo}/dist"
+if node scripts/resolve-pages-output-path.mjs "${fake_repo}/dist/js" "${fake_repo}" >/dev/null 2>&1; then
+  echo "Pages artifact output validation must reject dist symlinks into repository assets" >&2
+  exit 1
+fi
+if [[ ! -f "${fake_repo}/assets/js/sentinel.txt" ]]; then
+  echo "Pages artifact output validation must not remove tracked paths through a dist symlink" >&2
+  exit 1
+fi
+rm "${fake_repo}/dist"
+ln -s . "${fake_repo}/dist"
+if node scripts/resolve-pages-output-path.mjs "${fake_repo}/dist/pages" "${fake_repo}" >/dev/null 2>&1; then
+  echo "Pages artifact output validation must reject dist symlinks to the repository root" >&2
+  exit 1
+fi
+rm "${fake_repo}/dist"
+mkdir -p "${fake_repo}/dist"
+ln -s ../assets/js "${fake_repo}/dist/pages"
+if node scripts/resolve-pages-output-path.mjs "${fake_repo}/dist/pages" "${fake_repo}" >/dev/null 2>&1; then
+  echo "Pages artifact output validation must reject a symlinked dist/pages output" >&2
+  exit 1
+fi
+if [[ ! -f "${fake_repo}/assets/js/sentinel.txt" ]]; then
+  echo "Pages artifact output validation must preserve tracked files behind a dist/pages symlink" >&2
+  exit 1
+fi
+rm "${fake_repo}/dist/pages"
+mkdir -p "${tmp_dir}/redirected-pages-target"
+printf 'keep\n' > "${tmp_dir}/redirected-pages-target/sentinel.txt"
+ln -s "${tmp_dir}/redirected-pages-target" "${fake_repo}/dist/pages"
+if node scripts/resolve-pages-output-path.mjs "${fake_repo}/dist/pages" "${fake_repo}" >/dev/null 2>&1; then
+  echo "Pages artifact output validation must reject repo-local aliases even when they target the system temporary directory" >&2
+  exit 1
+fi
+if [[ ! -f "${tmp_dir}/redirected-pages-target/sentinel.txt" ]]; then
+  echo "Pages artifact output validation must preserve temporary files behind a repo-local output alias" >&2
   exit 1
 fi
 

--- a/scripts/test-pages-workflow.sh
+++ b/scripts/test-pages-workflow.sh
@@ -110,6 +110,11 @@ if ! grep -F 'node scripts/sync-runtime-cache-keys.mjs --materialize-root "${out
   exit 1
 fi
 
+if ! grep -F 'node scripts/resolve-pages-output-path.mjs "${output_dir}" "${repo_root}"' scripts/build-pages-artifact.sh >/dev/null; then
+  echo "Pages artifact builder must canonicalize and validate its output path before removal" >&2
+  exit 1
+fi
+
 if grep -F 'path: dist/system' "${workflow}" >/dev/null || grep -F 'path: dist/press-system' "${workflow}" >/dev/null; then
   echo "Pages workflow must not deploy a system update package directory because it excludes wwwroot site content" >&2
   exit 1
@@ -117,6 +122,11 @@ fi
 
 if ! grep -F 'scripts/build-pages-artifact.sh' assets/js/press-system-surface.mjs >/dev/null; then
   echo "Pages release-plan paths must include the shared Pages artifact builder" >&2
+  exit 1
+fi
+
+if ! grep -F 'scripts/resolve-pages-output-path.mjs' assets/js/press-system-surface.mjs >/dev/null; then
+  echo "Pages release-plan paths must include the output-path validator used by the artifact builder" >&2
   exit 1
 fi
 

--- a/scripts/test-press-system-surface.mjs
+++ b/scripts/test-press-system-surface.mjs
@@ -43,6 +43,9 @@ assert.deepEqual(
 );
 assert(!getPressSystemReleasePlanPaths().includes('scripts/build-pages-artifact.sh'));
 assert(getPressSystemReleasePlanPaths({ includePagesMaterializer: true }).includes('scripts/build-pages-artifact.sh'));
+assert(!getPressSystemReleasePlanPaths().includes('scripts/resolve-pages-output-path.mjs'));
+assert(getPressSystemReleasePlanPaths({ includePagesMaterializer: true }).includes('scripts/resolve-pages-output-path.mjs'));
+assert(!packagePaths.includes('scripts/resolve-pages-output-path.mjs'));
 assert(getPressSystemReleasePlanPaths().includes('packages/press-theme-contract'));
 assert(getPressSystemReleasePlanPaths().includes('scripts/build-theme-contract-package.mjs'));
 assert(getPressSystemReleasePlanPaths().includes('scripts/compare-theme-contract-package.mjs'));

--- a/scripts/test-press-version-runtime.js
+++ b/scripts/test-press-version-runtime.js
@@ -59,6 +59,7 @@ assert.equal((await loadPressSystemManifest({ manifestLoader: secondLoader })).v
 
 const guardedManifest = normalizePressSystemManifest({
   ...manifest('3.4.123'),
+  securityUpdate: true,
   themeContractUpgrade: {
     requiresInstalledThemeContractVersion: 4,
     message: 'Update installed themes to contract v4 first.'
@@ -68,13 +69,21 @@ const guardedManifest = normalizePressSystemManifest({
     message: 'Publish content model migration first.'
   }
 });
+assert.equal(guardedManifest.securityUpdate, true);
 assert.equal(guardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 4);
 assert.equal(guardedManifest.themeContractUpgrade.message, 'Update installed themes to contract v4 first.');
 assert.equal(guardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, true);
 assert.equal(guardedManifest.contentModelUpgrade.message, 'Publish content model migration first.');
 
 const unguardedManifest = normalizePressSystemManifest(manifest('3.4.122'));
+assert.equal(unguardedManifest.securityUpdate, false);
 assert.equal(unguardedManifest.themeContractUpgrade.requiresInstalledThemeContractVersion, 0);
 assert.equal(unguardedManifest.contentModelUpgrade.requiresUnifiedIndexTabs, false);
+
+assert.throws(
+  () => normalizePressSystemManifest(manifest('3.4.134')),
+  /securityUpdate.*explicit boolean/i
+);
+assert.equal(normalizePressSystemManifest({ ...manifest('3.4.134'), securityUpdate: false }).securityUpdate, false);
 
 console.log('ok - press system manifest loader state is explicit per instance');

--- a/scripts/test-recovery-updater-compatibility.mjs
+++ b/scripts/test-recovery-updater-compatibility.mjs
@@ -1,0 +1,294 @@
+import assert from 'node:assert/strict';
+import { createHash, webcrypto } from 'node:crypto';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = realpathSync(resolve(here, '..'));
+const recoveryVersion = '3.4.134';
+const recoveryTag = `v${recoveryVersion}`;
+// Every published source in the declared Recovery support interval is tested.
+// Code-blob sampling is insufficient because the same updater implementation
+// can behave differently when paired with a different installed manifest.
+const historicalTags = [
+  'v3.4.64',
+  ...Array.from({ length: 26 }, (_, index) => `v3.4.${108 + index}`)
+];
+const archiveName = `press-system-${recoveryTag}.zip`;
+const archiveUrl = `https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/${recoveryTag}/${archiveName}`;
+const manifestUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/system-release.json';
+const maxBuffer = 128 * 1024 * 1024;
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: options.encoding,
+    env: options.env || process.env,
+    input: options.input,
+    maxBuffer,
+    stdio: options.stdio
+  });
+}
+
+function isShallowCheckout() {
+  return String(run('git', ['rev-parse', '--is-shallow-repository'], { encoding: 'utf8' })).trim() === 'true';
+}
+
+function hasGitObject(spec) {
+  const result = spawnSync('git', ['cat-file', '-e', spec], {
+    cwd: repoRoot,
+    stdio: 'ignore'
+  });
+  return result.status === 0;
+}
+
+function exactArrayBuffer(value) {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
+function responseFromBuffer(value, { status = 200 } = {}) {
+  const buffer = Buffer.from(value);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => '' },
+    async arrayBuffer() {
+      return exactArrayBuffer(buffer);
+    },
+    async json() {
+      return JSON.parse(buffer.toString('utf8'));
+    },
+    async text() {
+      return buffer.toString('utf8');
+    }
+  };
+}
+
+function missingResponse(status = 404) {
+  return responseFromBuffer('', { status });
+}
+
+function extractHistoricalRuntime(tag, destination) {
+  const archive = run('git', [
+    'archive',
+    '--format=tar',
+    tag,
+    '--',
+    'assets/js',
+    'assets/i18n',
+    'assets/press-system.json'
+  ]);
+  run('tar', ['-xf', '-', '-C', destination], { input: archive });
+  writeFileSync(join(destination, 'package.json'), '{"type":"module"}\n');
+}
+
+function buildRecoveryArchive(outputDirectory) {
+  const manifestPath = join(repoRoot, 'assets/press-system.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  assert.equal(manifest.version, recoveryVersion, `worktree must target recovery version ${recoveryVersion}`);
+  assert.equal(manifest.tag, recoveryTag, `worktree must target recovery tag ${recoveryTag}`);
+  assert.deepEqual(
+    manifest.upgradeFrom && manifest.upgradeFrom.ranges,
+    [`>=3.4.64 <${recoveryVersion}`],
+    'recovery archive must directly admit the full supported source interval'
+  );
+  assert.equal(manifest.upgradeFrom && manifest.upgradeFrom.allowUnknownSource, false);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(manifest, 'themeContractUpgrade'),
+    false,
+    'recovery archive must not retain a theme cleanup prerequisite'
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(manifest, 'contentModelUpgrade'),
+    false,
+    'recovery archive must not retain a content cleanup prerequisite'
+  );
+
+  run('bash', [join(repoRoot, 'scripts/package-system-release.sh'), recoveryTag, outputDirectory], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PRESS_PACKAGE_SOURCE: 'worktree'
+    }
+  });
+
+  const archivePath = join(outputDirectory, archiveName);
+  assert.equal(existsSync(archivePath), true, `expected recovery archive at ${archivePath}`);
+  return {
+    archive: readFileSync(archivePath),
+    manifest
+  };
+}
+
+function localHistoricalResponse(root, requestUrl) {
+  const clean = String(requestUrl || '').split(/[?#]/u, 1)[0].replace(/^\.?\//u, '');
+  if (!clean || clean.startsWith('/') || clean.includes('\\')) return null;
+  const candidate = resolve(root, clean);
+  const rel = relative(root, candidate);
+  if (!rel || rel === '..' || rel.startsWith(`..${sep}`) || resolve(root, rel) !== candidate) return null;
+  try {
+    if (!statSync(candidate).isFile()) return null;
+    return responseFromBuffer(readFileSync(candidate));
+  } catch (_) {
+    return null;
+  }
+}
+
+function createReleaseManifest(archive, upgradeFrom) {
+  const digest = createHash('sha256').update(archive).digest('hex');
+  return {
+    schemaVersion: 1,
+    name: `Press ${recoveryTag}`,
+    tag: recoveryTag,
+    version: recoveryVersion,
+    publishedAt: '2026-07-10T00:00:00Z',
+    notes: 'Recovery updater compatibility fixture.',
+    htmlUrl: `https://github.com/EkilyHQ/Press/releases/tag/${recoveryTag}`,
+    upgradeFrom,
+    asset: {
+      name: archiveName,
+      url: archiveUrl,
+      size: archive.length,
+      digest: `sha256:${digest}`
+    }
+  };
+}
+
+function createFetchFixture({ archive, historicalRoot, releaseManifest }) {
+  const calls = [];
+  const fetchImpl = async (input) => {
+    const url = String(input && input.url ? input.url : input);
+    calls.push(url);
+    if (url === archiveUrl) return responseFromBuffer(archive);
+    if (url === manifestUrl || url.endsWith('/release-artifacts/system-release.json')) {
+      return responseFromBuffer(JSON.stringify(releaseManifest));
+    }
+    if (/\/api\/press\/system-release(?:[/?#]|$)/u.test(url)) return missingResponse();
+    if (/api\.github\.com\/repos\/EkilyHQ\/Press\/releases\/latest/u.test(url)) {
+      return missingResponse(500);
+    }
+    return localHistoricalResponse(historicalRoot, url) || missingResponse();
+  };
+  return { calls, fetchImpl };
+}
+
+function stagedFileText(file) {
+  if (typeof file.content === 'string') return file.content;
+  if (file.base64) return Buffer.from(file.base64, 'base64').toString('utf8');
+  return '';
+}
+
+async function verifyHistoricalUpdater({ archive, releaseManifest, tag, tempRoot }) {
+  const historicalRoot = join(tempRoot, tag);
+  mkdirSync(historicalRoot, { recursive: true });
+  extractHistoricalRuntime(tag, historicalRoot);
+
+  const sourceManifest = JSON.parse(readFileSync(join(historicalRoot, 'assets/press-system.json'), 'utf8'));
+  assert.equal(sourceManifest.tag, tag, `${tag} fixture must retain its tagged source manifest`);
+
+  const updaterUrl = pathToFileURL(join(historicalRoot, 'assets/js/system-updates.js'));
+  updaterUrl.searchParams.set('recovery-compat', tag);
+  const updater = await import(updaterUrl.href);
+  assert.equal(typeof updater.createSystemUpdatesController, 'function', `${tag} must expose its updater controller`);
+  assert.equal(typeof updater.verifySystemUpdateAsset, 'function', `${tag} must expose its asset verifier`);
+  assert.equal(typeof updater.collectSystemUpdateArchiveEntries, 'function', `${tag} must expose its archive reader`);
+
+  const archiveBuffer = exactArrayBuffer(archive);
+  const verification = await updater.verifySystemUpdateAsset(archiveBuffer, releaseManifest.asset);
+  assert.equal(verification.size, archive.length, `${tag} must verify the real recovery archive size`);
+  assert.equal(
+    verification.sha256,
+    releaseManifest.asset.digest.replace(/^sha256:/u, ''),
+    `${tag} must verify the real recovery archive digest`
+  );
+
+  const unpacked = updater.collectSystemUpdateArchiveEntries(archiveBuffer);
+  const unpackedPaths = new Set(unpacked.map((entry) => entry.path));
+  for (const requiredPath of [
+    'index.html',
+    'index_editor.html',
+    'assets/press-system.json',
+    'assets/js/system-updates.js'
+  ]) {
+    assert.equal(unpackedPaths.has(requiredPath), true, `${tag} must unpack ${requiredPath}`);
+  }
+
+  const { calls, fetchImpl } = createFetchFixture({ archive, historicalRoot, releaseManifest });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    const controller = updater.createSystemUpdatesController({ fetchImpl });
+    await controller.stageLatest();
+    const stagedFiles = controller.getCommitFiles();
+    assert(stagedFiles.length > 0, `${tag} must put recovery files into Composer staging`);
+    assert(
+      stagedFiles.every((file) => updater.isSystemUpdatePath(file.path)),
+      `${tag} must stage only Press system paths`
+    );
+
+    const stagedManifest = stagedFiles.find((file) => file.path === 'assets/press-system.json');
+    assert(stagedManifest, `${tag} must stage the recovery Press manifest`);
+    const parsedManifest = JSON.parse(stagedFileText(stagedManifest));
+    assert.equal(parsedManifest.version, recoveryVersion);
+    assert.equal(parsedManifest.tag, recoveryTag);
+    assert.equal(
+      calls.filter((url) => url === archiveUrl).length,
+      1,
+      `${tag} must download the canonical recovery archive exactly once`
+    );
+    assert(
+      calls.some((url) => url === manifestUrl || url.endsWith('/release-artifacts/system-release.json')),
+      `${tag} must resolve the browser-readable release manifest`
+    );
+    console.log(`PASS ${tag} -> ${recoveryTag} (${unpacked.length} unpacked, ${stagedFiles.length} staged)`);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+async function main() {
+  const missingTags = historicalTags.filter((tag) => (
+    !hasGitObject(`${tag}^{commit}`)
+    || !hasGitObject(`${tag}:assets/js/system-updates.js`)
+    || !hasGitObject(`${tag}:assets/press-system.json`)
+  ));
+  if (missingTags.length > 0) {
+    if (isShallowCheckout()) {
+      console.log(`SKIP recovery updater compatibility: shallow checkout is missing ${missingTags.join(', ')}`);
+      return;
+    }
+    throw new Error(`recovery updater compatibility requires historical tags: ${missingTags.join(', ')}`);
+  }
+
+  const tempRoot = mkdtempSync(join(tmpdir(), 'press-recovery-updater-'));
+  try {
+    const { archive, manifest } = buildRecoveryArchive(tempRoot);
+    const releaseManifest = createReleaseManifest(archive, manifest.upgradeFrom);
+    for (const tag of historicalTags) {
+      await verifyHistoricalUpdater({ archive, releaseManifest, tag, tempRoot });
+    }
+    console.log(`PASS recovery updater compatibility (${historicalTags.length} frozen updaters)`);
+  } finally {
+    rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+if (typeof globalThis.btoa !== 'function') {
+  globalThis.btoa = (value) => Buffer.from(String(value), 'binary').toString('base64');
+}
+
+await main();

--- a/scripts/test-release-graph.js
+++ b/scripts/test-release-graph.js
@@ -7,6 +7,7 @@ const test = require('node:test');
 
 const {
   analyzeReleaseGraph,
+  compareSemver,
   expectedTargetMetadata,
   loadPublishedReleaseRegistry,
   satisfiesSemverRange,
@@ -60,13 +61,15 @@ function upgradeFrom(range) {
 }
 
 function candidateManifest(version, range) {
-  return {
+  const manifest = {
     schemaVersion: 1,
     type: 'press-system',
     version,
     tag: `v${version}`,
     upgradeFrom: upgradeFrom(range)
   };
+  if (compareSemver(version, '3.4.134') >= 0) manifest.securityUpdate = false;
+  return manifest;
 }
 
 function candidateArchive(candidate) {
@@ -106,6 +109,7 @@ function makePublishedRelease(version, range, policy, artifactPaths) {
     schemaVersion: 1,
     tag: `v${version}`,
     version,
+    ...(compareSemver(version, '3.4.134') >= 0 ? { securityUpdate: false } : {}),
     upgradeFrom: upgradeFrom(range),
     runtime,
     asset,
@@ -134,6 +138,7 @@ function makePublishedRelease(version, range, policy, artifactPaths) {
     pressSystem: {
       asset,
       runtime,
+      ...(compareSemver(version, '3.4.134') >= 0 ? { securityUpdate: false } : {}),
       upgradeFrom: manifest.upgradeFrom
     }
   };
@@ -209,6 +214,24 @@ function enableDirectRecovery(fixture, version = '3.4.134') {
   fixture.policy.candidateGate.mode = 'direct';
   fixture.policy.legacyExceptions[0].status = 'recovered';
   fixture.policy.legacyExceptions[0].recoveredByVersion = version;
+}
+
+function publishedRecoveryFixture() {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  const recoveryRelease = makePublishedRelease(
+    '3.4.134',
+    '>=3.4.64 <3.4.134',
+    fixture.policy,
+    fixture.artifactPaths
+  );
+  fixture.publishedReleases.push(recoveryRelease);
+  fixture.gitTags.add('v3.4.134');
+  fixture.githubReleases.set('v3.4.134', githubReleaseFor(recoveryRelease));
+  fixture.latestReleaseIntentText = recoveryRelease.intentText;
+  fixture.latestSystemReleaseText = recoveryRelease.manifestText;
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  return { fixture, recoveryRelease };
 }
 
 test('current v3.4.133 baseline is explicit recovery debt, not a healthy multi-hop graph', () => {
@@ -328,6 +351,71 @@ test('direct mode accepts a recovery candidate that admits every supported publi
   assert.deepEqual(result.directMissing, []);
 });
 
+test('direct mode requires continuous support-domain coverage, not an enumeration of published tags', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest(
+    '3.4.134',
+    '=3.4.64 || =3.4.108 || =3.4.109 || =3.4.132 || =3.4.133'
+  );
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.deepEqual(result.directMissing, []);
+  assert.match(
+    result.failures.join('\n'),
+    /upgradeFrom must cover the complete declared support domain below the candidate/u
+  );
+});
+
+test('v3.4.134 and newer candidates require an explicit securityUpdate boolean', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  delete fixture.candidate.securityUpdate;
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /candidate v3\.4\.134 securityUpdate must be an explicit boolean/u);
+  assert.match(failures, /archive Press system manifest securityUpdate must be an explicit boolean/u);
+});
+
+test('securityUpdate marks presentation only and cannot bypass direct recovery coverage', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.133 <3.4.134');
+  fixture.candidate.securityUpdate = true;
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /lacks latest-only direct upgrade edges from: v3\.4\.64/u);
+  assert.ok(result.directMissing.includes('3.4.132'));
+});
+
+test('candidate ZIP securityUpdate must match the worktree source manifest', () => {
+  const fixture = baselineFixture();
+  enableDirectRecovery(fixture);
+  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  fixture.candidateArchive = candidateArchive(fixture.candidate);
+  fixture.candidateArchive.embeddedManifest.securityUpdate = true;
+  fixture.validationMode = 'candidate';
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(result.failures.join('\n'), /archive Press system manifest does not match the worktree candidate/u);
+});
+
+test('historical releases normalize a missing securityUpdate marker to false', () => {
+  const fixture = baselineFixture();
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.equal(fixture.publishedReleases.every((release) => !('securityUpdate' in release.manifest)), true);
+  assert.equal(result.failures.some((failure) => failure.includes('securityUpdate')), false);
+});
+
 test('auto mode audits the baseline and validates a newer worktree as a candidate', () => {
   const baseline = baselineFixture();
   baseline.validationMode = 'auto';
@@ -369,24 +457,44 @@ test('direct recovery must close the active debt state in the same candidate pol
 });
 
 test('recovered historical break remains auditable after the recovery release is published', () => {
-  const fixture = baselineFixture();
-  enableDirectRecovery(fixture);
-  const recoveryRelease = makePublishedRelease(
-    '3.4.134',
-    '>=3.4.64 <3.4.134',
-    fixture.policy,
-    fixture.artifactPaths
-  );
-  fixture.publishedReleases.push(recoveryRelease);
-  fixture.gitTags.add('v3.4.134');
-  fixture.githubReleases.set('v3.4.134', githubReleaseFor(recoveryRelease));
-  fixture.latestReleaseIntentText = recoveryRelease.intentText;
-  fixture.latestSystemReleaseText = recoveryRelease.manifestText;
-  fixture.candidate = candidateManifest('3.4.134', '>=3.4.64 <3.4.134');
+  const { fixture } = publishedRecoveryFixture();
   const result = analyzeReleaseGraph(fixture);
 
   assert.deepEqual(result.failures, []);
   assert.deepEqual(result.directMissing, []);
+});
+
+test('published source and system-release securityUpdate markers must match', () => {
+  const { fixture, recoveryRelease } = publishedRecoveryFixture();
+  recoveryRelease.sourceManifest.securityUpdate = true;
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(
+    result.failures.join('\n'),
+    /tagged Press system securityUpdate does not match system-release\.json/u
+  );
+});
+
+test('published system-release and release-intent securityUpdate markers must match', () => {
+  const { fixture, recoveryRelease } = publishedRecoveryFixture();
+  recoveryRelease.intent.pressSystem.securityUpdate = true;
+  const result = analyzeReleaseGraph(fixture);
+
+  assert.match(
+    result.failures.join('\n'),
+    /release intent securityUpdate does not match system-release\.json/u
+  );
+});
+
+test('published v3.4.134 manifests require explicit securityUpdate markers', () => {
+  const { fixture, recoveryRelease } = publishedRecoveryFixture();
+  delete recoveryRelease.manifest.securityUpdate;
+  delete recoveryRelease.intent.pressSystem.securityUpdate;
+  const result = analyzeReleaseGraph(fixture);
+  const failures = result.failures.join('\n');
+
+  assert.match(failures, /system-release securityUpdate must be an explicit boolean/u);
+  assert.match(failures, /release intent pressSystem securityUpdate must be an explicit boolean/u);
 });
 
 test('one explicit transient candidate tag can resume candidate validation without becoming latest', () => {

--- a/scripts/test-release-intent.js
+++ b/scripts/test-release-intent.js
@@ -10,8 +10,8 @@ const {
   getReleaseTargets
 } = require('./release-targets.js');
 
-function systemRelease(version = '3.4.62') {
-  return {
+function systemRelease(version = '3.4.62', options = {}) {
+  const release = {
     schemaVersion: 1,
     name: `v${version}`,
     tag: `v${version}`,
@@ -52,6 +52,10 @@ function systemRelease(version = '3.4.62') {
       latestUrl: 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/release-intent.json'
     }
   };
+  if (Object.prototype.hasOwnProperty.call(options, 'securityUpdate')) {
+    release.securityUpdate = options.securityUpdate;
+  }
+  return release;
 }
 
 test('buildReleaseIntent freezes Press release targets and artifact metadata', () => {
@@ -73,6 +77,7 @@ test('buildReleaseIntent freezes Press release targets and artifact metadata', (
   assert.equal(intent.latestSource, release.intent.latestUrl);
   assert.equal(intent.systemRelease.path, 'system-release.json');
   assert.equal(intent.systemRelease.digest, 'sha256:system');
+  assert.equal(intent.pressSystem.securityUpdate, false);
   assert.deepEqual(intent.pressSystem.themeContractUpgrade, release.themeContractUpgrade);
   assert.deepEqual(intent.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
   assert.deepEqual(intent.targets.map((target) => target.key), getReleaseTargets().map((target) => target.key));
@@ -84,6 +89,45 @@ test('buildReleaseIntent freezes Press release targets and artifact metadata', (
   assert.equal(arcusTarget.observedChannels.demoLock.source, 'https://raw.githubusercontent.com/EkilyHQ/Press-Theme-Arcus/demo/demo-release-lock.json');
   assert.equal(intent.targets[0].reconciler.idempotent, true);
   assert.deepEqual(validateReleaseIntent(intent, { systemRelease: release }), []);
+});
+
+test('securityUpdate is explicit from v3.4.134 and propagates into release intent', () => {
+  const ordinary = systemRelease('3.4.134', { securityUpdate: false });
+  const ordinaryIntent = buildReleaseIntent({ systemRelease: ordinary });
+  assert.equal(ordinaryIntent.pressSystem.securityUpdate, false);
+  assert.deepEqual(validateReleaseIntent(ordinaryIntent, { systemRelease: ordinary }), []);
+
+  const security = systemRelease('3.4.135', { securityUpdate: true });
+  const securityIntent = buildReleaseIntent({ systemRelease: security });
+  assert.equal(securityIntent.pressSystem.securityUpdate, true);
+  assert.deepEqual(validateReleaseIntent(securityIntent, { systemRelease: security }), []);
+});
+
+test('historical missing securityUpdate metadata normalizes to false', () => {
+  const release = systemRelease('3.4.133');
+  const intent = buildReleaseIntent({ systemRelease: release });
+
+  delete intent.pressSystem.securityUpdate;
+  assert.equal(validateReleaseIntent(intent, { systemRelease: release }).some((failure) => (
+    failure.includes('securityUpdate')
+  )), false);
+});
+
+test('v3.4.134 securityUpdate must be explicit and match system-release.json', () => {
+  const release = systemRelease('3.4.134', { securityUpdate: false });
+  const intent = buildReleaseIntent({ systemRelease: release });
+
+  intent.pressSystem.securityUpdate = true;
+  assert.match(
+    validateReleaseIntent(intent, { systemRelease: release }).join('\n'),
+    /release intent securityUpdate must match system-release\.json/u
+  );
+
+  delete intent.pressSystem.securityUpdate;
+  delete release.securityUpdate;
+  const failures = validateReleaseIntent(intent, { systemRelease: release }).join('\n');
+  assert.match(failures, /release intent pressSystem\.securityUpdate must be an explicit boolean/u);
+  assert.match(failures, /system-release\.json securityUpdate must be an explicit boolean/u);
 });
 
 test('buildReleaseIntent can point immutable intents at tag-scoped system release manifests', () => {

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -35,6 +35,11 @@ if [[ "$(grep -Fc 'git status --porcelain --untracked-files=all' "${full_workflo
   exit 1
 fi
 
+if ! grep -F 'fetch-depth: 0' "${full_workflow}" >/dev/null; then
+  echo "full test workflow must fetch historical tags required by compatibility tests" >&2
+  exit 1
+fi
+
 if grep -F 'pull-requests: write' "${workflow}" >/dev/null; then
   echo "system release workflow must not request pull request permissions" >&2
   exit 1
@@ -135,6 +140,7 @@ const manifest = require('./scripts/test-manifest.json');
 
 assert.deepEqual(manifest.tierOrder.guard, [
   'release-graph',
+  'recovery-updater-compatibility',
   'system-release-transaction',
   'system-release-package',
   'system-release-workflow',
@@ -163,6 +169,7 @@ assert.deepEqual(manifest.tierOrder.guard, [
 
 assert.deepEqual(manifest.tierOrder.release, [
   'release-graph',
+  'recovery-updater-compatibility',
   'system-release-transaction',
   'composer-action-contract',
   'composer-root-contract',
@@ -261,6 +268,31 @@ if grep -F '${{ steps.plan.outputs.changed_files }}' "${workflow}" >/dev/null \
   exit 1
 fi
 
+if grep -F 'Resume interrupted ${next_tag} release transaction' "${workflow}" >/dev/null; then
+  echo "release retries must regenerate the same changed-file list and presentation metadata as the initial attempt" >&2
+  exit 1
+fi
+
+if ! grep -F -- '- name: Prepare deterministic release presentation' "${workflow}" >/dev/null \
+  || ! grep -F "if: steps.plan.outputs.should_release == 'true' || steps.transaction.outputs.action == 'resume-promote'" "${workflow}" >/dev/null \
+  || ! grep -F 'steps.transaction.outputs.asset_digest' "${workflow}" >/dev/null \
+  || ! grep -F "typeof system.securityUpdate !== 'boolean'" "${workflow}" >/dev/null \
+  || ! grep -F 'release_title="Press Security Update ${NEXT_TAG}"' "${workflow}" >/dev/null \
+  || ! grep -F "echo '> [!IMPORTANT]'" "${workflow}" >/dev/null \
+  || ! grep -F "echo '> **Security update.** Apply this release promptly through the Press System Updates tool.'" "${workflow}" >/dev/null \
+  || ! grep -F 'RELEASE_TITLE: ${{ steps.presentation.outputs.release_title }}' "${workflow}" >/dev/null \
+  || [[ "$(grep -Fc 'draft release title or body does not match deterministic presentation metadata' "${workflow}")" -ne 2 ]] \
+  || [[ "$(grep -Fc 'published release title or body does not match deterministic presentation metadata' "${workflow}")" -ne 1 ]]; then
+  echo "securityUpdate must produce and revalidate deterministic title and warning metadata through promotion" >&2
+  exit 1
+fi
+
+if grep -E '^[[:space:]]+if:.*security(Update|_update)' "${workflow}" >/dev/null \
+  || grep -E 'security_update.*(should_release|validation_mode|graph_args)' "${workflow}" >/dev/null; then
+  echo "securityUpdate is presentation metadata and must never bypass release planning, graph validation, or tests" >&2
+  exit 1
+fi
+
 if grep -F 'node scripts/test-system-release-transaction.mjs' "${main_workflow}" >/dev/null \
   || grep -F 'bash scripts/test-system-release-package.sh' "${main_workflow}" >/dev/null; then
   echo "main guard local release tests must flow through the versioned manifest" >&2
@@ -280,10 +312,12 @@ fi
 
 build_line="$(grep -nF -- '- name: Build system update package' "${workflow}" | cut -d: -f1)"
 candidate_line="$(grep -nF -- '- name: Verify release graph candidate' "${workflow}" | cut -d: -f1)"
+presentation_line="$(grep -nF -- '- name: Prepare deterministic release presentation' "${workflow}" | cut -d: -f1)"
 draft_line="$(grep -nF -- '- name: Ensure draft release and asset' "${workflow}" | cut -d: -f1)"
-if [[ -z "${build_line}" || -z "${candidate_line}" || -z "${draft_line}"
-  || "${candidate_line}" -le "${build_line}" || "${candidate_line}" -ge "${draft_line}" ]]; then
-  echo "release graph candidate verification must run after package build and before draft release creation" >&2
+if [[ -z "${build_line}" || -z "${candidate_line}" || -z "${presentation_line}" || -z "${draft_line}"
+  || "${candidate_line}" -le "${build_line}" || "${presentation_line}" -le "${candidate_line}" \
+  || "${presentation_line}" -ge "${draft_line}" ]]; then
+  echo "release graph candidate verification and deterministic presentation must run after package build and before draft release creation" >&2
   exit 1
 fi
 
@@ -458,6 +492,11 @@ fi
 
 if ! grep -F '"upgradeFrom": system.get("upgradeFrom") or {}' "${workflow}" >/dev/null; then
   echo "system release manifest must publish upgradeFrom compatibility metadata" >&2
+  exit 1
+fi
+
+if ! grep -F '"securityUpdate": system.get("securityUpdate") is True' "${workflow}" >/dev/null; then
+  echo "system release manifest must publish the explicit securityUpdate classification" >&2
   exit 1
 fi
 

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -36,6 +36,7 @@ const {
   createSystemUpdatesController,
   getDisplayReleaseNotes,
   getSystemUpdateCommitFiles,
+  isSecurityUpdateReleaseName,
   normalizeSystemReleaseManifest,
   selectSystemUpdateAsset,
   stageLatestSystemUpdate,
@@ -269,6 +270,7 @@ await run('normalizes static system release manifests', async () => {
     version: '3.3.5',
     publishedAt: '2026-04-29T08:18:39Z',
     notes: 'Release notes',
+    securityUpdate: true,
     upgradeFrom: {
       ranges: ['>=3.3.0 <3.3.5'],
       allowUnknownSource: true,
@@ -285,6 +287,7 @@ await run('normalizes static system release manifests', async () => {
 
   assert.equal(release.tag, 'v3.3.5');
   assert.equal(release.version, '3.3.5');
+  assert.equal(release.securityUpdate, true);
   assert.deepEqual(release.upgradeFrom.ranges, ['>=3.3.0 <3.3.5']);
   assert.equal(release.asset.name, 'press-system-v3.3.5.zip');
   assert.throws(
@@ -303,6 +306,43 @@ await run('normalizes static system release manifests', async () => {
       schemaVersion: 1,
       name: 'v3.3.5',
       tag: 'v3.3.5',
+      version: '3.3.5',
+      publishedAt: '2026-04-29T08:18:39Z',
+      notes: '',
+      securityUpdate: 'yes',
+      htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
+      asset: {
+        name: 'press-system-v3.3.5.zip',
+        url: 'https://github.com/EkilyHQ/Press/releases/download/v3.3.5/press-system-v3.3.5.zip',
+        size: 123,
+        digest: 'sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a'
+      }
+    }),
+    /securityUpdate/i
+  );
+  assert.throws(
+    () => normalizeSystemReleaseManifest({
+      schemaVersion: 1,
+      name: 'v3.4.134',
+      tag: 'v3.4.134',
+      version: '3.4.134',
+      publishedAt: '2026-07-10T00:00:00Z',
+      notes: '',
+      htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.4.134',
+      asset: {
+        name: 'press-system-v3.4.134.zip',
+        url: 'https://github.com/EkilyHQ/Press/releases/download/v3.4.134/press-system-v3.4.134.zip',
+        size: 123,
+        digest: 'sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a'
+      }
+    }),
+    /securityUpdate/i
+  );
+  assert.throws(
+    () => normalizeSystemReleaseManifest({
+      schemaVersion: 1,
+      name: 'v3.3.5',
+      tag: 'v3.3.5',
       publishedAt: '2026-04-29T08:18:39Z',
       notes: '',
       htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
@@ -315,6 +355,12 @@ await run('normalizes static system release manifests', async () => {
     }),
     /manifest/i
   );
+});
+
+await run('recognizes deterministic security release titles in API fallback metadata', async () => {
+  assert.equal(isSecurityUpdateReleaseName('Press Security Update v3.4.134'), true);
+  assert.equal(isSecurityUpdateReleaseName('Security Update v3.4.134'), true);
+  assert.equal(isSecurityUpdateReleaseName('Press v3.4.134'), false);
 });
 
 await run('hides stale release notes when no Press system package is attached', async () => {
@@ -847,6 +893,7 @@ await run('blocks system updates outside the declared source range', async () =>
       type: 'press-system',
       version: '4.0.0',
       tag: 'v4.0.0',
+      securityUpdate: false,
       upgradeFrom: {
         ranges: ['>=3.5.0 <4.0.0'],
         allowUnknownSource: false,
@@ -886,6 +933,7 @@ await run('preserves custom upgradeFrom block messages', async () => {
       type: 'press-system',
       version: '4.0.0',
       tag: 'v4.0.0',
+      securityUpdate: false,
       upgradeFrom: {
         ranges: ['>=3.5.0 <4.0.0'],
         allowUnknownSource: false,

--- a/scripts/test-theme-contract-package.mjs
+++ b/scripts/test-theme-contract-package.mjs
@@ -10,7 +10,7 @@ const sourceManifest = JSON.parse(await fs.readFile(path.join(root, 'packages', 
 
 assert.equal(sourceManifest.name, '@ekilyhq/press-theme-contract');
 assert.equal(sourceManifest.version, system.version);
-assert.equal(system.version, '3.4.133');
+assert.equal(system.version, '3.4.134');
 assert.equal(system.tag, `v${system.version}`);
 assert.equal(sourceManifest.publishConfig && sourceManifest.publishConfig.registry, 'https://npm.pkg.github.com');
 

--- a/scripts/test-theme-runtime.js
+++ b/scripts/test-theme-runtime.js
@@ -605,34 +605,24 @@ await run('theme controls ignore retired legacy DOM bridge hints from the active
   }
 });
 
-await run('theme controls keep current component contract during legacy theme module mount', async () => {
-  let mountedComponent = null;
-  let legacyTools = null;
-  const { mountThemeControls } = await freshThemeHelpers();
+await run('unsupported installed themes fall back to Native without executing legacy modules', async () => {
+  const requested = [];
   const { document } = installGlobals({
     savedPack: 'legacy',
     manifests: {
-      legacy: { ...makeManifest('legacy', ['modules/layout.js']), contractVersion: 1 }
+      legacy: { ...makeManifest('legacy', ['modules/legacy.js']), contractVersion: 1 },
+      native: { ...makeManifest('native', ['modules/native.js']), styles: ['theme.css'] }
     }
   });
-  window.__pressThemeModuleLoader = async () => ({
-    mount() {
-      const sidebar = document.createElement('aside');
-      sidebar.setAttribute('class', 'sidebar');
-      legacyTools = document.createElement('div');
-      legacyTools.setAttribute('id', 'tools');
-      sidebar.appendChild(legacyTools);
-      document.body.appendChild(sidebar);
-      mountedComponent = mountThemeControls({ variant: 'arcus' });
-    }
+  window.__pressThemeModuleLoader = async (_path, context = {}) => ({
+    mount() { requested.push(context.entry); }
   });
 
   const { ensureThemeLayout } = await freshThemeLayout();
-  await ensureThemeLayout({ pack: 'legacy', persist: false, reset: true });
-  assert.equal(mountedComponent && mountedComponent.tagName, 'PRESS-THEME-CONTROLS');
-  assert.equal(mountedComponent.getAttribute('contract-version'), null);
-  assert.equal(legacyTools.parentElement && legacyTools.parentElement.matches('.sidebar'), true);
-  assert.notEqual(legacyTools.parentElement.children[0], mountedComponent);
+  const context = await withQuietConsole(() => ensureThemeLayout({ pack: 'legacy', persist: false, reset: true }));
+  assert.equal(context.pack, 'native');
+  assert.equal(document.body.dataset.themeLayout, 'native');
+  assert.deepEqual(requested, ['modules/native.js']);
 });
 
 await run('theme controls hide language selector until public content languages resolve', async () => {


### PR DESCRIPTION
## What changed

- publish Recovery Transition v3.4.134 with a direct `>=3.4.64 <3.4.134` update range and close the recorded release-graph debt
- preserve legacy index/tabs sidecars while restoring exact-language runtime reads and safe Composer normalization
- migrate only non-sensitive legacy editor preferences, and fall back to Native before executing unsupported theme modules
- add explicit `securityUpdate` metadata across source, ZIP, system-release, release intent, retry, and promotion paths
- harden Pages output deletion against symlink and path-alias escapes
- add a durable compatibility guard that runs every one of the 27 published supported historical updaters against the real v3.4.134 ZIP
- remove eight zero-behavior-change ESLint blockers so the follow-up quality gate can start from a zero-error correctness profile

## Why

The latest-only updater could not bridge the unpublished v3.4.65-v3.4.107 gap, while the cleanup release also required theme/content state that older supported sites could not necessarily satisfy. Recovery must therefore be a direct, non-destructive transition from the declared v3.4.64 support floor. The same audit also exposed a Pages output alias that needed canonical-path enforcement and an emergency-release classification gap.

## User and release impact

- supported Press v3.4.64-v3.4.133 sites can update directly to v3.4.134
- legacy content remains readable and source sidecars are not automatically deleted
- unsupported external theme contracts fail safely to Native
- this is a release-bearing change: merge will publish v3.4.134, update the theme-contract package, dispatch downstream syncs, and materialize Pages
- `securityUpdate` is explicitly `false` for this Recovery release

## Verification

- independent release, data-compatibility, and Pages reviews: clear after fixes
- independent lint-blocker cleanup review: clear; four locale exports and loader failure behavior were proven equivalent
- manifest inventory: 177 logical / 178 physical / 1 alias
- guard tier: 26/26
- release tier: 30/30
- full tier: 177/177, rerun on the lint-blocker cleanup
- historical updater compatibility: 27/27 real tagged updaters
- release graph: 37/37
- release intent: 12/12
- system release transaction: 15/15
- actionlint, zero-error ESLint correctness-profile probe, runtime cache-key check, and `git diff --check`
