### PR TITLE
Preserve Product State security markers

### DIFF
--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -913,7 +913,7 @@ async function buildProductState(options = {}) {
       ? releaseIntentResult.source
       : '';
   const releaseIntentFailures = normalizedReleaseIntent
-    ? validateReleaseIntent(normalizedReleaseIntent, { systemRelease })
+    ? validateReleaseIntent(releaseIntentResult.value, { systemRelease })
     : [];
   const effectiveSources = clone(sources);
   if (normalizedReleaseIntent && !releaseIntentFailures.length) {

--- a/scripts/product-state-ledger.js
+++ b/scripts/product-state-ledger.js
@@ -415,6 +415,7 @@ function normalizeSystemRelease(input) {
     tag,
     version,
     publishedAt: String(source.publishedAt || source.published_at || '').trim(),
+    securityUpdate: typeof source.securityUpdate === 'boolean' ? source.securityUpdate : undefined,
     upgradeFrom: source.upgradeFrom && typeof source.upgradeFrom === 'object' ? source.upgradeFrom : {},
     themeContractUpgrade: source.themeContractUpgrade && typeof source.themeContractUpgrade === 'object'
       ? source.themeContractUpgrade

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -680,6 +680,23 @@ test('buildProductState preserves explicit security update markers for release i
   assert.equal(state.releaseIntent.status, 'ok');
   assert.equal(state.releaseIntent.problems, undefined);
 
+  const missingIntentMarker = clone(intent);
+  delete missingIntentMarker.pressSystem.securityUpdate;
+  const missingIntentState = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:system': release,
+      'fixture:intent': missingIntentMarker
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(missingIntentState.releaseIntent.status, 'drift');
+  assert.match(
+    missingIntentState.releaseIntent.problems.join('\n'),
+    /release intent pressSystem\.securityUpdate must be an explicit boolean/u
+  );
+
   const missingMarker = clone(release);
   delete missingMarker.securityUpdate;
   const missingState = await buildProductState({

--- a/scripts/test-product-state-ledger.js
+++ b/scripts/test-product-state-ledger.js
@@ -657,6 +657,48 @@ test('buildProductState preserves release upgrade metadata for release intent va
   assert.deepEqual(state.observed.pressSystem.contentModelUpgrade, release.contentModelUpgrade);
 });
 
+test('buildProductState preserves explicit security update markers for release intent validation', async () => {
+  const release = systemRelease('3.4.134');
+  release.securityUpdate = false;
+  release.upgradeFrom = {
+    ranges: ['>=3.4.64 <3.4.134'],
+    allowUnknownSource: false
+  };
+  const intent = releaseIntentFixture(release);
+  const fixtures = makeFixtures({
+    'fixture:system': release,
+    'fixture:intent': intent
+  });
+
+  const state = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(fixtures),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(state.pressSystem.securityUpdate, false);
+  assert.equal(state.releaseIntent.status, 'ok');
+  assert.equal(state.releaseIntent.problems, undefined);
+
+  const missingMarker = clone(release);
+  delete missingMarker.securityUpdate;
+  const missingState = await buildProductState({
+    sources: makeSources(),
+    loadJson: loader(makeFixtures({
+      'fixture:system': missingMarker,
+      'fixture:intent': intent
+    })),
+    generatedAt: '2026-05-25T00:00:00Z'
+  });
+
+  assert.equal(missingState.pressSystem.securityUpdate, undefined);
+  assert.equal(missingState.releaseIntent.status, 'drift');
+  assert.match(
+    missingState.releaseIntent.problems.join('\n'),
+    /system-release\.json securityUpdate must be an explicit boolean/u
+  );
+});
+
 test('buildProductState honors top-level theme release metadata fallbacks', async () => {
   const release = themeRelease('arcus');
   release.tag = release.release.tag;


### PR DESCRIPTION
## Summary

- preserve the explicit `securityUpdate` boolean while normalizing `system-release.json` for Product State
- keep missing-vs-`false` semantics so v3.4.134+ metadata validation remains strict
- add a regression covering both the v3.4.134 ordinary-release path and the missing-marker failure path

## Why

The v3.4.134 release artifacts and all downstream targets converged, but Product State discarded `securityUpdate: false` before calling the release-intent validator. The ledger therefore reported a synthetic drift even though the canonical artifact was valid.

## Verification

- `mise x node@22.18.0 -- node scripts/test-product-state-ledger.js` (40/40)
- `mise x node@22.18.0 -- node scripts/test-release-intent.js` (12/12)
- `bash scripts/test-product-state-workflow.sh`
- `mise x node@22.18.0 -- node scripts/product-state-ledger.js --check --require-converged --quiet` against live v3.4.134 sources
- `mise x node@22.18.0 -- node scripts/run-tests.mjs --tier full` in a normal clone (177/177)
- independent local subagent review: clean

## Release impact

Tooling/test-only change. It does not modify the Press system surface, so the post-merge System Release should settle without publishing a new version. Product State should regenerate as converged.